### PR TITLE
AGE-548 | Add RUM skill

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -10,6 +10,7 @@ A collection of Claude Code skills for the [`cx` Coralogix CLI](https://github.c
 | `query-logs` | Query and analyze Coralogix logs using DataPrime syntax via `cx logs` |
 | `metrics-query` | Investigate production issues by searching metrics, constructing PromQL queries, and analyzing results via `cx metrics` |
 | `query-spans` | Query distributed traces and analyze span latency via `cx spans` |
+| `rum` | Query and analyze Real User Monitoring data — frontend errors, web vitals, user interactions, page performance via `cx logs` |
 | `telemetry-querying` | Gateway skill for telemetry-driven investigation — decide where to look (metrics, logs, traces, RUM, APM) before querying |
 
 ## Installation

--- a/skills/rum/SKILL.md
+++ b/skills/rum/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: rum
+description: |
+  Query and analyze Coralogix Real User Monitoring (RUM) data. Use this skill when the user asks about
+  frontend errors, page load times, web vitals, user interactions, browser errors, mobile crashes,
+  Core Web Vitals (LCP, CLS, FID, INP, TTFB), JavaScript exceptions, page performance, session errors,
+  RUM data, real user monitoring, or any frontend/client-side observability question — even if they
+  don't explicitly say "RUM".
+version: 0.1.0
+---
+
+# RUM Querying Skill
+
+Query and analyze Coralogix Real User Monitoring data using the `cx logs` command with DataPrime syntax.
+
+## Understanding RUM in Coralogix
+
+RUM captures real user interactions from browsers and mobile apps — errors, performance metrics, network requests, web vitals, and user interactions.
+
+**RUM data is stored as regular logs.** All RUM events live in the `cx_rum` subsystem and are queried with the same `cx logs` command and DataPrime syntax used for any other logs. The difference is in the fields: all RUM-specific data lives under `$d.cx_rum.*`.
+
+**What you can do:** Query, filter, aggregate, and analyze individual RUM log events — errors, page performance, user interactions, network requests, web vitals, mobile vitals.
+
+**What you cannot do:** View RUM sessions as a complete unit (session replay), view session flows across pages, or access full session context. Only individual RUM log events are available.
+
+For general log querying concepts and field discovery, see the **`query-logs`** skill. For DataPrime query language syntax, see the **[DataPrime Reference](../shared/references/dataprime-reference.md)**.
+
+---
+
+## CLI Command
+
+RUM queries use `cx logs` — the same command as the `query-logs` skill:
+
+```bash
+cx logs '<dataprime_query>'
+```
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--start` | `now-1h` | Start time (ISO 8601 or relative, e.g. `now-7d`) |
+| `--end` | `now` | End time |
+| `--limit` | `100` | Maximum number of results |
+| `--tier` | `frequent` | Storage tier: `frequent` or `archive` |
+| `-o, --output` | `text` | Output format: `text`, `json`, or `agents` |
+
+**RUM-specific default:** Use `--start now-7d` (or wider) for performance and web vitals queries. Short time ranges produce unreliable percentiles because low-traffic pages have too few data points.
+
+---
+
+## Identifying RUM Logs
+
+**Every RUM query MUST include:**
+
+```
+filter $l.subsystemname == 'cx_rum'
+```
+
+### Application Filtering
+
+For RUM data, use RUM-specific application fields — **NOT** `$l.applicationname`:
+
+```bash
+# Correct — RUM application name
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.version_metadata.app_name == "my-app"'
+
+# Also correct — micro-frontend app label
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.labels.mfeApp == "my-app"'
+
+# WRONG — $l.applicationname is not the RUM application name
+cx logs 'filter $l.subsystemname == "cx_rum" && $l.applicationname == "my-app"'
+```
+
+---
+
+## Event Types
+
+Filter by `$d.cx_rum.event_context.type`:
+
+| Type | Description |
+|------|-------------|
+| `error` | Errors, unhandled exceptions, crashes (browser and mobile) |
+| `resources` | Resource loading (scripts, images, CSS, fonts) |
+| `network-request` | XHR/Fetch HTTP requests |
+| `user-interaction` | Clicks, inputs, scrolls |
+| `web-vitals` | Web Vitals (LT, LCP, FID, CLS, FCP, INP, TTFB, TBT) |
+| `longtask` | Long tasks blocking the main thread |
+| `life-cycle` | Page lifecycle events (load, unload, visibility) |
+| `dom` | DOM mutations and changes |
+| `log` | Console logs captured by the SDK |
+| `custom-measurement` | Custom metrics sent by the app |
+| `mobile-vitals` | Mobile-specific performance metrics |
+
+---
+
+## Key Fields
+
+All RUM fields live under `$d.cx_rum.*`. The fields you'll use most often:
+
+| Context | Key Fields | Used For |
+|---------|-----------|----------|
+| `event_context` | `type`, `severity` (5 = error) | Filtering by event type and errors |
+| `rum_template_id` | Error fingerprint | Grouping errors into distinct issues |
+| `error_context` | `error_message`, `error_type`, `is_crash`, `original_stacktrace` | Error details |
+| `session_context` | `user_id`, `session_id`, `browser`, `os`, `device`, `ip_geoip.*` | User/session identity |
+| `version_metadata` | `app_name`, `app_version` | App filtering (use instead of `$l.applicationname`) |
+| `page_context` | `page_url`, `page_fragments` (use for groupby) | Page identification |
+| `network_request_context` | `url`, `fragments`, `method`, `status_code`, `duration` | HTTP request analysis |
+| `web_vitals_context` | `name` (LT/LCP/FID/CLS/FCP/INP/TTFB/TBT), `value`, `rating` | Performance metrics |
+| `interaction_context` | `target_element_inner_text` (use for groupby), `event_name` | Click/input analysis |
+| `labels` | `mfeApp`, `mfeVersion` | Micro-frontend identification |
+
+For the complete field reference including resource context, mobile contexts, and all sub-fields, see **[RUM Fields Reference](references/rum-fields.md)**.
+
+---
+
+## Querying RUM Data
+
+### Errors and Issues
+
+RUM errors can come from multiple event types: `error`, `network-request`, or `custom-log`. The universal identifiers are:
+
+- **`event_context.severity == 5`** — indicates an error regardless of event type
+- **`rum_template_id`** — groups similar errors into distinct issues
+
+**Rules:**
+- Always filter by severity: `$d.cx_rum.event_context.severity:num == 5`
+- Always group by issue: `groupby $d.cx_rum.rum_template_id`
+- Always filter null template IDs: `$d.cx_rum.rum_template_id != null`
+- Always include descriptive fields with `any_value()` when aggregating
+- Always include application name: `any_value($d.cx_rum.version_metadata.app_name) as app_name`
+
+**Composing error descriptions:** When grouping by `rum_template_id`, include fields for all error types — irrelevant fields will be null:
+
+- For `error` events → use `error_message`
+- For `network-request` events → compose as `"<method> <url_fragments> (status <status_code>)"`
+- For `custom-log` events → use `custom_log_message`
+
+### Web Vitals
+
+- Use **`percentile(0.75, ...)`** for p75 values — NOT `avg` (skewed by outliers)
+- Use `$d.cx_rum.web_vitals_context.value` without `:num` cast
+- **Only query the specific vitals the user asks about** — e.g., for "loading times" query only `LT`, for "LCP" query only `LCP`. Do NOT include all vitals unless explicitly asked for a full overview.
+- For a single vital: `filter $d.cx_rum.web_vitals_context.name == 'LT'`
+- For multiple vitals in one query: use conditional `if()` inside percentile
+- **Use wide time ranges** (7+ days) for reliable percentiles
+
+### User Interactions
+
+- **NEVER return raw interaction events** — always aggregate
+- **Always group by `interaction_context.target_element_inner_text`** — the button/link text the user sees
+- **Always filter out empty/null inner text**
+- Do NOT group by `target_element` (HTML tag) or `target_selector`
+- Do NOT use `user_interaction_context` — the correct prefix is `interaction_context`
+
+### Network Requests
+
+- Filter by event type: `$d.cx_rum.event_context.type == 'network-request'`
+- For errors: combine with `event_context.severity:num == 5`
+- Compose description as: `"<method> <fragments> (status <status_code>)"`
+
+### Page Performance
+
+- Use the `LT` (Load Time) web vital for page loading time queries
+- Group by `$d.cx_rum.page_context.page_fragments` (not `page_url`)
+- Include user count for context: `distinct_count($d.cx_rum.session_context.user_id:string) as users`
+
+---
+
+## Common Query Patterns
+
+### Top Errors by Issue
+
+```bash
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5 && $d.cx_rum.rum_template_id != null | groupby $d.cx_rum.rum_template_id aggregate count() as error_count, any_value($d.cx_rum.version_metadata.app_name) as app_name, any_value($d.cx_rum.event_context.type) as event_type, any_value($d.cx_rum.error_context.error_message) as error_message, any_value($d.cx_rum.network_request_context.method) as method, any_value($d.cx_rum.network_request_context.fragments) as url_fragments, any_value($d.cx_rum.network_request_context.status_code) as status_code, any_value($d.cx_rum.custom_log_context.message) as custom_log_message, distinct_count($d.cx_rum.session_context.user_id) as affected_users | orderby error_count desc' --start now-7d
+```
+
+### Network Request Errors
+
+```bash
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5 && $d.cx_rum.event_context.type == "network-request" | groupby $d.cx_rum.rum_template_id aggregate count() as error_count, any_value($d.cx_rum.version_metadata.app_name) as app_name, any_value($d.cx_rum.network_request_context.method) as method, any_value($d.cx_rum.network_request_context.fragments) as fragments, any_value($d.cx_rum.network_request_context.status_code) as status_code | orderby error_count desc' --start now-7d
+```
+
+### Slow Loading Pages (LT p75)
+
+```bash
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "web-vitals" && $d.cx_rum.web_vitals_context.name == "LT" | groupby $d.cx_rum.page_context.page_fragments aggregate distinct_count($d.cx_rum.session_context.user_id:string) as users, count() as page_views, percentile(0.75, $d.cx_rum.web_vitals_context.value) as LT_p75_ms | orderby users desc' --start now-7d
+```
+
+### User Interactions on a Page
+
+```bash
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "user-interaction" && $d.cx_rum.page_context.page_fragments ~ "/some/page" && $d.cx_rum.interaction_context.target_element_inner_text != null && $d.cx_rum.interaction_context.target_element_inner_text != "" | groupby $d.cx_rum.interaction_context.target_element_inner_text aggregate count() as click_count, distinct_count($d.cx_rum.session_context.user_id) as unique_users | orderby click_count desc' --start now-7d
+```
+
+### Affected Users per Error
+
+```bash
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5 && $d.cx_rum.rum_template_id != null | groupby $d.cx_rum.rum_template_id aggregate distinct_count($d.cx_rum.session_context.user_id) as affected_users, count() as error_count, any_value($d.cx_rum.error_context.error_message) as error_message | orderby affected_users desc' --start now-7d
+```
+
+### Single Web Vital (e.g., LCP by Page)
+
+```bash
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "web-vitals" && $d.cx_rum.web_vitals_context.name == "LCP" | groupby $d.cx_rum.page_context.page_fragments aggregate percentile(0.75, $d.cx_rum.web_vitals_context.value) as LCP_p75_ms, count() as samples | orderby LCP_p75_ms desc' --start now-7d
+```
+
+---
+
+## Troubleshooting
+
+If a query returns no results, change **one thing at a time**:
+
+1. **Extend the time range**: `--start now-7d` or `--start now-30d`
+2. **Relax filters**: remove the most restrictive condition
+3. **Verify field names**: run a sample query with `-o json` to inspect actual fields
+4. **Try archive tier**: `--tier archive --start now-30d` for older data
+
+**Note:** Filtering by `cx_rum` fields will show **only RUM/frontend logs** and hide backend logs. This is expected behavior when analyzing RUM data.
+
+---
+
+## References
+
+- **[RUM Fields Reference](references/rum-fields.md)** — Complete field reference for all RUM contexts (session, network, web vitals, mobile, etc.)
+- **[`query-logs` skill](../query-logs/SKILL.md)** — General log querying, field discovery, investigation workflows, wildfind policy
+- **[DataPrime Reference](../shared/references/dataprime-reference.md)** — Full query language: commands, operators, aggregations, text extraction, type conversions
+- **[Logs Advanced Usage](../query-logs/references/advanced-usage.md)** — Investigation workflows, common query patterns, performance tips
+
+For inline DataPrime help:
+
+```bash
+cx dataprime list                  # List all commands and functions
+cx dataprime show filter           # Detailed help for a specific command
+```
+
+---
+
+## Related Skills
+
+- **`query-logs`** — General log querying with DataPrime (RUM data is logs)
+- **`query-spans`** — Distributed traces and service latency
+- **`metrics-query`** — Aggregated counters, gauges, and histograms (PromQL)
+- **`telemetry-querying`** — Gateway skill for choosing the right data source
+- **`cx-alerts`** — Create and manage alerts based on log patterns

--- a/skills/rum/SKILL.md
+++ b/skills/rum/SKILL.md
@@ -15,13 +15,12 @@ Query and analyze Coralogix Real User Monitoring data using the `cx logs` comman
 
 ## Understanding RUM in Coralogix
 
-RUM captures real user interactions from browsers and mobile apps — errors, performance metrics, network requests, web vitals, and user interactions.
+RUM captures real user interactions from browsers and mobile apps — errors, performance metrics, network requests, web vitals, and user interactions. **RUM data is stored as regular logs** in the `cx_rum` subsystem, queried with the same `cx logs` command and DataPrime syntax used for any other logs.
 
-**RUM data is stored as regular logs.** All RUM events live in the `cx_rum` subsystem and are queried with the same `cx logs` command and DataPrime syntax used for any other logs. The difference is in the fields: all RUM-specific data lives under `$d.cx_rum.*`.
-
-**What you can do:** Query, filter, aggregate, and analyze individual RUM log events — errors, page performance, user interactions, network requests, web vitals, mobile vitals.
-
-**What you cannot do:** View RUM sessions as a complete unit (session replay), view session flows across pages, or access full session context. Only individual RUM log events are available.
+This means:
+- **Metadata (`$m.*`)** and **labels (`$l.*`)** work the same as regular logs — you can filter on timestamp, severity, etc.
+- **User data (`$d.cx_rum.*`)** contains all RUM-specific fields — event types, errors, sessions, web vitals, interactions, and more. See the **[RUM Fields Reference](references/rum-fields.md)** for the complete field catalog.
+- **Session replay and session flows are not available** — only individual RUM log events can be queried.
 
 For general log querying concepts and field discovery, see the **`query-logs`** skill. For DataPrime query language syntax, see the **[DataPrime Reference](../shared/references/dataprime-reference.md)**.
 
@@ -29,11 +28,11 @@ For general log querying concepts and field discovery, see the **`query-logs`** 
 
 ## CLI Command
 
-RUM queries use `cx logs` — the same command as the `query-logs` skill:
-
 ```bash
 cx logs '<dataprime_query>'
 ```
+
+The `source logs` prefix is automatically injected if the query doesn't already include a `source` command.
 
 ### Options
 
@@ -45,36 +44,30 @@ cx logs '<dataprime_query>'
 | `--tier` | `frequent` | Storage tier: `frequent` or `archive` |
 | `-o, --output` | `text` | Output format: `text`, `json`, or `agents` |
 
-**RUM-specific default:** Use `--start now-7d` (or wider) for performance and web vitals queries. Short time ranges produce unreliable percentiles because low-traffic pages have too few data points.
+**Note:** Use `--start now-7d` (or wider) for web vitals and page performance queries. Short time ranges produce unreliable percentiles — low-traffic pages have too few data points.
 
 ---
 
-## Identifying RUM Logs
+## RUM Data Model
 
-**Every RUM query MUST include:**
+### Identifying RUM Logs
 
-```
-filter $l.subsystemname == 'cx_rum'
-```
+Every RUM query must include `$l.subsystemname == 'cx_rum'`.
 
-### Application Filtering
-
-For RUM data, use RUM-specific application fields — **NOT** `$l.applicationname`:
+Application filtering in RUM uses dedicated fields — `$l.applicationname` does not map to the RUM application name:
 
 ```bash
-# Correct — RUM application name
+# RUM application name
 cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.version_metadata.app_name == "my-app"'
 
-# Also correct — micro-frontend app label
+# Micro-frontend app label
 cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.labels.mfeApp == "my-app"'
 
 # WRONG — $l.applicationname is not the RUM application name
 cx logs 'filter $l.subsystemname == "cx_rum" && $l.applicationname == "my-app"'
 ```
 
----
-
-## Event Types
+### Event Types
 
 Filter by `$d.cx_rum.event_context.type`:
 
@@ -84,7 +77,7 @@ Filter by `$d.cx_rum.event_context.type`:
 | `resources` | Resource loading (scripts, images, CSS, fonts) |
 | `network-request` | XHR/Fetch HTTP requests |
 | `user-interaction` | Clicks, inputs, scrolls |
-| `web-vitals` | Web Vitals (LT, LCP, FID, CLS, FCP, INP, TTFB, TBT) |
+| `web-vitals` | Web Vitals: `LT` (Load Time), `LCP`, `FID`, `CLS`, `FCP`, `INP`, `TTFB`, `TBT` |
 | `longtask` | Long tasks blocking the main thread |
 | `life-cycle` | Page lifecycle events (load, unload, visibility) |
 | `dom` | DOM mutations and changes |
@@ -92,11 +85,9 @@ Filter by `$d.cx_rum.event_context.type`:
 | `custom-measurement` | Custom metrics sent by the app |
 | `mobile-vitals` | Mobile-specific performance metrics |
 
----
+### Key Fields
 
-## Key Fields
-
-All RUM fields live under `$d.cx_rum.*`. The fields you'll use most often:
+All RUM fields live under `$d.cx_rum.*`. The most commonly used:
 
 | Context | Key Fields | Used For |
 |---------|-----------|----------|
@@ -107,104 +98,78 @@ All RUM fields live under `$d.cx_rum.*`. The fields you'll use most often:
 | `version_metadata` | `app_name`, `app_version` | App filtering (use instead of `$l.applicationname`) |
 | `page_context` | `page_url`, `page_fragments` (use for groupby) | Page identification |
 | `network_request_context` | `url`, `fragments`, `method`, `status_code`, `duration` | HTTP request analysis |
-| `web_vitals_context` | `name` (LT/LCP/FID/CLS/FCP/INP/TTFB/TBT), `value`, `rating` | Performance metrics |
+| `web_vitals_context` | `name`, `value`, `rating` | Performance metrics |
 | `interaction_context` | `target_element_inner_text` (use for groupby), `event_name` | Click/input analysis |
 | `labels` | `mfeApp`, `mfeVersion` | Micro-frontend identification |
 
 For the complete field reference including resource context, mobile contexts, and all sub-fields, see **[RUM Fields Reference](references/rum-fields.md)**.
 
----
+### Error Detection
 
-## Querying RUM Data
+RUM errors can come from multiple event types (`error`, `network-request`, `custom-log`). The universal error marker is `event_context.severity == 5`, which applies regardless of event type.
 
-### Errors and Issues
-
-RUM errors can come from multiple event types: `error`, `network-request`, or `custom-log`. The universal identifiers are:
-
-- **`event_context.severity == 5`** — indicates an error regardless of event type
-- **`rum_template_id`** — groups similar errors into distinct issues
-
-**Rules:**
-- Always filter by severity: `$d.cx_rum.event_context.severity:num == 5`
-- Always group by issue: `groupby $d.cx_rum.rum_template_id`
-- Always filter null template IDs: `$d.cx_rum.rum_template_id != null`
-- Always include descriptive fields with `any_value()` when aggregating
-- Always include application name: `any_value($d.cx_rum.version_metadata.app_name) as app_name`
-
-**Composing error descriptions:** When grouping by `rum_template_id`, include fields for all error types — irrelevant fields will be null:
-
-- For `error` events → use `error_message`
-- For `network-request` events → compose as `"<method> <url_fragments> (status <status_code>)"`
-- For `custom-log` events → use `custom_log_message`
-
-### Web Vitals
-
-- Use **`percentile(0.75, ...)`** for p75 values — NOT `avg` (skewed by outliers)
-- Use `$d.cx_rum.web_vitals_context.value` without `:num` cast
-- **Only query the specific vitals the user asks about** — e.g., for "loading times" query only `LT`, for "LCP" query only `LCP`. Do NOT include all vitals unless explicitly asked for a full overview.
-- For a single vital: `filter $d.cx_rum.web_vitals_context.name == 'LT'`
-- For multiple vitals in one query: use conditional `if()` inside percentile
-- **Use wide time ranges** (7+ days) for reliable percentiles
-
-### User Interactions
-
-- **NEVER return raw interaction events** — always aggregate
-- **Always group by `interaction_context.target_element_inner_text`** — the button/link text the user sees
-- **Always filter out empty/null inner text**
-- Do NOT group by `target_element` (HTML tag) or `target_selector`
-- Do NOT use `user_interaction_context` — the correct prefix is `interaction_context`
-
-### Network Requests
-
-- Filter by event type: `$d.cx_rum.event_context.type == 'network-request'`
-- For errors: combine with `event_context.severity:num == 5`
-- Compose description as: `"<method> <fragments> (status <status_code>)"`
-
-### Page Performance
-
-- Use the `LT` (Load Time) web vital for page loading time queries
-- Group by `$d.cx_rum.page_context.page_fragments` (not `page_url`)
-- Include user count for context: `distinct_count($d.cx_rum.session_context.user_id:string) as users`
-
----
-
-## Common Query Patterns
-
-### Top Errors by Issue
+The `rum_template_id` field groups similar error events into distinct issues — always group by it when analyzing errors, and filter out nulls:
 
 ```bash
 cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5 && $d.cx_rum.rum_template_id != null | groupby $d.cx_rum.rum_template_id aggregate count() as error_count, any_value($d.cx_rum.version_metadata.app_name) as app_name, any_value($d.cx_rum.event_context.type) as event_type, any_value($d.cx_rum.error_context.error_message) as error_message, any_value($d.cx_rum.network_request_context.method) as method, any_value($d.cx_rum.network_request_context.fragments) as url_fragments, any_value($d.cx_rum.network_request_context.status_code) as status_code, any_value($d.cx_rum.custom_log_context.message) as custom_log_message, distinct_count($d.cx_rum.session_context.user_id) as affected_users | orderby error_count desc' --start now-7d
 ```
 
-### Network Request Errors
+Include `any_value()` for descriptive fields from all error types — irrelevant fields will be null. When composing error descriptions from grouped results, the relevant fields depend on the event type:
+- `error` → `error_message`
+- `network-request` → `"<method> <url_fragments> (status <status_code>)"`
+- `custom-log` → `custom_log_context.message`
+
+---
+
+## Querying RUM Data
+
+### Essential Examples
 
 ```bash
-cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5 && $d.cx_rum.event_context.type == "network-request" | groupby $d.cx_rum.rum_template_id aggregate count() as error_count, any_value($d.cx_rum.version_metadata.app_name) as app_name, any_value($d.cx_rum.network_request_context.method) as method, any_value($d.cx_rum.network_request_context.fragments) as fragments, any_value($d.cx_rum.network_request_context.status_code) as status_code | orderby error_count desc' --start now-7d
-```
+# All RUM errors in the last 7 days
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5' --start now-7d
 
-### Slow Loading Pages (LT p75)
+# Network request errors
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5 && $d.cx_rum.event_context.type == "network-request" | groupby $d.cx_rum.rum_template_id aggregate count() as error_count, any_value($d.cx_rum.network_request_context.method) as method, any_value($d.cx_rum.network_request_context.fragments) as fragments, any_value($d.cx_rum.network_request_context.status_code) as status_code | orderby error_count desc' --start now-7d
 
-```bash
-cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "web-vitals" && $d.cx_rum.web_vitals_context.name == "LT" | groupby $d.cx_rum.page_context.page_fragments aggregate distinct_count($d.cx_rum.session_context.user_id:string) as users, count() as page_views, percentile(0.75, $d.cx_rum.web_vitals_context.value) as LT_p75_ms | orderby users desc' --start now-7d
-```
+# Slow loading pages (LT p75)
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "web-vitals" && $d.cx_rum.web_vitals_context.name == "LT" | groupby $d.cx_rum.page_context.page_fragments aggregate distinct_count($d.cx_rum.session_context.user_id:string) as users, percentile(0.75, $d.cx_rum.web_vitals_context.value) as LT_p75_ms | orderby users desc' --start now-7d
 
-### User Interactions on a Page
-
-```bash
+# User interactions on a page
 cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "user-interaction" && $d.cx_rum.page_context.page_fragments ~ "/some/page" && $d.cx_rum.interaction_context.target_element_inner_text != null && $d.cx_rum.interaction_context.target_element_inner_text != "" | groupby $d.cx_rum.interaction_context.target_element_inner_text aggregate count() as click_count, distinct_count($d.cx_rum.session_context.user_id) as unique_users | orderby click_count desc' --start now-7d
-```
 
-### Affected Users per Error
-
-```bash
+# Affected users per error
 cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.severity:num == 5 && $d.cx_rum.rum_template_id != null | groupby $d.cx_rum.rum_template_id aggregate distinct_count($d.cx_rum.session_context.user_id) as affected_users, count() as error_count, any_value($d.cx_rum.error_context.error_message) as error_message | orderby affected_users desc' --start now-7d
-```
 
-### Single Web Vital (e.g., LCP by Page)
-
-```bash
+# LCP by page
 cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "web-vitals" && $d.cx_rum.web_vitals_context.name == "LCP" | groupby $d.cx_rum.page_context.page_fragments aggregate percentile(0.75, $d.cx_rum.web_vitals_context.value) as LCP_p75_ms, count() as samples | orderby LCP_p75_ms desc' --start now-7d
 ```
+
+### Web Vitals Querying
+
+Web vitals use `percentile(0.75, ...)` for p75 values — `avg` is skewed by outliers. Use `$d.cx_rum.web_vitals_context.value` without `:num` cast.
+
+Only query the specific vitals the user asks about. For "loading times" query `LT`, for "LCP" query `LCP`. Include all vitals only when the user explicitly asks for a full overview.
+
+For multiple vitals in one query, use conditional `if()` inside percentile:
+
+```bash
+cx logs 'filter $l.subsystemname == "cx_rum" && $d.cx_rum.event_context.type == "web-vitals" | groupby $d.cx_rum.page_context.page_fragments aggregate percentile(0.75, if($d.cx_rum.web_vitals_context.name == "LT", $d.cx_rum.web_vitals_context.value)) as LT_p75, percentile(0.75, if($d.cx_rum.web_vitals_context.name == "LCP", $d.cx_rum.web_vitals_context.value)) as LCP_p75' --start now-7d
+```
+
+### User Interaction Querying
+
+User interaction queries should always aggregate results — raw interaction events are noisy. Group by `interaction_context.target_element_inner_text` (the button/link text the user sees), and filter out null/empty values.
+
+Do not group by `target_element` (HTML tag like DIV, SPAN) or `target_selector` — these are not meaningful to users. The correct field prefix is `interaction_context`, not `user_interaction_context`.
+
+### Network Requests
+
+Filter network requests by event type `$d.cx_rum.event_context.type == 'network-request'`. For failed requests, combine with `event_context.severity:num == 5`. Compose descriptions as `"<method> <fragments> (status <status_code>)"`.
+
+### Page Performance
+
+Use the `LT` (Load Time) web vital for page loading time questions. Group by `$d.cx_rum.page_context.page_fragments` (not `page_url`), and include user count for context with `distinct_count($d.cx_rum.session_context.user_id:string) as users`.
 
 ---
 
@@ -217,7 +182,7 @@ If a query returns no results, change **one thing at a time**:
 3. **Verify field names**: run a sample query with `-o json` to inspect actual fields
 4. **Try archive tier**: `--tier archive --start now-30d` for older data
 
-**Note:** Filtering by `cx_rum` fields will show **only RUM/frontend logs** and hide backend logs. This is expected behavior when analyzing RUM data.
+**Note:** Filtering by `cx_rum` fields will show **only RUM/frontend logs** and hide backend logs. This is expected when analyzing RUM data.
 
 ---
 

--- a/skills/rum/references/rum-fields.md
+++ b/skills/rum/references/rum-fields.md
@@ -1,0 +1,159 @@
+# RUM Field Reference
+
+All fields are under `$d.cx_rum.*`.
+
+## Table of Contents
+
+- [Event Context](#event-context)
+- [Error Context & Grouping](#error-context--grouping)
+- [Session Context](#session-context)
+- [Version & Environment](#version--environment)
+- [Page Context](#page-context)
+- [Network Request Context](#network-request-context)
+- [Web Vitals Context](#web-vitals-context)
+- [Interaction Context](#interaction-context)
+- [Resource Context](#resource-context)
+- [Mobile Contexts](#mobile-contexts)
+- [Other Fields](#other-fields)
+
+---
+
+## Event Context
+
+`event_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `type` | Event type (`error`, `resources`, `network-request`, `user-interaction`, `web-vitals`, `longtask`, `life-cycle`, `dom`, `log`, `custom-measurement`, `mobile-vitals`) |
+| `severity` | Severity level (`5` = error, applies to all event types) |
+| `source` | Event source |
+
+## Error Context & Grouping
+
+`error_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `error_message` | Error message text |
+| `error_type` | Error classification |
+| `is_crash` | Whether the error is a crash |
+| `original_stacktrace` | Stack trace |
+| `threads` | Thread information |
+
+Top-level error grouping fields:
+
+| Field | Description |
+|-------|-------------|
+| `rum_template_id` | Error fingerprint — groups similar errors into distinct issues |
+| `fingerPrint` | Additional fingerprint field |
+
+## Session Context
+
+`session_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `user_id`, `user_email`, `user_name`, `user_metadata` | User identity |
+| `session_id`, `session_creation_date` | Session identity |
+| `browser`, `browserVersion` | Browser info |
+| `os`, `osVersion`, `device`, `user_agent` | Device info |
+| `ip` | IP address |
+| `ip_geoip.country_name`, `city_name`, `continent_name`, `is_local` | Geolocation |
+| `hasRecording`, `hasScreenshot`, `hasError` | Session flags |
+
+## Version & Environment
+
+| Field | Description |
+|-------|-------------|
+| `version_metadata.app_name` | Application name (use for RUM app filtering) |
+| `version_metadata.app_version` | Application version |
+| `platform` | Platform (web, iOS, Android) |
+| `environment` | Deployment environment |
+| `labels.*` | Custom labels (e.g. `labels.mfeApp`, `labels.mfeVersion`) |
+
+## Page Context
+
+`page_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `page_url` | Full page URL |
+| `page_fragments` | URL path — **always use this for groupby** |
+| `referrer` | Referring page |
+| `page_url_blueprint` | URL pattern/template |
+
+## Network Request Context
+
+`network_request_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `url`, `url_blueprint`, `fragments`, `host`, `schema` | Request URL parts |
+| `method` | HTTP method |
+| `status_code`, `status_text` | Response status |
+| `duration` | Request duration |
+| `response_content_length` | Response size |
+| `source` | Request source |
+
+## Web Vitals Context
+
+`web_vitals_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `name` | Vital name: `LT` (Load Time), `LCP`, `FID`, `CLS`, `FCP`, `INP`, `TTFB`, `TBT` |
+| `value` | Metric value |
+| `rating` | Rating classification |
+| `domComplete`, `domInteractive` | DOM timing milestones |
+| `domContentLoadedEventStart`, `domContentLoadedEventEnd` | DCL timing |
+| `loadEventStart`, `loadEventEnd` | Load event timing |
+| `attribution.element`, `attribution.eventTarget` | Attribution fields |
+
+## Interaction Context
+
+`interaction_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `event_name` | Interaction event type |
+| `target_element` | HTML element tag |
+| `target_element_inner_text` | User-visible button/link text — **use this for groupby** |
+| `target_element_type` | Element type |
+| `element_id`, `element_classes` | Element identifiers |
+
+## Resource Context
+
+`resource_context.*`
+
+| Field | Description |
+|-------|-------------|
+| `initiatorType` | Resource type (script, img, css, etc.) |
+| `name`, `fragments` | Resource URL |
+| `duration`, `responseStatus` | Loading performance |
+| `transferSize`, `decodedBodySize` | Size metrics |
+| `contentType`, `contentEncoding` | Content metadata |
+| `deliveryType`, `nextHopProtocol` | Delivery info |
+
+## Mobile Contexts
+
+**Device Context** (`device_context.*`): `device`, `device_name`, `os`, `osVersion`, `emulator`
+
+**Mobile SDK** (`mobile_sdk.*`): `framework`, `sdk_version`
+
+**View Context** (`view_context.*`): `view`, `view_activity`, `view_fragment`
+
+**Mobile Vitals** (`mobile_vitals_context.*`):
+- CPU: `cpu.cpu_usage`, `cpu.total_cpu_time`, `cpu.main_thread_cpu_time`
+- Memory: `memory.memory_utilization`, `memory.heap_max`, `memory.heap_used`
+- Performance: `fps`, `cold`, `warm`, `slow_frozen.slow_frames`, `slow_frozen.frozen_frames`, `anr`
+
+## Other Fields
+
+| Field | Description |
+|-------|-------------|
+| `traceId`, `spanId` | Distributed tracing correlation |
+| `screenshot_context.id`, `screenshotId` | Screenshot references |
+| `log_context.message` | Console log message |
+| `longtask_context.id`, `name`, `duration` | Long task details |
+| `custom_measurement_context.name`, `value` | Custom metrics |
+| `browser_sdk.version` | Browser SDK version |

--- a/skills/telemetry-querying/SKILL.md
+++ b/skills/telemetry-querying/SKILL.md
@@ -83,7 +83,7 @@ Based on discovery results, pick the pillar with the clearest signal and delegat
 | Metrics | `metrics-query` |
 | Logs | `query-logs` |
 | Traces/Spans | `query-spans` |
-| RUM | `RUM-data-querying` |
+| RUM | `rum` |
 | APM | APM-specific guidance |
 
 ---
@@ -143,7 +143,7 @@ Do not stop after one failed attempt. Try at least two pillars before concluding
 
 **Approach:**
 1. This is clearly a RUM question — frontend page load data
-2. Use `RUM-data-querying` skill directly
+2. Use `rum` skill directly
 3. If RUM shows backend calls are slow, pivot to `query-spans` for the API calls
 
 ### Example 4: Error Investigation (Logs + Traces)
@@ -173,5 +173,5 @@ Do not stop after one failed attempt. Try at least two pillars before concluding
 - **`metrics-query`** — PromQL queries, metric discovery, instant and range queries
 - **`query-logs`** — DataPrime log queries, log field exploration
 - **`query-spans`** — Trace search, span analysis, distributed tracing
-- **`RUM-data-querying`** — Frontend performance, user sessions, page loads
+- **`rum`** — Frontend performance, user sessions, page loads
 - **`cx-alerts`** — Creating alerts on metrics, logs, or traces


### PR DESCRIPTION
AIAG-454

## Summary
- Add new `rum` skill for querying Real User Monitoring data via `cx logs`
- Covers frontend errors, web vitals, user interactions, network requests, page performance, and mobile vitals
- SKILL.md contains querying policies and common patterns; full field reference in `references/rum-fields.md`
- Update `telemetry-querying` skill references from `RUM-data-querying` to `rum`
- Add `rum` to skills README