### PR TITLE
Add development workflow skills for agent contributors

### DIFF
--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: add-command
+description: Use this skill when the user asks to "add a command", "implement cx <something>", "new subcommand", "new CLI command", "add a new cx command", "create a command", "add subcommand", "implement a new command", "build a cx command", "wire up a new command", "extend the CLI", "add an API to cx", "new cx feature", "integrate a Coralogix API", or wants to add new functionality to the cx CLI. Use this even when the user describes a feature that implies a new command without saying "command" explicitly.
+version: 0.1.0
+---
+
+# Add a CLI Command
+
+End-to-end workflow for adding a new command to `cx`. Every command falls into one of two archetypes — determine which one first, then follow the corresponding steps.
+
+`docs/adding-a-command.md` has copy-pasteable code templates for every step below. Read it alongside this workflow.
+
+## Step 0: Understand What You're Building
+
+Before writing any code, get clarity on the domain:
+
+1. **What Coralogix API are you wrapping?** Find the API docs or example responses. Understand the data model — what entities exist, what fields they have, what operations are supported.
+2. **What should the user be able to do?** List the subcommands (e.g., `list`, `get`, `create`) and what flags make sense.
+3. **Which archetype fits?**
+
+| Archetype | When to use | Reference implementation |
+|-----------|------------|--------------------------|
+| **A: DataPrime-based** | Querying logs, spans, or any DataPrime source | `src/commands/logs.rs` |
+| **B: REST-based** | Wrapping a Coralogix REST API (most new commands) | `src/api/alerts.rs` + `src/commands/alerts.rs` |
+
+DataPrime commands delegate to a shared pipeline and require minimal code (~130 lines). REST commands build the full pipeline (API client, fan-out, merge, render) — more code but more control.
+
+**Important:** All API integrations must use REST (HTTP). The CLI is HTTP-only by design — do not use gRPC.
+
+## Step 1: Read Reference Implementations
+
+Before writing any code, read these files to internalize the existing patterns. This step is critical — agents that read existing code first produce implementations that are consistent with the codebase rather than inventing new patterns.
+
+**Always read:**
+- `src/main.rs` — study the `Commands` enum to see how variants are structured, and the `match cli.command` dispatch block to see where your new variant fits. Note which commands early-exit (no credentials needed) vs which go through the full config resolution flow.
+- `src/commands/mod.rs` — see existing module registrations so you add yours in the right place
+- `docs/adding-a-command.md` — full guide with code templates for both archetypes
+
+**DataPrime archetype — also read:**
+- `src/commands/logs.rs` — a complete DataPrime command; notice how little code is needed because the shared pipeline does the heavy lifting
+- `src/commands/dataprime.rs` — the shared pipeline your command will delegate to; understand the `run_query()` signature and what it handles (fan-out, merge, spilling, agents output)
+
+**REST archetype — also read:**
+- `src/api/alerts.rs` — see how response types are structured, how the API struct borrows `&CxClient`, how deserialization tests are written
+- `src/api/mod.rs` — module registrations
+- `src/commands/alerts.rs` — see the fan-out/merge/render pattern, how dual row structs work, and how all three output formats are handled
+
+## Step 2: Create API Layer (REST Only)
+
+> Skip this step for DataPrime commands — they use the shared DataPrime pipeline.
+
+Create `src/api/<domain>.rs`. See `docs/adding-a-command.md` § "Archetype B, Step 1" for the full template.
+
+Key conventions and why they matter:
+
+- **`#[serde(rename_all = "camelCase")]`** on response types — Coralogix APIs use camelCase JSON keys
+- **`#[serde(default)]` on `Vec` fields** — the API sometimes omits empty arrays entirely rather than sending `[]`, so this prevents deserialization failures
+- **`Option<T>` for fields that may be absent** — be defensive, APIs evolve and fields vary across tiers
+- **API struct borrows `&CxClient`** (don't own it) — the client is shared across the fan-out and must outlive individual API calls
+- **`const BASE_PATH`** for the endpoint prefix — keeps URLs DRY
+- **Deserialization tests are mandatory** — test both happy-path and edge cases (empty lists, missing optional fields) since these are the cases that break in production
+
+Register the module in `src/api/mod.rs`.
+
+## Step 3: Create Command Module
+
+Create `src/commands/<domain>.rs`. See `docs/adding-a-command.md` for full templates of both archetypes.
+
+### DataPrime archetype
+
+Provide two things:
+1. A text renderer: `pub fn render_<domain>_text(merged: &MergedResults) -> Result<()>` — called only for `OutputFormat::Text`; JSON and Agents output are handled by the shared pipeline
+2. A thin `run()` wrapper that calls `super::dataprime::run_query()` with your DataPrime source name
+
+### REST archetype
+
+Build the full fan-out/merge/render pipeline. Key patterns to understand:
+
+- **Dual row structs** — two `Tabled` structs are needed (one with Profile column, one without) because `tabled` derives columns from struct fields and can't conditionally show/hide a column at runtime
+- **`let include_profile = targets.len() > 1;`** — this single boolean controls all multi-profile behavior (Profile column in text, `"profile"` key in JSON)
+- **Fan-out errors are non-fatal** — print to stderr and continue, because one misconfigured profile shouldn't block results from others
+- **Status messages go to stderr** (`eprintln!`) — stdout is reserved for data so piped output isn't polluted
+- **All three output formats must be handled** — Text (via `Table::new`), Json (via `serde_json::to_string_pretty`), Agents (via `toon_encode`, optimized for AI consumption)
+
+Register the module in `src/commands/mod.rs`.
+
+## Step 4: Wire into CLI
+
+In `src/main.rs`, add three things. See `docs/adding-a-command.md` § "CLI Wiring" for templates.
+
+1. **`Commands` enum variant** — DataPrime commands use inline args; REST commands reference a subcommand enum
+2. **Subcommand enum** (REST only) — defines `List`, `Get`, etc.
+3. **Dispatch match arm** — inside the `match cli.command` block. Most commands go through the full config resolution flow; only commands that don't need credentials (like `profiles`, `cleanup`) early-exit.
+
+## Step 5: Add Tests
+
+- **API deserialization tests** (REST, already done in Step 2) — realistic JSON fixtures, edge cases
+- **Data transformation tests** — if you have non-trivial mapping logic in the command module
+
+## Step 6: Create User-Facing Skill
+
+Every command needs a corresponding skill in `skills/` so AI agents know how to use it. See `docs/adding-a-skill.md` for the full guide and a copy-pasteable template.
+
+Key requirements:
+- Frontmatter `description` with 10+ trigger phrases (this is how agents decide when to activate)
+- CLI Commands table, workflow steps, key principles, and examples
+- Reference files in `skills/<domain>/references/` for dense material (>100 lines)
+- Update `skills/README.md` with the new skill
+
+## Step 7: Verify
+
+Run `cargo build`, `cargo test`, `cargo clippy`, and `cargo fmt --check`. Fix any issues before committing.
+
+If you have credentials configured, smoke test all three output formats (`text`, `json`, `agents`) and multi-profile (`-p profile1 -p profile2`).
+
+See `docs/adding-a-command.md` § "PR Checklist" for the full checklist to include in your PR description.

--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -99,13 +99,7 @@ In `src/main.rs`, add three things. See `docs/adding-a-command.md` § "CLI Wirin
 
 ## Step 6: Create User-Facing Skill
 
-Every command needs a corresponding skill in `skills/` so AI agents know how to use it. See `docs/adding-a-skill.md` for the full guide and a copy-pasteable template.
-
-Key requirements:
-- Frontmatter `description` with 10+ trigger phrases (this is how agents decide when to activate)
-- CLI Commands table, workflow steps, key principles, and examples
-- Reference files in `skills/<domain>/references/` for dense material (>100 lines)
-- Update `skills/README.md` with the new skill
+Every command needs a corresponding skill in `skills/` so AI agents know how to use it. Use the **add-skill** workflow to create it — it walks through the full process including reading reference implementations, writing effective trigger descriptions, and verification.
 
 ## Step 7: Verify
 

--- a/.claude/skills/add-skill/SKILL.md
+++ b/.claude/skills/add-skill/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: add-skill
+description: Use this skill when the user asks to "add a skill", "create a skill", "new skill", "write a skill for", "skill for cx <something>", "add a user-facing skill", "create a SKILL.md", "teach an agent how to use", "agent skill for", "document a command as a skill", "make a skill", "add skill to skills/", "create agent instructions for", "build a skill", or wants to create a new user-facing skill in the skills/ directory that teaches AI agents how to use a cx CLI command. Use this even when the user is following the add-command workflow and reaches the skill creation step.
+version: 0.1.0
+---
+
+# Add a User-Facing Skill
+
+End-to-end workflow for creating a skill in `skills/` that teaches AI agents how to use a cx CLI command. This skill is often invoked from `add-command` Step 6, but can also be used standalone when documenting an existing command.
+
+`docs/adding-a-skill.md` has the full reference guide and a copy-pasteable template. Read it alongside this workflow.
+
+## Step 0: Understand the Domain
+
+Before writing anything, answer these questions:
+
+1. **What cx command are you documenting?** Identify the command and all its subcommands (e.g., `cx alerts list`, `cx alerts get`, `cx alerts create`).
+2. **What can the user do with it?** List the key operations, flags, and output formats supported.
+3. **Who is the audience?** Skills are consumed by AI agents, not humans directly. Write instructions an agent can follow step-by-step to accomplish a user's goal.
+4. **Is there dense reference material?** Schemas, enum catalogs, field references, or language syntax exceeding ~100 lines belong in a separate `references/` file.
+
+## Step 1: Read Existing Skills
+
+Before writing any skill, read existing ones to internalize the project's patterns. Agents that study existing skills first produce consistent, high-quality results rather than inventing new formats.
+
+**Always read:**
+- `docs/adding-a-skill.md` — full guide with directory structure, frontmatter conventions, reference file rules, and a copy-pasteable template
+- `skills/README.md` — the public catalog you'll update in Step 4
+
+**Study at least two existing skills:**
+
+| Skill | Why study it |
+|-------|-------------|
+| `skills/cx-alerts/SKILL.md` | REST-based command with rich examples, JSON payloads, investigation workflow, and reference files |
+| `skills/metrics-query/SKILL.md` | Investigation-oriented, multi-step workflow with retry logic and common patterns |
+| `skills/dataprime/SKILL.md` | Minimal body that delegates to a large reference file — good model for reference-heavy domains |
+| `skills/rum/SKILL.md` | Builds on other skills (references query-logs and dataprime) — good model for cross-skill integration |
+| `skills/telemetry-querying/SKILL.md` | Gateway/routing skill with no CLI commands of its own — delegates to other skills |
+
+Pick the two closest to what you're building and read them completely.
+
+## Step 2: Create Directory and Write SKILL.md
+
+Create `skills/<domain-name>/SKILL.md`. Use the directory structure, frontmatter format, and copy-pasteable template from `docs/adding-a-skill.md` § "Directory Structure" through "Complete Template".
+
+### Writing effective trigger descriptions
+
+The `description` frontmatter field is the primary trigger mechanism — agents use it to decide when to activate a skill. This is the single most important line in the file. Write at least **10 trigger phrases** covering:
+- Explicit command names (`"list alerts"`, `"get alert by ID"`)
+- User intents (`"investigate alert failures"`, `"debug noisy alerts"`)
+- Synonyms and variations (`"check"`, `"find"`, `"search"`, `"analyze"`)
+- Domain jargon (`"SLO breach"`, `"error budget"`)
+
+### Body structure
+
+Follow this order (see `docs/adding-a-skill.md` § "Complete Template" for a starting point):
+
+1. **Title and intro** — one sentence explaining what the skill covers and which `cx` commands it uses
+2. **CLI Commands table** — `| Command | Purpose | Key flags |` for every subcommand. Include `-o json`/`-o agents` and `-p <profile>` notes.
+3. **Workflow / Investigation steps** — numbered steps an agent should follow. Start with discovery, end with verification.
+4. **Key Principles** — 4-6 bullet points: use `-o json` with `jq`, multi-profile behavior, always verify, etc.
+5. **Additional Resources** — links to `references/` files and related skills
+
+### Style guidelines
+
+- Write for an AI agent — be explicit about what to run and in what order
+- Use code blocks for every CLI invocation
+- Include realistic examples with actual flag values, not placeholders
+- Show `jq` filtering examples when the command supports `-o json`
+- Keep SKILL.md under ~200 lines; move dense material to `references/`
+
+## Step 3: Add Reference Files and Update README
+
+Follow `docs/adding-a-skill.md` § "Reference Files" for when and how to create `references/` files, and § "Updating skills/README.md" for adding the skill to the public catalog.
+
+## Step 4: Verify
+
+1. **Frontmatter** — `name` matches directory, `description` has 10+ trigger phrases, `version` is `0.1.0`
+2. **Body completeness** — has CLI Commands table, workflow steps, key principles, and additional resources (if references exist)
+3. **Reference links** — any `references/` paths in SKILL.md point to files that actually exist
+4. **README updated** — `skills/README.md` has the new row
+5. **No bloat** — SKILL.md doesn't duplicate >100 lines of material that belongs in `references/`
+6. **Agent readability** — would an AI agent know exactly what to do after reading this skill? If not, add missing steps or examples
+
+For advanced trigger optimization, use the `/skill-creator` skill to run eval-driven description testing and iterate on your trigger phrases.
+
+Use the PR checklist from `docs/adding-a-skill.md` § "PR Checklist" in your PR description.

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: run-tests
+description: Use this skill when the user asks to "run tests", "test this", "check if tests pass", "cargo test", "run clippy", "lint this", "check formatting", "cargo fmt", "CI checks", "verify changes", "does this pass tests", "run the full check", "pre-commit check", or wants to verify that code changes are correct. Use this even when the user says something like "make sure this works" or "check for issues" in the context of code changes.
+version: 0.1.0
+---
+
+# Run Tests & Verify
+
+How to run tests, lint, and verify changes in the `cx` CLI. This skill covers running only — for writing new tests, see the `add-command` skill.
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `cargo test` | Run all unit + integration tests |
+| `cargo test <name>` | Run tests matching a name substring |
+| `cargo test -- --ignored` | Run integration tests (filesystem-dependent, skipped by default) |
+| `cargo fmt --check` | Check formatting (no changes) |
+| `cargo fmt` | Auto-fix formatting |
+| `cargo clippy --locked -- -D warnings` | Lint with warnings-as-errors |
+| `cargo build` | Verify compilation |
+
+## Full CI Check
+
+This is the exact sequence CI runs on every PR. Run it before committing or creating a PR:
+
+```bash
+cargo fmt --check && cargo clippy --locked -- -D warnings && cargo test --locked
+```
+
+The `--locked` flag ensures the lockfile is respected — this matches `.github/workflows/test.yml` and `lint.yml` exactly. CI runs tests on Ubuntu, macOS, and Windows.
+
+## What to Run After a Change
+
+Pick the right level of verification based on what changed:
+
+- **Any `.rs` file** — `cargo test` + `cargo clippy --locked -- -D warnings`
+- **Formatting only** — `cargo fmt --check` (or `cargo fmt` to auto-fix)
+- **`Cargo.toml`** — full CI check (dependency changes affect everything)
+- **API types (`src/api/`)** — run that module's tests first (`cargo test alerts`, `cargo test dataprime`), then the full suite
+- **Test files only** — `cargo test <relevant_test_name>`
+
+## Running Specific Tests
+
+Target tests efficiently instead of running the entire suite:
+
+- `cargo test alerts` — all tests with "alerts" in the name
+- `cargo test --test dataprime_input` — only the `tests/dataprime_input.rs` integration test file
+- `cargo test --test dataprime_output` — only the `tests/dataprime_output.rs` integration test file
+- `cargo test config::tests` — only the tests in the `config` module
+- `cargo test metrics::tests` — only metrics formatting tests
+
+## Interpreting Failures
+
+**Clippy warnings** — treated as errors via `-D warnings`. Fix every warning before committing. Common ones: unused variables, unnecessary clones, missing error handling.
+
+**Format failures** — run `cargo fmt` to auto-fix. These never need manual intervention.
+
+**Deserialization test failures** — usually means struct field names don't match JSON keys. Check that `#[serde(rename_all = "camelCase")]` is on response types and that `#[serde(default)]` is on `Vec` fields (the API sometimes omits empty arrays).
+
+**Compilation errors in tests** — likely caused by changing a public function signature. Check callers in both `src/` and `tests/` directories.
+
+**Integration test failures (`--ignored`)** — these depend on filesystem state (`~/.cx/` config directory). They may fail if the local environment isn't set up. This is expected in CI where no config exists.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,4 +61,49 @@ Config lives in `~/.cx/`. Environment variables `CX_PROFILE`, `CX_API_KEY`, `CX_
 
 ### Documentation
 
-`docs/` contains detailed reference documentation: [configuration](docs/configuration.md), [agents output format](docs/agents-output.md), [multi-profile fan-out](docs/multi-profile.md), [time syntax](docs/time-syntax.md), and [development guide](docs/development.md).
+**Contributor guides:** [architecture](docs/architecture.md), [adding a command](docs/adding-a-command.md), [adding a skill](docs/adding-a-skill.md), [development](docs/development.md)
+
+**Reference docs:** [configuration](docs/configuration.md), [agents output format](docs/agents-output.md), [multi-profile fan-out](docs/multi-profile.md), [time syntax](docs/time-syntax.md)
+
+## Contributing
+
+### Development Skills
+
+The `.claude/skills/` directory contains workflow skills for agents developing cx itself:
+
+| Skill | Trigger | Purpose |
+|-------|---------|---------|
+| `/add-command` | "add a command", "implement cx ..." | End-to-end workflow for adding a new CLI command |
+| `/add-skill` | "add a skill", "create a skill" | End-to-end workflow for creating a user-facing skill |
+| `/run-tests` | "run tests", "cargo test", "check CI" | Run tests, clippy, fmt — full verification |
+| `/create-pr` | "create a PR", "open a pull request" | Create GitHub PR with auto-generated summary |
+
+### Skill Coverage
+
+Which CLI commands have user-facing skills in `skills/`:
+
+| CLI Command | User-Facing Skill | Status |
+|-------------|-------------------|--------|
+| `cx logs` | `query-logs` | Covered |
+| `cx spans` | `query-spans` | Covered |
+| `cx metrics` | `metrics-query` | Covered |
+| `cx alerts` | `cx-alerts` | Covered |
+| `cx dataprime` | `dataprime` | Covered |
+| `cx logs` (RUM) | `rum` | Covered |
+| _(cross-signal)_ | `telemetry-querying` | Gateway skill |
+| `cx dashboards` | — | Not covered |
+| `cx search-fields` | — | Not covered |
+| `cx profiles` | — | Not covered |
+| `cx cleanup` | — | Not covered |
+
+### Testing Expectations
+
+All agent-authored code must pass before committing:
+
+- **`cargo fmt`** — all code must be formatted
+- **`cargo clippy`** — no warnings allowed
+- **`cargo test`** — all existing tests must pass
+- **New commands** — add at least one unit test for output formatting
+- **New skills** — verify skill triggers and reference file completeness
+
+Use `/run-tests` to run the full check before committing.


### PR DESCRIPTION
AIAP-1334

## Summary
- Add three `.claude/skills/` development workflow skills: `add-command`, `add-skill`, and `run-tests` — end-to-end guides for agents developing cx itself
- Update `CLAUDE.md` with a Contributing section documenting development skills, user-facing skill coverage table, and testing expectations