### PR TITLE
Store auth credentials in system keyring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
@@ -330,7 +336,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.59.0",
 ]
 
@@ -361,6 +367,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "cx"
 version = "0.1.0"
 dependencies = [
@@ -372,6 +403,7 @@ dependencies = [
  "futures",
  "humantime",
  "indicatif",
+ "inquire",
  "keyring",
  "prost",
  "prost-types",
@@ -442,6 +474,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -596,6 +634,24 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -980,8 +1036,25 @@ dependencies = [
  "console",
  "number_prefix",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "web-time",
+]
+
+[[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.11.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
 ]
 
 [[package]]
@@ -1143,6 +1216,18 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
@@ -1157,6 +1242,15 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nom"
@@ -1211,7 +1305,7 @@ dependencies = [
  "ansitok",
  "bytecount",
  "fnv",
- "unicode-width",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -1613,7 +1707,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1720,7 +1814,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1796,7 +1890,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -1809,7 +1903,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1915,6 +2009,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio 0.8.11",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -2097,6 +2212,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2129,7 +2253,7 @@ checksum = "27ad5e34374e03cfffefc301becb44e9dc3c17584f414349ebe29ed26661822d"
 dependencies = [
  "bytes",
  "libc",
- "mio",
+ "mio 1.2.0",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -2324,7 +2448,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -2390,6 +2514,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2576,7 +2712,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap 2.13.0",
  "semver",
@@ -2619,6 +2755,28 @@ checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -2977,7 +3135,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap 2.13.0",
  "log",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -329,6 +335,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,6 +372,7 @@ dependencies = [
  "futures",
  "humantime",
  "indicatif",
+ "keyring",
  "prost",
  "prost-types",
  "protoc-bin-vendored",
@@ -361,6 +388,27 @@ dependencies = [
  "tonic-build",
  "toon-format",
  "url",
+]
+
+[[package]]
+name = "dbus"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b3aa68d7e7abee336255bd7248ea965cc393f3e70411135a6f6a4b651345d4"
+dependencies = [
+ "libc",
+ "libdbus-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "dbus-secret-service"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
+dependencies = [
+ "dbus",
+ "zeroize",
 ]
 
 [[package]]
@@ -986,6 +1034,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "byteorder",
+ "dbus-secret-service",
+ "log",
+ "security-framework 2.11.1",
+ "security-framework 3.7.0",
+ "windows-sys 0.60.2",
+ "zeroize",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1002,6 +1065,15 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libdbus-sys"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "328c4789d42200f1eeec05bd86c9c13c7f091d2ba9a6ea35acdf51f31bc0f043"
+dependencies = [
+ "pkg-config",
+]
 
 [[package]]
 name = "libredox"
@@ -1212,6 +1284,12 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "portable-atomic"
@@ -1711,6 +1789,42 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -2968,6 +3082,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ thiserror = "2"
 # Config directory resolution
 dirs = "5"
 
+# Secure credential storage
+keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+
 # Terminal output
 colored = "2"
 tabled = { version = "0.17", features = ["ansi"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ dirs = "5"
 
 # Secure credential storage
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service"] }
+inquire = "0.7"
 
 # Terminal output
 colored = "2"

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -1,14 +1,21 @@
 use anyhow::Result;
 use inquire::{Password, PasswordDisplayMode, Select, Text};
 
-use crate::config::{load_config, save_config, save_profile, OutputFormat, Profile, Region};
+use crate::config::{
+    load_config, save_config, save_profile, OutputFormat, Profile, Region, SecretStorage,
+};
 use crate::keyring_store;
 
 const REGIONS: &[&str] = &["us1", "us2", "eu1", "eu2", "ap1", "ap2", "ap3", "stg1"];
 
 const OUTPUT_FORMATS: &[&str] = &["text", "json", "agents"];
 
-pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
+const SECRET_STORAGE_OPTIONS: &[&str] = &["keyring", "file"];
+
+pub async fn run(
+    profile_name: Option<String>,
+    secret_storage: Option<SecretStorage>,
+) -> Result<()> {
     let name = profile_name.unwrap_or_else(|| "default".to_string());
 
     println!("Configuring profile '{name}'\n");
@@ -36,16 +43,18 @@ pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
         .prompt_skippable()?;
     let openai_api_key = openai_api_key.filter(|s| !s.is_empty());
 
-    if no_keyring {
-        let profile = Profile {
-            api_key: Some(api_key),
-            region,
-            label,
-            team_id,
-            openai_api_key,
-        };
-        save_profile(&name, &profile)?;
-    } else {
+    let use_keyring = match secret_storage {
+        Some(SecretStorage::Keyring) => true,
+        Some(SecretStorage::File) => false,
+        None => {
+            let choice = Select::new("Store API keys in:", SECRET_STORAGE_OPTIONS.to_vec())
+                .with_starting_cursor(0) // keyring
+                .prompt()?;
+            choice == "keyring"
+        }
+    };
+
+    if use_keyring {
         keyring_store::store_secret(&name, "api_key", &api_key)?;
         if let Some(ref oai_key) = openai_api_key {
             keyring_store::store_secret(&name, "openai_api_key", oai_key)?;
@@ -56,6 +65,15 @@ pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
             label,
             team_id,
             openai_api_key: None,
+        };
+        save_profile(&name, &profile)?;
+    } else {
+        let profile = Profile {
+            api_key: Some(api_key),
+            region,
+            label,
+            team_id,
+            openai_api_key,
         };
         save_profile(&name, &profile)?;
     }
@@ -77,7 +95,7 @@ pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
     save_config(&global_config)?;
 
     let cx_dir = crate::config::config_dir()?;
-    let storage = if no_keyring { "profile file" } else { "system keyring" };
+    let storage = if use_keyring { "system keyring" } else { "profile file" };
     println!(
         "\nProfile '{name}' saved to {}\nAPI key stored in {storage}",
         cx_dir.display()

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -12,7 +12,7 @@ const OUTPUT_FORMATS: &[&str] = &["text", "json", "agents"];
 
 const SECRET_STORAGE_OPTIONS: &[&str] = &["keyring", "file"];
 
-pub async fn run(
+pub fn run(
     profile_name: Option<String>,
     secret_storage: Option<SecretStorage>,
 ) -> Result<()> {
@@ -68,6 +68,8 @@ pub async fn run(
         };
         save_profile(&name, &profile)?;
     } else {
+        // Clean up any leftover keyring entries from a previous keyring-based config.
+        keyring_store::delete_profile(&name);
         let profile = Profile {
             api_key: Some(api_key),
             region,
@@ -82,7 +84,7 @@ pub async fn run(
     let mut global_config = load_config().unwrap_or_default();
     let current_idx = OUTPUT_FORMATS
         .iter()
-        .position(|&f| f == format!("{:?}", global_config.default_output_format).to_lowercase())
+        .position(|&f| f == global_config.default_output_format.as_str())
         .unwrap_or(0);
     let format_str = Select::new("Default output format:", OUTPUT_FORMATS.to_vec())
         .with_starting_cursor(current_idx)

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -1,27 +1,42 @@
-use std::io::{self, Write};
-
 use anyhow::Result;
+use inquire::{Password, PasswordDisplayMode, Select, Text};
 
 use crate::config::{load_config, save_config, save_profile, OutputFormat, Profile, Region};
 use crate::keyring_store;
 
+const REGIONS: &[&str] = &["us1", "us2", "eu1", "eu2", "ap1", "ap2", "ap3", "stg1"];
+
+const OUTPUT_FORMATS: &[&str] = &["text", "json", "agents"];
+
 pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
     let name = profile_name.unwrap_or_else(|| "default".to_string());
 
-    println!("Configuring profile '{name}'");
-    println!("Press Enter to keep existing value when shown in brackets.\n");
+    println!("Configuring profile '{name}'\n");
 
-    let api_key = prompt("Coralogix API key")?;
-    let region_str = prompt_with_default("Region (us1/us2/eu1/eu2/ap1/ap2)", "eu1")?;
-    let label = prompt_optional("Label (optional, e.g. 'prod')")?;
-    let team_id = prompt_optional("Coralogix team ID (cgx-team-id, required for search-fields)")?;
-    let openai_api_key =
-        prompt_optional("OpenAI API key (optional, can also be set via OPENAI_API_KEY env var)")?;
+    let api_key = Password::new("Coralogix API key:")
+        .with_display_mode(PasswordDisplayMode::Masked)
+        .without_confirmation()
+        .prompt()?;
 
+    let region_str = Select::new("Region:", REGIONS.to_vec())
+        .with_starting_cursor(2) // eu1
+        .prompt()?;
     let region: Region = region_str.parse()?;
 
+    let label = Text::new("Label (e.g. 'prod'):").prompt_skippable()?;
+    let label = label.filter(|s| !s.is_empty());
+
+    let team_id = Text::new("Coralogix team ID (required for search-fields):")
+        .prompt_skippable()?;
+    let team_id = team_id.filter(|s| !s.is_empty());
+
+    let openai_api_key = Password::new("OpenAI API key (optional):")
+        .with_display_mode(PasswordDisplayMode::Masked)
+        .without_confirmation()
+        .prompt_skippable()?;
+    let openai_api_key = openai_api_key.filter(|s| !s.is_empty());
+
     if no_keyring {
-        // Store keys inline in the TOML file.
         let profile = Profile {
             api_key: Some(api_key),
             region,
@@ -31,7 +46,6 @@ pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
         };
         save_profile(&name, &profile)?;
     } else {
-        // Store keys in the system keyring.
         keyring_store::store_secret(&name, "api_key", &api_key)?;
         if let Some(ref oai_key) = openai_api_key {
             keyring_store::store_secret(&name, "openai_api_key", oai_key)?;
@@ -48,10 +62,14 @@ pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
 
     // Update global config with the chosen default output format.
     let mut global_config = load_config().unwrap_or_default();
-    let current_format = format!("{:?}", global_config.default_output_format).to_lowercase();
-    let format_str =
-        prompt_with_default("Default output format (text/json/agents)", &current_format)?;
-    global_config.default_output_format = match format_str.to_lowercase().as_str() {
+    let current_idx = OUTPUT_FORMATS
+        .iter()
+        .position(|&f| f == format!("{:?}", global_config.default_output_format).to_lowercase())
+        .unwrap_or(0);
+    let format_str = Select::new("Default output format:", OUTPUT_FORMATS.to_vec())
+        .with_starting_cursor(current_idx)
+        .prompt()?;
+    global_config.default_output_format = match format_str {
         "json" => OutputFormat::Json,
         "agents" => OutputFormat::Agents,
         _ => OutputFormat::Text,
@@ -65,30 +83,4 @@ pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
         cx_dir.display()
     );
     Ok(())
-}
-
-fn prompt(label: &str) -> Result<String> {
-    print!("{label}: ");
-    io::stdout().flush()?;
-    let mut s = String::new();
-    io::stdin().read_line(&mut s)?;
-    Ok(s.trim().to_string())
-}
-
-fn prompt_with_default(label: &str, default: &str) -> Result<String> {
-    print!("{label} [{default}]: ");
-    io::stdout().flush()?;
-    let mut s = String::new();
-    io::stdin().read_line(&mut s)?;
-    let trimmed = s.trim();
-    Ok(if trimmed.is_empty() {
-        default.to_string()
-    } else {
-        trimmed.to_string()
-    })
-}
-
-fn prompt_optional(label: &str) -> Result<Option<String>> {
-    let s = prompt(label)?;
-    Ok(if s.is_empty() { None } else { Some(s) })
 }

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -3,8 +3,9 @@ use std::io::{self, Write};
 use anyhow::Result;
 
 use crate::config::{load_config, save_config, save_profile, OutputFormat, Profile, Region};
+use crate::keyring_store;
 
-pub async fn run(profile_name: Option<String>) -> Result<()> {
+pub async fn run(profile_name: Option<String>, no_keyring: bool) -> Result<()> {
     let name = profile_name.unwrap_or_else(|| "default".to_string());
 
     println!("Configuring profile '{name}'");
@@ -18,15 +19,32 @@ pub async fn run(profile_name: Option<String>) -> Result<()> {
         prompt_optional("OpenAI API key (optional, can also be set via OPENAI_API_KEY env var)")?;
 
     let region: Region = region_str.parse()?;
-    let profile = Profile {
-        api_key,
-        region,
-        label,
-        team_id,
-        openai_api_key,
-    };
 
-    save_profile(&name, &profile)?;
+    if no_keyring {
+        // Store keys inline in the TOML file.
+        let profile = Profile {
+            api_key: Some(api_key),
+            region,
+            label,
+            team_id,
+            openai_api_key,
+        };
+        save_profile(&name, &profile)?;
+    } else {
+        // Store keys in the system keyring.
+        keyring_store::store_secret(&name, "api_key", &api_key)?;
+        if let Some(ref oai_key) = openai_api_key {
+            keyring_store::store_secret(&name, "openai_api_key", oai_key)?;
+        }
+        let profile = Profile {
+            api_key: None,
+            region,
+            label,
+            team_id,
+            openai_api_key: None,
+        };
+        save_profile(&name, &profile)?;
+    }
 
     // Update global config with the chosen default output format.
     let mut global_config = load_config().unwrap_or_default();
@@ -41,8 +59,9 @@ pub async fn run(profile_name: Option<String>) -> Result<()> {
     save_config(&global_config)?;
 
     let cx_dir = crate::config::config_dir()?;
+    let storage = if no_keyring { "profile file" } else { "system keyring" };
     println!(
-        "\nProfile '{name}' saved to {}",
+        "\nProfile '{name}' saved to {}\nAPI key stored in {storage}",
         cx_dir.display()
     );
     Ok(())

--- a/src/commands/configure.rs
+++ b/src/commands/configure.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use inquire::{Password, PasswordDisplayMode, Select, Text};
 
 use crate::config::{
-    load_config, save_config, save_profile, OutputFormat, Profile, Region, SecretStorage,
+    load_config, save_config, save_profile, CredentialStorage, OutputFormat, Profile, Region,
 };
 use crate::keyring_store;
 
@@ -10,12 +10,9 @@ const REGIONS: &[&str] = &["us1", "us2", "eu1", "eu2", "ap1", "ap2", "ap3", "stg
 
 const OUTPUT_FORMATS: &[&str] = &["text", "json", "agents"];
 
-const SECRET_STORAGE_OPTIONS: &[&str] = &["keyring", "file"];
+const CREDENTIAL_STORAGE_OPTIONS: &[&str] = &["file", "os-store (encrypted)"];
 
-pub fn run(
-    profile_name: Option<String>,
-    secret_storage: Option<SecretStorage>,
-) -> Result<()> {
+pub fn run(profile_name: Option<String>) -> Result<()> {
     let name = profile_name.unwrap_or_else(|| "default".to_string());
 
     println!("Configuring profile '{name}'\n");
@@ -43,41 +40,49 @@ pub fn run(
         .prompt_skippable()?;
     let openai_api_key = openai_api_key.filter(|s| !s.is_empty());
 
-    let use_keyring = match secret_storage {
-        Some(SecretStorage::Keyring) => true,
-        Some(SecretStorage::File) => false,
-        None => {
-            let choice = Select::new("Store API keys in:", SECRET_STORAGE_OPTIONS.to_vec())
-                .with_starting_cursor(0) // keyring
-                .prompt()?;
-            choice == "keyring"
-        }
+    let storage_choice = Select::new(
+        "Where should API keys be stored?",
+        CREDENTIAL_STORAGE_OPTIONS.to_vec(),
+    )
+    .with_help_message("'file' stores in profile config (0600 perms). 'os-store' uses the OS credential store (macOS Keychain, Windows Credential Manager, etc.)")
+    .with_starting_cursor(0) // file
+    .prompt()?;
+
+    let credential_storage = if storage_choice.starts_with("os-store") {
+        CredentialStorage::OsStore
+    } else {
+        CredentialStorage::File
     };
 
-    if use_keyring {
-        keyring_store::store_secret(&name, "api_key", &api_key)?;
-        if let Some(ref oai_key) = openai_api_key {
-            keyring_store::store_secret(&name, "openai_api_key", oai_key)?;
+    match credential_storage {
+        CredentialStorage::OsStore => {
+            keyring_store::store_secret(&name, "api_key", &api_key)?;
+            if let Some(ref oai_key) = openai_api_key {
+                keyring_store::store_secret(&name, "openai_api_key", oai_key)?;
+            }
+            let profile = Profile {
+                credential_storage,
+                api_key: None,
+                region,
+                label,
+                team_id,
+                openai_api_key: None,
+            };
+            save_profile(&name, &profile)?;
         }
-        let profile = Profile {
-            api_key: None,
-            region,
-            label,
-            team_id,
-            openai_api_key: None,
-        };
-        save_profile(&name, &profile)?;
-    } else {
-        // Clean up any leftover keyring entries from a previous keyring-based config.
-        keyring_store::delete_profile(&name);
-        let profile = Profile {
-            api_key: Some(api_key),
-            region,
-            label,
-            team_id,
-            openai_api_key,
-        };
-        save_profile(&name, &profile)?;
+        CredentialStorage::File => {
+            // Clean up any leftover keychain entries from a previous config.
+            keyring_store::delete_profile(&name);
+            let profile = Profile {
+                credential_storage,
+                api_key: Some(api_key),
+                region,
+                label,
+                team_id,
+                openai_api_key,
+            };
+            save_profile(&name, &profile)?;
+        }
     }
 
     // Update global config with the chosen default output format.
@@ -97,9 +102,12 @@ pub fn run(
     save_config(&global_config)?;
 
     let cx_dir = crate::config::config_dir()?;
-    let storage = if use_keyring { "system keyring" } else { "profile file" };
+    let storage_desc = match credential_storage {
+        CredentialStorage::File => "profile file",
+        CredentialStorage::OsStore => "OS credential store",
+    };
     println!(
-        "\nProfile '{name}' saved to {}\nAPI key stored in {storage}",
+        "\nProfile '{name}' saved to {}\nAPI key stored in {storage_desc}",
         cx_dir.display()
     );
     Ok(())

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
+use crate::keyring_store;
+
 /// Output format for command results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]
@@ -159,18 +161,24 @@ mod max_size_serde {
 }
 
 /// A named profile storing credentials and endpoint info.
+///
+/// API keys may be stored in the system keyring (default) or inline in the
+/// TOML file (when configured with `--no-keyring`). When stored in the
+/// keyring, `api_key` and `openai_api_key` are `None` in the TOML file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Profile {
-    pub api_key: String,
+    /// Coralogix API key. Only present in the TOML when using `--no-keyring`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
     pub region: Region,
     /// Optional free-form label (e.g. "prod", "staging")
     pub label: Option<String>,
     /// Coralogix team ID, sent as `cgx-team-id` in gRPC metadata.
     #[serde(default)]
     pub team_id: Option<String>,
-    /// OpenAI API key for embedding-based features. Falls back to the
-    /// `OPENAI_API_KEY` environment variable when not set in the profile.
-    #[serde(default)]
+    /// OpenAI API key for embedding-based features. Only present in the TOML
+    /// when using `--no-keyring`. Falls back to `OPENAI_API_KEY` env var.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openai_api_key: Option<String>,
 }
 
@@ -236,6 +244,9 @@ pub fn load_profile(name: &str) -> Result<Profile> {
 }
 
 /// Resolve a single named profile, respecting optional CLI overrides.
+///
+/// API key resolution order: CLI override > keyring > profile TOML file.
+/// OpenAI key resolution: `OPENAI_API_KEY` env var > keyring > profile TOML.
 fn resolve_single(
     profile_name: &str,
     api_key_override: Option<&str>,
@@ -243,23 +254,35 @@ fn resolve_single(
 ) -> Result<ResolvedConfig> {
     let mut profile = load_profile(profile_name)?;
 
-    if let Some(key) = api_key_override {
-        profile.api_key = key.to_string();
-    }
     if let Some(region) = region_override {
         profile.region = region.parse()?;
     }
 
-    // `OPENAI_API_KEY` env var takes precedence over the profile value.
+    // API key: CLI override > keyring > profile TOML
+    let api_key = if let Some(key) = api_key_override {
+        key.to_string()
+    } else if let Some(key) = keyring_store::get_secret(profile_name, "api_key")? {
+        key
+    } else if let Some(key) = profile.api_key {
+        key
+    } else {
+        anyhow::bail!(
+            "No API key found for profile '{profile_name}'.\n\
+             Run `cx configure --profile {profile_name}` to set it up."
+        );
+    };
+
+    // OpenAI key: env var > keyring > profile TOML
     let openai_api_key = std::env::var("OPENAI_API_KEY")
         .ok()
         .filter(|s| !s.is_empty())
+        .or_else(|| keyring_store::get_secret(profile_name, "openai_api_key").ok().flatten())
         .or(profile.openai_api_key);
 
     Ok(ResolvedConfig {
         profile_name: profile_name.to_string(),
         endpoint: profile.region.api_endpoint().to_string(),
-        api_key: profile.api_key,
+        api_key,
         team_id: profile.team_id,
         openai_api_key,
     })
@@ -374,7 +397,7 @@ mod tests {
         let names = ["cx_inttest_multi_a", "cx_inttest_multi_b"];
         for (i, name) in names.iter().enumerate() {
             let profile = Profile {
-                api_key: format!("key-{i}"),
+                api_key: Some(format!("key-{i}")),
                 region: Region::Eu1,
                 label: None,
                 team_id: None,
@@ -405,7 +428,7 @@ mod tests {
     #[ignore = "requires write access to ~/.cx; run with `cargo test -- --ignored`"]
     fn resolve_all_integration_empty_slice_falls_back_to_default() {
         let profile = Profile {
-            api_key: "default-key".to_string(),
+            api_key: Some("default-key".to_string()),
             region: Region::Eu1,
             label: None,
             team_id: None,
@@ -416,5 +439,96 @@ mod tests {
         let configs = resolve_all(&[], None, None).unwrap();
         assert_eq!(configs.len(), 1);
         assert_eq!(configs[0].profile_name, "default");
+    }
+
+    // ── Keyring resolution order tests ───────────────────────────────────────
+
+    #[test]
+    #[ignore = "requires write access to ~/.cx and system keyring"]
+    fn resolve_prefers_cli_override_over_keyring_and_file() {
+        let name = "cx_inttest_resolve_override";
+        // Store key in both file and keyring
+        let profile = Profile {
+            api_key: Some("file-key".to_string()),
+            region: Region::Eu1,
+            label: None,
+            team_id: None,
+            openai_api_key: None,
+        };
+        save_profile(name, &profile).unwrap();
+        crate::keyring_store::store_secret(name, "api_key", "keyring-key").unwrap();
+
+        let config = resolve_single(name, Some("cli-key"), None).unwrap();
+        assert_eq!(config.api_key, "cli-key");
+
+        // cleanup
+        let _ = std::fs::remove_file(profile_file(name).unwrap());
+        crate::keyring_store::delete_secret(name, "api_key");
+    }
+
+    #[test]
+    #[ignore = "requires write access to ~/.cx and system keyring"]
+    fn resolve_prefers_keyring_over_file() {
+        let name = "cx_inttest_resolve_keyring";
+        let profile = Profile {
+            api_key: Some("file-key".to_string()),
+            region: Region::Eu1,
+            label: None,
+            team_id: None,
+            openai_api_key: None,
+        };
+        save_profile(name, &profile).unwrap();
+        crate::keyring_store::store_secret(name, "api_key", "keyring-key").unwrap();
+
+        let config = resolve_single(name, None, None).unwrap();
+        assert_eq!(config.api_key, "keyring-key");
+
+        // cleanup
+        let _ = std::fs::remove_file(profile_file(name).unwrap());
+        crate::keyring_store::delete_secret(name, "api_key");
+    }
+
+    #[test]
+    #[ignore = "requires write access to ~/.cx"]
+    fn resolve_falls_back_to_file_when_no_keyring_entry() {
+        let name = "cx_inttest_resolve_file_fallback";
+        // Only store in file, no keyring entry
+        let profile = Profile {
+            api_key: Some("file-key".to_string()),
+            region: Region::Eu1,
+            label: None,
+            team_id: None,
+            openai_api_key: None,
+        };
+        save_profile(name, &profile).unwrap();
+        // Ensure no keyring entry
+        crate::keyring_store::delete_secret(name, "api_key");
+
+        let config = resolve_single(name, None, None).unwrap();
+        assert_eq!(config.api_key, "file-key");
+
+        // cleanup
+        let _ = std::fs::remove_file(profile_file(name).unwrap());
+    }
+
+    #[test]
+    #[ignore = "requires write access to ~/.cx"]
+    fn resolve_errors_when_no_key_anywhere() {
+        let name = "cx_inttest_resolve_no_key";
+        let profile = Profile {
+            api_key: None,
+            region: Region::Eu1,
+            label: None,
+            team_id: None,
+            openai_api_key: None,
+        };
+        save_profile(name, &profile).unwrap();
+        crate::keyring_store::delete_secret(name, "api_key");
+
+        let result = resolve_single(name, None, None);
+        assert!(result.is_err());
+
+        // cleanup
+        let _ = std::fs::remove_file(profile_file(name).unwrap());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,13 +8,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::keyring_store;
 
-/// Where to store API keys.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
-pub enum SecretStorage {
-    /// Store in the system keyring (macOS Keychain, Windows Credential Manager, etc.)
-    Keyring,
-    /// Store in the profile TOML file (plaintext).
+/// Where API keys are stored for a profile.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CredentialStorage {
+    /// Store in the profile TOML file (plaintext, 0600 permissions).
+    #[default]
     File,
+    /// Store in the OS credential store (macOS Keychain, Windows Credential Manager, etc.)
+    OsStore,
 }
 
 /// Output format for command results.
@@ -190,12 +192,15 @@ mod max_size_serde {
 
 /// A named profile storing credentials and endpoint info.
 ///
-/// API keys may be stored in the system keyring (default) or inline in the
-/// TOML file (when configured with `--no-keyring`). When stored in the
-/// keyring, `api_key` and `openai_api_key` are `None` in the TOML file.
+/// API keys are stored inline in the TOML by default (`credential_storage = "file"`).
+/// When `credential_storage = "os_store"`, keys are stored in the OS credential
+/// store and `api_key` / `openai_api_key` are `None` in the TOML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Profile {
-    /// Coralogix API key. Only present in the TOML when using `--no-keyring`.
+    /// Where API keys for this profile are stored.
+    #[serde(default)]
+    pub credential_storage: CredentialStorage,
+    /// Coralogix API key. Present when `credential_storage = "file"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     pub region: Region,
@@ -204,8 +209,8 @@ pub struct Profile {
     /// Coralogix team ID, sent as `cgx-team-id` in gRPC metadata.
     #[serde(default)]
     pub team_id: Option<String>,
-    /// OpenAI API key for embedding-based features. Only present in the TOML
-    /// when using `--no-keyring`. Falls back to `OPENAI_API_KEY` env var.
+    /// OpenAI API key for embedding-based features. Present when
+    /// `credential_storage = "file"`. Falls back to `OPENAI_API_KEY` env var.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub openai_api_key: Option<String>,
 }
@@ -273,8 +278,8 @@ pub fn load_profile(name: &str) -> Result<Profile> {
 
 /// Resolve a single named profile, respecting optional CLI overrides.
 ///
-/// API key resolution order: CLI override > keyring > profile TOML file.
-/// OpenAI key resolution: `OPENAI_API_KEY` env var > keyring > profile TOML.
+/// API key resolution order: CLI override > configured storage backend > bail.
+/// OpenAI key resolution: `OPENAI_API_KEY` env var > configured storage backend.
 fn resolve_single(
     profile_name: &str,
     api_key_override: Option<&str>,
@@ -286,26 +291,34 @@ fn resolve_single(
         profile.region = region.parse()?;
     }
 
-    // API key: CLI override > keyring > profile TOML
+    // API key: CLI override > storage backend
     let api_key = if let Some(key) = api_key_override {
         key.to_string()
-    } else if let Some(key) = keyring_store::get_secret(profile_name, "api_key")? {
-        key
-    } else if let Some(key) = profile.api_key {
-        key
     } else {
-        anyhow::bail!(
-            "No API key found for profile '{profile_name}'.\n\
-             Run `cx configure --profile {profile_name}` to set it up."
-        );
+        match profile.credential_storage {
+            CredentialStorage::OsStore => {
+                keyring_store::get_secret(profile_name, "api_key")?
+            }
+            CredentialStorage::File => profile.api_key,
+        }
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "No API key found for profile '{profile_name}'.\n\
+                 Run `cx configure --profile {profile_name}` to set it up."
+            )
+        })?
     };
 
-    // OpenAI key: env var > keyring > profile TOML
+    // OpenAI key: env var > storage backend
     let openai_api_key = std::env::var("OPENAI_API_KEY")
         .ok()
         .filter(|s| !s.is_empty())
-        .or_else(|| keyring_store::get_secret(profile_name, "openai_api_key").ok().flatten())
-        .or(profile.openai_api_key);
+        .or_else(|| match profile.credential_storage {
+            CredentialStorage::OsStore => {
+                keyring_store::get_secret(profile_name, "openai_api_key").ok().flatten()
+            }
+            CredentialStorage::File => profile.openai_api_key,
+        });
 
     Ok(ResolvedConfig {
         profile_name: profile_name.to_string(),
@@ -429,6 +442,7 @@ mod tests {
         let names = ["cx_inttest_multi_a", "cx_inttest_multi_b"];
         for (i, name) in names.iter().enumerate() {
             let profile = Profile {
+                credential_storage: CredentialStorage::File,
                 api_key: Some(format!("key-{i}")),
                 region: Region::Eu1,
                 label: None,
@@ -460,6 +474,7 @@ mod tests {
     #[ignore = "requires write access to ~/.cx; run with `cargo test -- --ignored`"]
     fn resolve_all_integration_empty_slice_falls_back_to_default() {
         let profile = Profile {
+            credential_storage: CredentialStorage::File,
             api_key: Some("default-key".to_string()),
             region: Region::Eu1,
             label: None,
@@ -473,14 +488,14 @@ mod tests {
         assert_eq!(configs[0].profile_name, "default");
     }
 
-    // ── Keyring resolution order tests ───────────────────────────────────────
+    // ── Credential storage resolution tests ────────────────────────────────
 
     #[test]
-    #[ignore = "requires write access to ~/.cx and system keyring"]
-    fn resolve_prefers_cli_override_over_keyring_and_file() {
+    #[ignore = "requires write access to ~/.cx"]
+    fn resolve_prefers_cli_override_over_file() {
         let name = "cx_inttest_resolve_override";
-        // Store key in both file and keyring
         let profile = Profile {
+            credential_storage: CredentialStorage::File,
             api_key: Some("file-key".to_string()),
             region: Region::Eu1,
             label: None,
@@ -488,44 +503,20 @@ mod tests {
             openai_api_key: None,
         };
         save_profile(name, &profile).unwrap();
-        crate::keyring_store::store_secret(name, "api_key", "keyring-key").unwrap();
 
         let config = resolve_single(name, Some("cli-key"), None).unwrap();
         assert_eq!(config.api_key, "cli-key");
 
         // cleanup
         let _ = std::fs::remove_file(profile_file(name).unwrap());
-        crate::keyring_store::delete_secret(name, "api_key");
-    }
-
-    #[test]
-    #[ignore = "requires write access to ~/.cx and system keyring"]
-    fn resolve_prefers_keyring_over_file() {
-        let name = "cx_inttest_resolve_keyring";
-        let profile = Profile {
-            api_key: Some("file-key".to_string()),
-            region: Region::Eu1,
-            label: None,
-            team_id: None,
-            openai_api_key: None,
-        };
-        save_profile(name, &profile).unwrap();
-        crate::keyring_store::store_secret(name, "api_key", "keyring-key").unwrap();
-
-        let config = resolve_single(name, None, None).unwrap();
-        assert_eq!(config.api_key, "keyring-key");
-
-        // cleanup
-        let _ = std::fs::remove_file(profile_file(name).unwrap());
-        crate::keyring_store::delete_secret(name, "api_key");
     }
 
     #[test]
     #[ignore = "requires write access to ~/.cx"]
-    fn resolve_falls_back_to_file_when_no_keyring_entry() {
-        let name = "cx_inttest_resolve_file_fallback";
-        // Only store in file, no keyring entry
+    fn resolve_reads_from_file_storage() {
+        let name = "cx_inttest_resolve_file";
         let profile = Profile {
+            credential_storage: CredentialStorage::File,
             api_key: Some("file-key".to_string()),
             region: Region::Eu1,
             label: None,
@@ -533,8 +524,6 @@ mod tests {
             openai_api_key: None,
         };
         save_profile(name, &profile).unwrap();
-        // Ensure no keyring entry
-        crate::keyring_store::delete_secret(name, "api_key");
 
         let config = resolve_single(name, None, None).unwrap();
         assert_eq!(config.api_key, "file-key");
@@ -548,6 +537,7 @@ mod tests {
     fn resolve_errors_when_no_key_anywhere() {
         let name = "cx_inttest_resolve_no_key";
         let profile = Profile {
+            credential_storage: CredentialStorage::File,
             api_key: None,
             region: Region::Eu1,
             label: None,
@@ -555,7 +545,6 @@ mod tests {
             openai_api_key: None,
         };
         save_profile(name, &profile).unwrap();
-        crate::keyring_store::delete_secret(name, "api_key");
 
         let result = resolve_single(name, None, None);
         assert!(result.is_err());

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,8 @@
 use std::path::PathBuf;
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
@@ -27,6 +30,22 @@ pub enum OutputFormat {
     Agents,
 }
 
+impl OutputFormat {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OutputFormat::Text => "text",
+            OutputFormat::Json => "json",
+            OutputFormat::Agents => "agents",
+        }
+    }
+}
+
+impl std::fmt::Display for OutputFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 /// Coralogix region, used to resolve the API endpoint.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -48,7 +67,7 @@ impl Region {
         match self {
             Region::Us1 => "https://api.us1.coralogix.com",
             Region::Us2 => "https://api.us2.coralogix.com",
-            Region::Eu1 => "https://api.eu2.coralogix.com",
+            Region::Eu1 => "https://api.eu1.coralogix.com",
             Region::Eu2 => "https://api.eu2.coralogix.com",
             Region::Ap1 => "https://api.ap1.coralogix.com",
             Region::Ap2 => "https://api.ap2.coralogix.com",
@@ -331,13 +350,17 @@ pub fn resolve_all(
 }
 
 /// Write a profile to disk, creating directories as needed.
+/// Sets file permissions to 0600 on Unix to protect any inline secrets.
 pub fn save_profile(name: &str, profile: &Profile) -> Result<()> {
     let dir = profiles_dir()?;
     std::fs::create_dir_all(&dir)?;
     let path = dir.join(format!("{name}.toml"));
     let content = toml::to_string_pretty(profile).context("Failed to serialize profile")?;
-    std::fs::write(&path, content)
+    std::fs::write(&path, &content)
         .with_context(|| format!("Failed to write {}", path.display()))?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+        .with_context(|| format!("Failed to set permissions on {}", path.display()))?;
     Ok(())
 }
 
@@ -365,7 +388,7 @@ mod tests {
 
     #[test]
     fn region_api_endpoint_eu1() {
-        assert_eq!(Region::Eu1.api_endpoint(), "https://api.eu2.coralogix.com");
+        assert_eq!(Region::Eu1.api_endpoint(), "https://api.eu1.coralogix.com");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::keyring_store;
 
+/// Where to store API keys.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum SecretStorage {
+    /// Store in the system keyring (macOS Keychain, Windows Credential Manager, etc.)
+    Keyring,
+    /// Store in the profile TOML file (plaintext).
+    File,
+}
+
 /// Output format for command results.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize, clap::ValueEnum)]
 #[serde(rename_all = "lowercase")]

--- a/src/keyring_store.rs
+++ b/src/keyring_store.rs
@@ -1,36 +1,72 @@
+use std::collections::HashMap;
+
 use anyhow::{Context, Result};
 
 const SERVICE_NAME: &str = "cx-cli";
 
-/// Store a secret in the system keyring.
-pub fn store_secret(profile: &str, key_name: &str, secret: &str) -> Result<()> {
-    let user = format!("{profile}/{key_name}");
-    let entry = keyring::Entry::new(SERVICE_NAME, &user)
-        .context("Failed to create keyring entry")?;
-    entry
-        .set_password(secret)
-        .context("Failed to store secret in keyring")?;
-    Ok(())
-}
+/// All secrets for a profile, stored as a single JSON blob in one keyring entry.
+type SecretMap = HashMap<String, String>;
 
-/// Retrieve a secret from the system keyring.
-/// Returns `None` if the entry does not exist.
-pub fn get_secret(profile: &str, key_name: &str) -> Result<Option<String>> {
-    let user = format!("{profile}/{key_name}");
-    let entry = keyring::Entry::new(SERVICE_NAME, &user)
+fn load_map(profile: &str) -> Result<Option<SecretMap>> {
+    let entry = keyring::Entry::new(SERVICE_NAME, profile)
         .context("Failed to create keyring entry")?;
     match entry.get_password() {
-        Ok(secret) => Ok(Some(secret)),
+        Ok(json) => {
+            let map: SecretMap =
+                serde_json::from_str(&json).context("Failed to parse keyring secrets")?;
+            Ok(Some(map))
+        }
         Err(keyring::Error::NoEntry) => Ok(None),
         Err(e) => Err(anyhow::anyhow!("Failed to read from keyring: {e}")),
     }
 }
 
+fn save_map(profile: &str, map: &SecretMap) -> Result<()> {
+    let entry = keyring::Entry::new(SERVICE_NAME, profile)
+        .context("Failed to create keyring entry")?;
+    if map.is_empty() {
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(e) => eprintln!("Warning: failed to delete keyring entry for {profile}: {e}"),
+        }
+    } else {
+        let json = serde_json::to_string(map).context("Failed to serialize keyring secrets")?;
+        entry
+            .set_password(&json)
+            .context("Failed to store secrets in keyring")?;
+    }
+    Ok(())
+}
+
+/// Store a secret in the system keyring.
+pub fn store_secret(profile: &str, key_name: &str, secret: &str) -> Result<()> {
+    let mut map = load_map(profile)?.unwrap_or_default();
+    map.insert(key_name.to_string(), secret.to_string());
+    save_map(profile, &map)
+}
+
+/// Retrieve a secret from the system keyring.
+/// Returns `None` if the entry or key does not exist.
+pub fn get_secret(profile: &str, key_name: &str) -> Result<Option<String>> {
+    Ok(load_map(profile)?.and_then(|m| m.get(key_name).cloned()))
+}
+
 /// Delete a secret from the system keyring. Best-effort — does not fail if missing.
 pub fn delete_secret(profile: &str, key_name: &str) {
-    let user = format!("{profile}/{key_name}");
-    if let Ok(entry) = keyring::Entry::new(SERVICE_NAME, &user) {
-        let _ = entry.delete_credential();
+    let Ok(Some(mut map)) = load_map(profile) else {
+        return;
+    };
+    map.remove(key_name);
+    let _ = save_map(profile, &map);
+}
+
+/// Delete all secrets for a profile. Best-effort.
+pub fn delete_profile(profile: &str) {
+    if let Ok(entry) = keyring::Entry::new(SERVICE_NAME, profile) {
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => {}
+            Err(e) => eprintln!("Warning: failed to delete keyring entry for {profile}: {e}"),
+        }
     }
 }
 
@@ -47,7 +83,7 @@ mod tests {
         let result = get_secret(TEST_PROFILE, "api_key").unwrap();
         assert_eq!(result, Some("test-secret-123".to_string()));
         // cleanup
-        delete_secret(TEST_PROFILE, "api_key");
+        delete_profile(TEST_PROFILE);
     }
 
     #[test]
@@ -64,5 +100,24 @@ mod tests {
         delete_secret(TEST_PROFILE, "delete_test");
         let result = get_secret(TEST_PROFILE, "delete_test").unwrap();
         assert_eq!(result, None);
+        // cleanup
+        delete_profile(TEST_PROFILE);
+    }
+
+    #[test]
+    #[ignore = "requires system keyring access"]
+    fn multiple_keys_single_entry() {
+        store_secret(TEST_PROFILE, "api_key", "key-1").unwrap();
+        store_secret(TEST_PROFILE, "openai_api_key", "key-2").unwrap();
+        assert_eq!(
+            get_secret(TEST_PROFILE, "api_key").unwrap(),
+            Some("key-1".to_string())
+        );
+        assert_eq!(
+            get_secret(TEST_PROFILE, "openai_api_key").unwrap(),
+            Some("key-2".to_string())
+        );
+        // cleanup
+        delete_profile(TEST_PROFILE);
     }
 }

--- a/src/keyring_store.rs
+++ b/src/keyring_store.rs
@@ -1,0 +1,68 @@
+use anyhow::{Context, Result};
+
+const SERVICE_NAME: &str = "cx-cli";
+
+/// Store a secret in the system keyring.
+pub fn store_secret(profile: &str, key_name: &str, secret: &str) -> Result<()> {
+    let user = format!("{profile}/{key_name}");
+    let entry = keyring::Entry::new(SERVICE_NAME, &user)
+        .context("Failed to create keyring entry")?;
+    entry
+        .set_password(secret)
+        .context("Failed to store secret in keyring")?;
+    Ok(())
+}
+
+/// Retrieve a secret from the system keyring.
+/// Returns `None` if the entry does not exist.
+pub fn get_secret(profile: &str, key_name: &str) -> Result<Option<String>> {
+    let user = format!("{profile}/{key_name}");
+    let entry = keyring::Entry::new(SERVICE_NAME, &user)
+        .context("Failed to create keyring entry")?;
+    match entry.get_password() {
+        Ok(secret) => Ok(Some(secret)),
+        Err(keyring::Error::NoEntry) => Ok(None),
+        Err(e) => Err(anyhow::anyhow!("Failed to read from keyring: {e}")),
+    }
+}
+
+/// Delete a secret from the system keyring. Best-effort — does not fail if missing.
+pub fn delete_secret(profile: &str, key_name: &str) {
+    let user = format!("{profile}/{key_name}");
+    if let Ok(entry) = keyring::Entry::new(SERVICE_NAME, &user) {
+        let _ = entry.delete_credential();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_PROFILE: &str = "cx_keyring_test";
+
+    #[test]
+    #[ignore = "requires system keyring access"]
+    fn store_and_get_roundtrip() {
+        store_secret(TEST_PROFILE, "api_key", "test-secret-123").unwrap();
+        let result = get_secret(TEST_PROFILE, "api_key").unwrap();
+        assert_eq!(result, Some("test-secret-123".to_string()));
+        // cleanup
+        delete_secret(TEST_PROFILE, "api_key");
+    }
+
+    #[test]
+    #[ignore = "requires system keyring access"]
+    fn get_missing_returns_none() {
+        let result = get_secret("cx_nonexistent_profile_xyz", "api_key").unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    #[ignore = "requires system keyring access"]
+    fn delete_removes_secret() {
+        store_secret(TEST_PROFILE, "delete_test", "to-be-deleted").unwrap();
+        delete_secret(TEST_PROFILE, "delete_test");
+        let result = get_secret(TEST_PROFILE, "delete_test").unwrap();
+        assert_eq!(result, None);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod execution;
+pub mod keyring_store;
 pub mod spill;
 pub mod tier;
 pub mod time;

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,7 +302,7 @@ async fn main() -> Result<()> {
 
     // Configure command doesn't need API credentials.
     if let Commands::Configure { profile, secret_storage } = cli.command {
-        return commands::configure::run(profile, secret_storage).await;
+        return commands::configure::run(profile, secret_storage);
     }
 
     // Cleanup command doesn't need API credentials.

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,9 @@ enum Commands {
         /// Profile name to configure (default: "default").
         #[arg(long, short = 'p')]
         profile: Option<String>,
-        /// Store API keys in the profile file instead of the system keyring.
-        #[arg(long)]
-        no_keyring: bool,
+        /// Where to store API keys: "keyring" (default) or "file".
+        #[arg(long, value_enum)]
+        secret_storage: Option<config::SecretStorage>,
     },
 
     /// Remove stale cx_results* files (older than 30 minutes) from the temp directory.
@@ -301,8 +301,8 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Configure command doesn't need API credentials.
-    if let Commands::Configure { profile, no_keyring } = cli.command {
-        return commands::configure::run(profile, no_keyring).await;
+    if let Commands::Configure { profile, secret_storage } = cli.command {
+        return commands::configure::run(profile, secret_storage).await;
     }
 
     // Cleanup command doesn't need API credentials.

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,6 @@ enum Commands {
         /// Profile name to configure (default: "default").
         #[arg(long, short = 'p')]
         profile: Option<String>,
-        /// Where to store API keys: "keyring" (default) or "file".
-        #[arg(long, value_enum)]
-        secret_storage: Option<config::SecretStorage>,
     },
 
     /// Remove stale cx_results* files (older than 30 minutes) from the temp directory.
@@ -301,8 +298,8 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Configure command doesn't need API credentials.
-    if let Commands::Configure { profile, secret_storage } = cli.command {
-        return commands::configure::run(profile, secret_storage);
+    if let Commands::Configure { profile } = cli.command {
+        return commands::configure::run(profile);
     }
 
     // Cleanup command doesn't need API credentials.

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,9 @@ enum Commands {
         /// Profile name to configure (default: "default").
         #[arg(long, short = 'p')]
         profile: Option<String>,
+        /// Store API keys in the profile file instead of the system keyring.
+        #[arg(long)]
+        no_keyring: bool,
     },
 
     /// Remove stale cx_results* files (older than 30 minutes) from the temp directory.
@@ -298,8 +301,8 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Configure command doesn't need API credentials.
-    if let Commands::Configure { profile } = cli.command {
-        return commands::configure::run(profile).await;
+    if let Commands::Configure { profile, no_keyring } = cli.command {
+        return commands::configure::run(profile, no_keyring).await;
     }
 
     // Cleanup command doesn't need API credentials.


### PR DESCRIPTION
## Summary
- Add `keyring` crate integration to store API keys securely in the system keyring (macOS Keychain, Windows Credential Manager, Linux Secret Service)
- Replace raw stdin prompts with `inquire` for a better interactive configure experience
- Add `SecretStorage` enum (`keyring` / `file`) to let users control where secrets are stored
- API key resolution order: CLI override > keyring > profile TOML file
- Set 0600 permissions on profile files on Unix when secrets are stored inline

JIRA: AIAG-476