### PR TITLE
AGE-692 | Add skills distribution via npx skills

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,36 +1,55 @@
 # cx Skills
 
-A collection of Claude Code skills for the [`cx` Coralogix CLI](https://github.com/coralogix/cx-cli). Install this plugin to give Claude deep knowledge of how to investigate observability data using the CLI.
+A collection of agent skills for the [`cx` Coralogix CLI](https://github.com/coralogix/cx-cli). Install these skills to give your coding agent deep knowledge of how to investigate observability data using the CLI.
+
+Supports **Claude Code**, **Cursor**, **Codex**, **OpenCode**, and [40+ more agents](https://github.com/vercel-labs/skills#supported-agents).
 
 ## Available Skills
 
 | Skill | Description |
 |---|---|
 | `cx-alerts` | Manage Coralogix alert definitions — list, inspect, create, enable/disable via `cx alerts` |
-| `query-logs` | Query and analyze Coralogix logs using DataPrime syntax via `cx logs` |
+| `dataprime` | DataPrime query language reference — syntax, commands, operators, aggregations, text extraction |
 | `metrics-query` | Investigate production issues by searching metrics, constructing PromQL queries, and analyzing results via `cx metrics` |
+| `query-logs` | Query and analyze Coralogix logs using DataPrime syntax via `cx logs` |
 | `query-spans` | Query distributed traces and analyze span latency via `cx spans` |
 | `rum` | Query and analyze Real User Monitoring data — frontend errors, web vitals, user interactions, page performance via `cx logs` |
 | `telemetry-querying` | Gateway skill for telemetry-driven investigation — decide where to look (metrics, logs, traces, RUM, APM) before querying |
 
 ## Installation
 
-Install as a Claude Code plugin:
+Install all skills:
 
 ```bash
-cc --plugin-dir /path/to/skills
+npx skills add coralogix/cx-cli
 ```
 
-Or add it permanently in your Claude Code settings.
+Install specific skills:
+
+```bash
+npx skills add coralogix/cx-cli --skill query-logs --skill dataprime
+```
+
+Install globally (available across all projects):
+
+```bash
+npx skills add coralogix/cx-cli -g
+```
+
+Install for a specific agent:
+
+```bash
+npx skills add coralogix/cx-cli -a claude-code -g -y
+```
 
 ## Requirements
 
 - [`cx` CLI](https://github.com/coralogix/cx-cli) installed and configured with a valid profile (`cx profiles add`)
-- Claude Code
+- A supported coding agent (Claude Code, Cursor, Codex, etc.)
 
 ## Usage
 
-Once installed, Claude will automatically use the relevant skill when you ask questions like:
+Once installed, your agent will automatically use the relevant skill when you ask questions like:
 
 - "Investigate why we're seeing high error rates"
 - "Check CPU usage for the api service"

--- a/skills/dataprime/SKILL.md
+++ b/skills/dataprime/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: dataprime
+description: |
+  DataPrime query language reference for Coralogix. This is a companion skill used by query-logs,
+  query-spans, and rum for detailed syntax help. It triggers when the user needs help with DataPrime
+  syntax specifically — how to write filters, groupby, aggregations, extract fields with regex,
+  use type conversions, time bucketing with roundTime, arrayContains, or asks "how do I write a
+  DataPrime query", "what operators does DataPrime support", "how does extract work in DataPrime".
+  If the user wants to actually run a query against a data source, use query-logs, query-spans, or
+  rum instead — this skill is the language reference, not the execution guide.
+version: 0.1.0
+---
+
+# DataPrime Query Language
+
+Reference for the DataPrime query language used across Coralogix to search and analyze logs, spans, and other observability data. Covers syntax, commands, operators, and functions.
+
+To actually run queries against a data source, use the **`query-logs`**, **`query-spans`**, or **`rum`** skills — they include enough inline DataPrime guidance for common cases and point here when deeper syntax help is needed.
+
+## Quick Reference
+
+A DataPrime query is a pipeline of commands separated by `|`:
+
+```dataprime
+filter $m.severity == ERROR | groupby $l.subsystemname aggregate count() as errors | orderby errors desc
+```
+
+## Full Reference
+
+See **[DataPrime Reference](references/dataprime-reference.md)** for the complete language documentation:
+
+- Query structure and pipeline syntax
+- Data prefixes (`$m`, `$l`, `$d`) and field access
+- All commands: `filter`, `groupby`, `choose`, `create`, `extract`, `orderby`, `dedupeby`, `wildfind`, `lucene`, and more
+- Operators: comparison, logical, contains (`~`), null checks
+- Aggregation functions: `count`, `sum`, `avg`, `min`, `max`, `percentile`, `distinct_count`, etc.
+- Type conversions, time bucketing (`roundTime`), multi-value matching (`arrayContains`)
+- Text extraction with regex and JSON parsing
+- Built-in documentation commands (`cx dataprime list`, `cx dataprime show`)

--- a/skills/dataprime/SKILL.md
+++ b/skills/dataprime/SKILL.md
@@ -1,21 +1,20 @@
 ---
 name: dataprime
 description: |
-  DataPrime query language reference for Coralogix. This is a companion skill used by query-logs,
-  query-spans, and rum for detailed syntax help. It triggers when the user needs help with DataPrime
-  syntax specifically — how to write filters, groupby, aggregations, extract fields with regex,
-  use type conversions, time bucketing with roundTime, arrayContains, or asks "how do I write a
-  DataPrime query", "what operators does DataPrime support", "how does extract work in DataPrime".
-  If the user wants to actually run a query against a data source, use query-logs, query-spans, or
-  rum instead — this skill is the language reference, not the execution guide.
-version: 0.1.0
+  DataPrime query language reference for Coralogix. This is a companion skill for detailed syntax
+  help. It triggers when the user needs help with DataPrime syntax specifically — how to write
+  filters, groupby, aggregations, extract fields with regex, use type conversions, time bucketing
+  with roundTime, arrayContains, or asks "how do I write a DataPrime query", "what operators does
+  DataPrime support", "how does extract work in DataPrime". This skill is the language reference,
+  not the execution guide — if the user wants to actually run a query against a specific data
+  source, use the appropriate source-specific skill instead.
 ---
 
 # DataPrime Query Language
 
 Reference for the DataPrime query language used across Coralogix to search and analyze logs, spans, and other observability data. Covers syntax, commands, operators, and functions.
 
-To actually run queries against a data source, use the **`query-logs`**, **`query-spans`**, or **`rum`** skills — they include enough inline DataPrime guidance for common cases and point here when deeper syntax help is needed.
+This skill is the language reference. To actually run queries against a specific data source, use the appropriate source-specific skill instead.
 
 ## Quick Reference
 

--- a/skills/dataprime/references/dataprime-reference.md
+++ b/skills/dataprime/references/dataprime-reference.md
@@ -1,7 +1,5 @@
 # DataPrime Query Language Reference
 
-DataPrime is the query language used to search and analyze logs, spans, and other observability data in Coralogix.
-
 ## Query Structure
 
 A DataPrime query is a pipeline of commands separated by `|`. Each command transforms the output of the previous one:

--- a/skills/query-logs/SKILL.md
+++ b/skills/query-logs/SKILL.md
@@ -159,7 +159,7 @@ If a query returns no results, change **one thing at a time**:
 
 ## References
 
-- **[DataPrime Reference](../shared/references/dataprime-reference.md)** — Full query language: commands, operators, aggregations, text extraction, type conversions
+- **`dataprime` skill** — Full query language reference: commands, operators, aggregations, text extraction, type conversions
 - **[Advanced Usage](references/advanced-usage.md)** — Investigation workflows, common query patterns, performance tips, production debugging
 
 For inline DataPrime help:

--- a/skills/query-spans/SKILL.md
+++ b/skills/query-spans/SKILL.md
@@ -179,7 +179,7 @@ If a query returns no results, change **one thing at a time**:
 
 ## References
 
-- **[DataPrime Reference](../shared/references/dataprime-reference.md)** — Full query language: commands, operators, aggregations, text extraction, type conversions
+- **`dataprime` skill** — Full query language reference: commands, operators, aggregations, text extraction, type conversions
 - **[Advanced Usage](references/advanced-usage.md)** — Investigation workflows, common query patterns, latency analysis, trace debugging
 
 For inline DataPrime help:

--- a/skills/rum/SKILL.md
+++ b/skills/rum/SKILL.md
@@ -22,7 +22,7 @@ This means:
 - **User data (`$d.cx_rum.*`)** contains all RUM-specific fields — event types, errors, sessions, web vitals, interactions, and more. See the **[RUM Fields Reference](references/rum-fields.md)** for the complete field catalog.
 - **Session replay and session flows are not available** — only individual RUM log events can be queried.
 
-For general log querying concepts and field discovery, see the **`query-logs`** skill. For DataPrime query language syntax, see the **[DataPrime Reference](../shared/references/dataprime-reference.md)**.
+For general log querying concepts and field discovery, see the **`query-logs`** skill. For DataPrime query language syntax, see the **`dataprime`** skill.
 
 ---
 
@@ -189,9 +189,8 @@ If a query returns no results, change **one thing at a time**:
 ## References
 
 - **[RUM Fields Reference](references/rum-fields.md)** — Complete field reference for all RUM contexts (session, network, web vitals, mobile, etc.)
-- **[`query-logs` skill](../query-logs/SKILL.md)** — General log querying, field discovery, investigation workflows, wildfind policy
-- **[DataPrime Reference](../shared/references/dataprime-reference.md)** — Full query language: commands, operators, aggregations, text extraction, type conversions
-- **[Logs Advanced Usage](../query-logs/references/advanced-usage.md)** — Investigation workflows, common query patterns, performance tips
+- **`query-logs` skill** — General log querying, field discovery, investigation workflows, wildfind policy
+- **`dataprime` skill** — Full query language reference: commands, operators, aggregations, text extraction, type conversions
 
 For inline DataPrime help:
 

--- a/skills/telemetry-querying/SKILL.md
+++ b/skills/telemetry-querying/SKILL.md
@@ -170,6 +170,7 @@ Do not stop after one failed attempt. Try at least two pillars before concluding
 
 ## Related Skills
 
+- **`dataprime`** — DataPrime query language reference (syntax, operators, aggregations, functions)
 - **`metrics-query`** — PromQL queries, metric discovery, instant and range queries
 - **`query-logs`** — DataPrime log queries, log field exploration
 - **`query-spans`** — Trace search, span analysis, distributed tracing


### PR DESCRIPTION
AIAG-576

## Summary
- Created standalone `dataprime` skill from shared references, making each skill self-contained and installable independently
- Updated `skills/README.md` with `npx skills add` installation instructions supporting 40+ coding agents
- Replaced cross-skill file links (`../shared/...`) with skill-name references that survive independent installation
- Added `dataprime` to `telemetry-querying` related skills