### PR TITLE
Rename coralogix-cli references to cx-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,3 @@
 # Rust-specific
 **/*.rs.bk
 *.pdb
-
-# Claire AI agent working directory
-.claire/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "cx"
 version = "0.1.0"
 edition = "2021"
 description = "Coralogix CLI — query observability data from the command line"
-repository = "https://github.com/coralogix/coralogix-cli"
+repository = "https://github.com/coralogix/cx-cli"
 license = "Apache-2.0"
 default-run = "cx"
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ The CLI for Coralogix observability. Query logs, metrics, traces, dashboards, an
 ### Shell (macOS / Linux)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/coralogix/coralogix-cli/master/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/coralogix/cx-cli/master/install.sh | sh
 ```
 
 You can pin a specific version:
 
 ```bash
-CX_VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/coralogix/coralogix-cli/master/install.sh | sh
+CX_VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/coralogix/cx-cli/master/install.sh | sh
 ```
 
 ### Homebrew (macOS / Linux)
@@ -41,7 +41,7 @@ cargo install cx
 
 ### Pre-built binaries
 
-Download the latest release for your platform from [GitHub Releases](https://github.com/coralogix/coralogix-cli/releases).
+Download the latest release for your platform from [GitHub Releases](https://github.com/coralogix/cx-cli/releases).
 
 ### Build from source
 

--- a/homebrew/cx.rb.template
+++ b/homebrew/cx.rb.template
@@ -1,27 +1,27 @@
 class Cx < Formula
   desc "Coralogix CLI — query observability data from the command line"
-  homepage "https://github.com/coralogix/coralogix-cli"
+  homepage "https://github.com/coralogix/cx-cli"
   version "@@VERSION@@"
   license "Apache-2.0"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/coralogix/coralogix-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-x86_64-apple-darwin.tar.gz"
+      url "https://github.com/coralogix/cx-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-x86_64-apple-darwin.tar.gz"
       sha256 "@@SHA256_MACOS_X86@@"
     end
     if Hardware::CPU.arm?
-      url "https://github.com/coralogix/coralogix-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-aarch64-apple-darwin.tar.gz"
+      url "https://github.com/coralogix/cx-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-aarch64-apple-darwin.tar.gz"
       sha256 "@@SHA256_MACOS_ARM@@"
     end
   end
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/coralogix/coralogix-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-x86_64-unknown-linux-musl.tar.gz"
+      url "https://github.com/coralogix/cx-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-x86_64-unknown-linux-musl.tar.gz"
       sha256 "@@SHA256_LINUX_X86@@"
     end
     if Hardware::CPU.arm?
-      url "https://github.com/coralogix/coralogix-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-aarch64-unknown-linux-musl.tar.gz"
+      url "https://github.com/coralogix/cx-cli/releases/download/v@@VERSION@@/cx-@@VERSION@@-aarch64-unknown-linux-musl.tar.gz"
       sha256 "@@SHA256_LINUX_ARM@@"
     end
   end

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-REPO="coralogix/coralogix-cli"
+REPO="coralogix/cx-cli"
 BINARY_NAME="cx"
 
 main() {

--- a/skills/README.md
+++ b/skills/README.md
@@ -1,6 +1,6 @@
 # cx Skills
 
-A collection of agent skills for the [`cx` Coralogix CLI](https://github.com/coralogix/coralogix-cli). Install these skills to give your coding agent deep knowledge of how to investigate observability data using the CLI.
+A collection of agent skills for the [`cx` Coralogix CLI](https://github.com/coralogix/cx-cli). Install these skills to give your coding agent deep knowledge of how to investigate observability data using the CLI.
 
 Supports **Claude Code**, **Cursor**, **Codex**, **OpenCode**, and [40+ more agents](https://github.com/vercel-labs/skills#supported-agents).
 
@@ -21,30 +21,30 @@ Supports **Claude Code**, **Cursor**, **Codex**, **OpenCode**, and [40+ more age
 Install all skills:
 
 ```bash
-npx skills add coralogix/coralogix-cli
+npx skills add coralogix/cx-cli
 ```
 
 Install specific skills:
 
 ```bash
-npx skills add coralogix/coralogix-cli --skill query-logs --skill dataprime
+npx skills add coralogix/cx-cli --skill query-logs --skill dataprime
 ```
 
 Install globally (available across all projects):
 
 ```bash
-npx skills add coralogix/coralogix-cli -g
+npx skills add coralogix/cx-cli -g
 ```
 
 Install for a specific agent:
 
 ```bash
-npx skills add coralogix/coralogix-cli -a claude-code -g -y
+npx skills add coralogix/cx-cli -a claude-code -g -y
 ```
 
 ## Requirements
 
-- [`cx` CLI](https://github.com/coralogix/coralogix-cli) installed and configured with a valid profile (`cx profiles add`)
+- [`cx` CLI](https://github.com/coralogix/cx-cli) installed and configured with a valid profile (`cx profiles add`)
 - A supported coding agent (Claude Code, Cursor, Codex, etc.)
 
 ## Usage


### PR DESCRIPTION
AIAG-597

## Summary
- Updated all references from `coralogix-cli` to `cx-cli` to match the renamed GitHub repository
- Affected files: `Cargo.toml`, `README.md`, `install.sh`, `homebrew/cx.rb.template`, `skills/README.md`
- No code logic changes — only URLs and identifiers updated

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/coralogix/codesmith/cx-cli/pr/25"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR — just tag <code>@codesmith</code> or enable autofix.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->