### PR TITLE
Add test utilities and mock API harness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +100,16 @@ name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "atomic-waker"
@@ -388,6 +407,7 @@ dependencies = [
  "toml",
  "toon-format",
  "url",
+ "wiremock",
 ]
 
 [[package]]
@@ -410,6 +430,24 @@ dependencies = [
  "dbus",
  "zeroize",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "derive_more"
@@ -663,6 +701,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -682,6 +739,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -723,6 +786,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,9 +816,11 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1087,6 +1158,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1190,6 +1267,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1400,6 +1487,35 @@ dependencies = [
  "libredox",
  "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -1953,6 +2069,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2637,6 +2766,29 @@ name = "winnow"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,6 +76,9 @@ keyring = { version = "3", features = ["windows-native"] }
 [target.'cfg(all(target_os = "linux", not(target_env = "musl")))'.dependencies]
 keyring = { version = "3", features = ["sync-secret-service"] }
 
+[dev-dependencies]
+wiremock = "0.6"
+
 [profile.release]
 strip = true
 lto = true

--- a/tests/alerts.rs
+++ b/tests/alerts.rs
@@ -1,0 +1,190 @@
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use cx::commands::alerts::{run_disable, run_enable, run_get, run_list};
+use cx::config::OutputFormat;
+
+#[tokio::test]
+async fn list_alerts_returns_items_from_mock() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "alertDefs": [
+            {
+                "id": "alert-001",
+                "name": "High Error Rate",
+                "enabled": true,
+                "priority": "ALERT_DEF_PRIORITY_P2",
+                "type": "ALERT_DEF_TYPE_LOGS_THRESHOLD",
+                "status": "OK",
+                "updatedTime": "2024-06-01T12:00:00Z"
+            },
+            {
+                "id": "alert-002",
+                "name": "CPU Spike",
+                "enabled": false,
+                "priority": "ALERT_DEF_PRIORITY_P1",
+                "type": "ALERT_DEF_TYPE_METRIC_THRESHOLD",
+                "status": "ALERTING"
+            }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_list(&targets, None, OutputFormat::Json)
+        .await
+        .expect("run_list should succeed");
+}
+
+#[tokio::test]
+async fn list_alerts_with_name_filter() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "alertDefs": [
+            { "id": "alert-001", "name": "High Error Rate" },
+            { "id": "alert-002", "name": "CPU Spike" }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    // Filter should not error even if it filters everything out
+    run_list(&targets, Some("cpu"), OutputFormat::Json)
+        .await
+        .expect("run_list with filter should succeed");
+}
+
+#[tokio::test]
+async fn get_alert_by_id() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "alertDef": {
+            "id": "alert-001",
+            "name": "High Error Rate",
+            "enabled": true,
+            "priority": "ALERT_DEF_PRIORITY_P2",
+            "type": "ALERT_DEF_TYPE_LOGS_THRESHOLD",
+            "status": "OK"
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-001",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_get(&targets, "alert-001", OutputFormat::Json)
+        .await
+        .expect("run_get should succeed");
+}
+
+#[tokio::test]
+async fn get_alert_falls_back_to_version_id_on_404() {
+    let server = MockServer::start().await;
+
+    // Primary endpoint returns 404
+    Mock::given(method("GET"))
+        .and(path(
+            "/mgmt/openapi/latest/alerts/alerts-general/v3/ver-123",
+        ))
+        .respond_with(ResponseTemplate::new(404).set_body_json(json!({"message": "not found"})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    // Fallback version-id endpoint succeeds
+    let body = json!({
+        "alertDef": {
+            "id": "alert-real-id",
+            "name": "Found by version"
+        }
+    });
+    Mock::given(method("GET"))
+        .and(path(
+            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-version-id/ver-123",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_get(&targets, "ver-123", OutputFormat::Json)
+        .await
+        .expect("run_get should fall back to version ID");
+}
+
+#[tokio::test]
+async fn enable_alert() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-001:setActive",
+        ))
+        .and(query_param("active", "true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_enable(&targets, "alert-001")
+        .await
+        .expect("run_enable should succeed");
+}
+
+#[tokio::test]
+async fn disable_alert() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-001:setActive",
+        ))
+        .and(query_param("active", "false"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_disable(&targets, "alert-001")
+        .await
+        .expect("run_disable should succeed");
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,0 +1,23 @@
+use std::sync::Arc;
+
+use cx::config::ResolvedConfig;
+use cx::execution::ExecutionTarget;
+
+/// Build an [`ExecutionTarget`] that sends all HTTP traffic to `base_url`.
+///
+/// Intended for use with a [`wiremock::MockServer`] — pass `mock_server.uri()`
+/// as `base_url`.
+pub fn test_target(profile_name: &str, base_url: &str) -> Arc<ExecutionTarget> {
+    // reqwest with rustls-no-provider needs an explicit crypto provider.
+    // `.ok()` ignores the error when another test already installed it.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+
+    let cfg = ResolvedConfig {
+        profile_name: profile_name.to_string(),
+        api_key: "test-api-key-00000".to_string(),
+        endpoint: base_url.to_string(),
+    };
+    Arc::new(ExecutionTarget::new(cfg).expect("test_target: failed to build ExecutionTarget"))
+}

--- a/tests/dashboard_catalog.rs
+++ b/tests/dashboard_catalog.rs
@@ -1,0 +1,115 @@
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use cx::api::dashboards::DashboardsApi;
+use cx::commands::dashboards::run_catalog;
+use cx::config::OutputFormat;
+
+/// Verify that `DashboardsApi::catalog()` correctly deserializes a mocked
+/// response from the dashboard catalog endpoint.
+#[tokio::test]
+async fn catalog_returns_items_from_mock() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "items": [
+            {
+                "id": "dash-001",
+                "name": "Production Overview",
+                "description": "Main production dashboard",
+                "slugName": "production-overview",
+                "createTime": "2024-01-01T00:00:00Z",
+                "updateTime": "2024-06-15T12:00:00Z",
+                "isDefault": false,
+                "isPinned": true,
+                "isLocked": false,
+                "folder": {
+                    "id": "folder-01",
+                    "name": "Operations",
+                    "parentId": null
+                }
+            },
+            {
+                "id": "dash-002",
+                "name": "Error Rates",
+                "description": null,
+                "slugName": "error-rates",
+                "createTime": "2024-03-10T08:00:00Z",
+                "updateTime": "2024-06-20T09:30:00Z",
+                "isDefault": false,
+                "isPinned": false,
+                "isLocked": true,
+                "folder": null
+            }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/mgmt/openapi/latest/dashboards/dashboards/v1/catalog",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let api = DashboardsApi::new(&target.client);
+    let response = api.catalog().await.expect("catalog() should succeed");
+
+    assert_eq!(response.items.len(), 2);
+    assert_eq!(response.items[0].id.as_deref(), Some("dash-001"));
+    assert_eq!(
+        response.items[0].name.as_deref(),
+        Some("Production Overview")
+    );
+    assert_eq!(response.items[0].is_pinned, Some(true));
+    assert_eq!(
+        response.items[0]
+            .folder
+            .as_ref()
+            .and_then(|f| f.name.as_deref()),
+        Some("Operations")
+    );
+    assert_eq!(response.items[1].id.as_deref(), Some("dash-002"));
+    assert_eq!(response.items[1].is_locked, Some(true));
+    assert!(response.items[1].folder.is_none());
+}
+
+/// Verify that `run_catalog` (the full command runner) succeeds with JSON output
+/// when backed by a mock server. This exercises the fan-out + rendering path.
+#[tokio::test]
+async fn run_catalog_json_output_succeeds() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "items": [
+            {
+                "id": "dash-100",
+                "name": "Test Dashboard",
+                "slugName": "test-dash",
+                "isPinned": false,
+                "isLocked": false
+            }
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path(
+            "/mgmt/openapi/latest/dashboards/dashboards/v1/catalog",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("mock-profile", &server.uri());
+    let targets = vec![target];
+
+    run_catalog(&targets, OutputFormat::Json)
+        .await
+        .expect("run_catalog with JSON output should succeed");
+}

--- a/tests/dataprime_query.rs
+++ b/tests/dataprime_query.rs
@@ -1,0 +1,234 @@
+mod common;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use cx::commands::dataprime::run_query;
+use cx::commands::logs;
+use cx::commands::spans;
+use cx::config::OutputFormat;
+use cx::Tier;
+
+/// Build a realistic NDJSON response string for the dataprime query endpoint.
+fn make_ndjson_response(rows: &[&str]) -> String {
+    let mut lines = vec![r#"{"queryId":{"queryId":"test-query-id"}}"#.to_string()];
+    if !rows.is_empty() {
+        let results: Vec<String> = rows.iter().map(|r| r.to_string()).collect();
+        lines.push(format!(
+            r#"{{"result":{{"results":[{}]}}}}"#,
+            results.join(",")
+        ));
+    }
+    lines.join("\n")
+}
+
+#[tokio::test]
+async fn dataprime_query_with_log_results() {
+    let server = MockServer::start().await;
+
+    let ndjson = make_ndjson_response(&[
+        r#"{"metadata":[{"key":"severity","value":"5"},{"key":"timestamp","value":"2024-06-22T10:00:00Z"}],"labels":[{"key":"applicationname","value":"api"}],"userData":"{\"message\":\"connection timeout\"}"}"#,
+        r#"{"metadata":[{"key":"severity","value":"3"},{"key":"timestamp","value":"2024-06-22T10:00:01Z"}],"labels":[{"key":"applicationname","value":"api"}],"userData":"{\"message\":\"request completed\"}"}"#,
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_query(
+        &targets,
+        "source logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Tier::FrequentSearch,
+        OutputFormat::Json,
+        None,
+        "/tmp",
+        None,
+    )
+    .await
+    .expect("dataprime query should succeed");
+}
+
+#[tokio::test]
+async fn dataprime_aggregate_query() {
+    let server = MockServer::start().await;
+
+    let ndjson = make_ndjson_response(&[
+        r#"{"metadata":[],"labels":[],"userData":"{\"region\":\"us1\",\"total_logs\":16}"}"#,
+        r#"{"metadata":[],"labels":[],"userData":"{\"region\":\"us2\",\"total_logs\":20}"}"#,
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_query(
+        &targets,
+        "source logs | groupby $l.region aggregate count() as total_logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Tier::FrequentSearch,
+        OutputFormat::Json,
+        None,
+        "/tmp",
+        None,
+    )
+    .await
+    .expect("aggregate query should succeed");
+}
+
+#[tokio::test]
+async fn dataprime_query_with_warning() {
+    let server = MockServer::start().await;
+
+    let ndjson = [
+        r#"{"queryId":{"queryId":"test-query-id"}}"#,
+        r#"{"result":{"results":[{"metadata":[],"labels":[],"userData":"{}"}]}}"#,
+        r#"{"warning":{"compileWarning":{"warningMessage":"query scanned too many rows"}}}"#,
+    ]
+    .join("\n");
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_query(
+        &targets,
+        "source logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Tier::FrequentSearch,
+        OutputFormat::Json,
+        None,
+        "/tmp",
+        None,
+    )
+    .await
+    .expect("query with warning should succeed");
+}
+
+#[tokio::test]
+async fn logs_command_delegates_to_dataprime() {
+    let server = MockServer::start().await;
+
+    let ndjson = make_ndjson_response(&[
+        r#"{"metadata":[{"key":"severity","value":"3"},{"key":"timestamp","value":"2024-06-22T10:00:00Z"}],"labels":[],"userData":"{\"message\":\"hello world\"}"}"#,
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    logs::run(
+        &targets,
+        "source logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Tier::FrequentSearch,
+        OutputFormat::Json,
+        None,
+        "/tmp",
+    )
+    .await
+    .expect("logs::run should succeed");
+}
+
+#[tokio::test]
+async fn spans_command_delegates_to_dataprime() {
+    let server = MockServer::start().await;
+
+    let ndjson = make_ndjson_response(&[
+        r#"{"metadata":[{"key":"duration","value":"5000"}],"labels":[{"key":"operationName","value":"GET /api/health"},{"key":"serviceName","value":"gateway"}],"userData":"{\"traceID\":\"abc123\",\"spanID\":\"span-1\"}"}"#,
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    spans::run(
+        &targets,
+        "source spans",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Tier::FrequentSearch,
+        OutputFormat::Json,
+        None,
+        "/tmp",
+    )
+    .await
+    .expect("spans::run should succeed");
+}
+
+#[tokio::test]
+async fn multi_profile_fan_out_tags_rows() {
+    let server = MockServer::start().await;
+
+    let ndjson = make_ndjson_response(&[
+        r#"{"metadata":[{"key":"severity","value":"3"}],"labels":[],"userData":"{\"message\":\"from profile\"}"}"#,
+    ]);
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .mount(&server)
+        .await;
+
+    let target1 = common::test_target("prod", &server.uri());
+    let target2 = common::test_target("staging", &server.uri());
+    let targets = vec![target1, target2];
+
+    run_query(
+        &targets,
+        "source logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Tier::FrequentSearch,
+        OutputFormat::Json,
+        None,
+        "/tmp",
+        None,
+    )
+    .await
+    .expect("multi-profile fan-out should succeed");
+}

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -1,0 +1,175 @@
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use cx::commands::metrics::{run_get_labels, run_query, run_query_range, run_search};
+use cx::config::OutputFormat;
+
+#[tokio::test]
+async fn instant_query_returns_samples() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "status": "success",
+        "data": {
+            "resultType": "vector",
+            "result": [
+                {
+                    "metric": { "__name__": "up", "instance": "localhost:9090" },
+                    "value": [1719000000, "1"]
+                },
+                {
+                    "metric": { "__name__": "up", "instance": "localhost:9091" },
+                    "value": [1719000000, "0"]
+                }
+            ]
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/metrics/api/v1/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_query(&targets, "up", None, OutputFormat::Json)
+        .await
+        .expect("run_query (instant) should succeed");
+}
+
+#[tokio::test]
+async fn range_query_returns_series() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "status": "success",
+        "data": {
+            "resultType": "matrix",
+            "result": [
+                {
+                    "metric": { "__name__": "http_requests_total", "method": "GET" },
+                    "values": [
+                        [1719000000, "100"],
+                        [1719000060, "105"],
+                        [1719000120, "112"]
+                    ]
+                }
+            ]
+        }
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/metrics/api/v1/query_range"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_query_range(
+        &targets,
+        "http_requests_total",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T01:00:00Z",
+        "60s",
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_query_range should succeed");
+}
+
+#[tokio::test]
+async fn search_by_name_pattern() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "status": "success",
+        "data": [
+            "http_requests_total",
+            "http_request_duration_seconds",
+            "http_response_size_bytes"
+        ]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/metrics/api/v1/label/__name__/values"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_search(&targets, Some("http_*"), None, OutputFormat::Json)
+        .await
+        .expect("run_search by name should succeed");
+}
+
+#[tokio::test]
+async fn search_by_description() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "results": [
+            {
+                "metric_name": "http_requests_total",
+                "description": "Total number of HTTP requests",
+                "metric_type": "counter",
+                "metric_suffixes": ["_total"],
+                "similarity_score": 0.95
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/semantic-search/metrics"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_search(
+        &targets,
+        None,
+        Some("total HTTP requests"),
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_search by description should succeed");
+}
+
+#[tokio::test]
+async fn get_labels_for_metric() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "status": "success",
+        "data": ["__name__", "instance", "job", "method", "status"]
+    });
+
+    Mock::given(method("GET"))
+        .and(path("/metrics/api/v1/labels"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_get_labels(&targets, "http_requests_total", OutputFormat::Json)
+        .await
+        .expect("run_get_labels should succeed");
+}

--- a/tests/search_fields.rs
+++ b/tests/search_fields.rs
@@ -1,0 +1,104 @@
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use cx::commands::search_fields;
+use cx::config::OutputFormat;
+
+#[tokio::test]
+async fn semantic_field_search_returns_results() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "results": [
+            {
+                "path_array": ["$d", "http", "status_code"],
+                "description": "HTTP response status code",
+                "similarity_score": 0.92,
+                "dataset_scope": null,
+                "labels": {}
+            },
+            {
+                "path_array": ["$d", "http", "method"],
+                "description": "HTTP request method",
+                "similarity_score": 0.85,
+                "dataset_scope": null,
+                "labels": {}
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/semantic-search/fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    search_fields::run(&targets, "HTTP status code", "logs", 10, OutputFormat::Json)
+        .await
+        .expect("search_fields should succeed");
+}
+
+#[tokio::test]
+async fn semantic_field_search_empty_results() {
+    let server = MockServer::start().await;
+
+    let body = json!({ "results": [] });
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/semantic-search/fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    search_fields::run(
+        &targets,
+        "nonexistent field",
+        "logs",
+        10,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("search_fields with no results should succeed");
+}
+
+#[tokio::test]
+async fn semantic_field_search_spans_dataset() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "results": [
+            {
+                "path_array": ["$d", "traceID"],
+                "description": "Distributed trace identifier",
+                "similarity_score": 0.88,
+                "dataset_scope": null,
+                "labels": {}
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/semantic-search/fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    search_fields::run(&targets, "trace ID", "spans", 5, OutputFormat::Json)
+        .await
+        .expect("search_fields on spans dataset should succeed");
+}


### PR DESCRIPTION
CXAI-2050

## Summary
- Add `wiremock` dev-dependency for HTTP mock server testing
- Add shared `test_target()` helper in `tests/common/` that builds an `ExecutionTarget` pointing at a mock server — no production code changes needed
- Add 22 integration tests covering all CLI command API interactions:
  - **Alerts** (6): list, list+filter, get by ID, get with 404→version-id fallback, enable, disable
  - **Dashboards** (2): catalog deserialization, full `run_catalog` pipeline
  - **DataPrime** (6): log results, aggregate query, warnings, logs command, spans command, multi-profile fan-out
  - **Metrics** (5): instant query, range query, name search, semantic description search, get labels
  - **Search fields** (3): semantic field search (logs + spans), empty results

## Test plan
- [x] `cargo test` — all 153 tests pass (89 unit + 22 new integration + 42 existing integration)
- [x] `cargo clippy` — no warnings
- [x] `cargo fmt --check` — clean

Closes AIAPP-1593