### PR TITLE
docs: align contributor docs with style guide

### DIFF
--- a/docs/adding-a-command.md
+++ b/docs/adding-a-command.md
@@ -2,7 +2,7 @@
 
 > Step-by-step guide for adding a new command to `cx`. Read [architecture.md](architecture.md) first for the execution flow and design decisions behind this structure.
 
-## Choose Your Archetype
+## Choose your archetype
 
 Every command falls into one of two patterns:
 
@@ -17,7 +17,7 @@ DataPrime commands delegate to the shared pipeline and require minimal code. RES
 
 ---
 
-## Archetype A: DataPrime-Based Command
+## Archetype A: DataPrime-based command
 
 Use this when your command queries a DataPrime source. The shared pipeline in `commands::dataprime` handles fan-out, merge, render, and spilling — you provide only a text renderer and a thin `run()` wrapper.
 
@@ -26,7 +26,7 @@ Use this when your command queries a DataPrime source. The shared pipeline in `c
 - `src/commands/mod.rs` (add module)
 - `src/main.rs` (CLI definition + dispatch)
 
-### Step 1: Command Module
+### Step 1: Command module
 
 Create `src/commands/your_domain.rs`:
 
@@ -116,7 +116,7 @@ The text renderer signature must be `fn(&MergedResults) -> Result<()>`. The shar
 
 **Reference:** `src/commands/logs.rs` — the entire module is ~130 lines.
 
-### Step 2: Register the Module
+### Step 2: Register the module
 
 Add your module to `src/commands/mod.rs`:
 
@@ -124,7 +124,7 @@ Add your module to `src/commands/mod.rs`:
 pub mod your_domain;
 ```
 
-### Step 3: CLI Wiring
+### Step 3: CLI wiring
 
 In `src/main.rs`, add a variant to the `Commands` enum:
 
@@ -178,7 +178,7 @@ That's it for a DataPrime command. The shared pipeline handles fan-out, merge, a
 
 ---
 
-## Archetype B: REST-Based Command
+## Archetype B: REST-based command
 
 Use this when your command wraps a Coralogix REST API. You'll build the full pipeline: API client, fan-out, merge, and render.
 
@@ -189,7 +189,7 @@ Use this when your command wraps a Coralogix REST API. You'll build the full pip
 - `src/commands/mod.rs` (add module)
 - `src/main.rs` (CLI definition + dispatch)
 
-### Step 1: API Module
+### Step 1: API module
 
 Create `src/api/your_domain.rs`:
 
@@ -279,7 +279,7 @@ Key conventions:
 
 **Reference:** `src/api/alerts.rs` — full example with list, get, create, and state-change endpoints.
 
-### Step 2: Register the API Module
+### Step 2: Register the API module
 
 Add to `src/api/mod.rs`:
 
@@ -287,7 +287,7 @@ Add to `src/api/mod.rs`:
 pub mod your_domain;
 ```
 
-### Step 3: Command Module
+### Step 3: Command module
 
 Create `src/commands/your_domain.rs`:
 
@@ -414,7 +414,7 @@ Key patterns to follow:
 
 **Reference:** `src/commands/alerts.rs` — full example with list, get, create, enable, disable.
 
-### Step 4: Register the Command Module
+### Step 4: Register the command module
 
 Add to `src/commands/mod.rs`:
 
@@ -422,7 +422,7 @@ Add to `src/commands/mod.rs`:
 pub mod your_domain;
 ```
 
-### Step 5: CLI Wiring
+### Step 5: CLI wiring
 
 In `src/main.rs`, define the subcommand enum and add to `Commands`:
 
@@ -467,7 +467,7 @@ Commands::YourDomain { cmd } => match cmd {
 
 ## Testing
 
-### Deserialization Tests (API layer)
+### Deserialization tests (API layer)
 
 Every API module must have deserialization tests. These verify that your response types correctly parse the actual API JSON shape.
 
@@ -499,7 +499,7 @@ mod tests {
 
 Test both happy-path responses and edge cases (empty lists, missing optional fields, fallback values).
 
-### Manual Smoke Testing
+### Manual smoke testing
 
 After building (`cargo build`), verify:
 
@@ -518,7 +518,7 @@ cx your-domain get <id>
 cx -p prod -p staging your-domain list
 ```
 
-### Run the Full Suite
+### Run the full suite
 
 ```bash
 cargo test                  # All unit tests
@@ -528,7 +528,7 @@ cargo fmt --check           # Format check
 
 ---
 
-## User-Facing Skill (Required)
+## User-facing skill (required)
 
 Every command must have a corresponding skill in `skills/`. Skills teach AI agents how to use your command effectively — including CLI syntax, workflows, and behavioral guidelines.
 
@@ -538,7 +538,7 @@ See **[Adding a Skill](adding-a-skill.md)** for the complete guide covering dire
 
 ---
 
-## PR Checklist
+## PR checklist
 
 Copy this into your PR description:
 

--- a/docs/adding-a-skill.md
+++ b/docs/adding-a-skill.md
@@ -2,7 +2,7 @@
 
 > Step-by-step guide for creating a user-facing skill in `skills/`. Read [adding-a-command.md](adding-a-command.md) first if you're adding a new CLI command — every command needs a skill, and the command guide links here.
 
-## Directory Structure
+## Directory structure
 
 Each skill lives in its own directory under `skills/`:
 
@@ -24,7 +24,7 @@ Directory name must be **kebab-case** and match the frontmatter `name` field (e.
 
 ---
 
-## SKILL.md Frontmatter
+## SKILL.md frontmatter
 
 Every `SKILL.md` starts with YAML frontmatter:
 
@@ -46,7 +46,7 @@ The `description` field is how agents decide when to activate a skill. Follow th
 
 ---
 
-## Reference Files
+## Reference files
 
 Use `references/` for dense reference material that would bloat `SKILL.md` but that agents need when constructing specific payloads or queries.
 
@@ -75,9 +75,9 @@ Use `references/` for dense reference material that would bloat `SKILL.md` but t
 - Link from SKILL.md at the bottom:
 
 ```markdown
-## Additional Resources
+## Additional resources
 
-### Reference Files
+### Reference files
 
 - **`references/your-reference.md`** — One-line description of what it contains
 ```
@@ -96,7 +96,7 @@ Also add a representative user query to the "Usage" section's example list if it
 
 ---
 
-## Handling Large Output
+## Handling large output
 
 If the data your skill handles is potentially very large (e.g., dashboard JSON, full alert definitions), the command should output to a file rather than stdout. In this case, the corresponding skill should document the expected JSON format so agents can easily parse and script around the output.
 
@@ -104,7 +104,7 @@ For example, if `cx your-domain get <id> -o json` produces large payloads, the s
 
 ---
 
-## Complete Template
+## Complete template
 
 Copy this as a starting point for `skills/your-domain/SKILL.md`:
 
@@ -119,7 +119,7 @@ version: 0.1.0
 
 Use this skill to query and manage YourDomain resources using the `cx your-domain` CLI commands.
 
-## CLI Commands
+## CLI commands
 
 | Command | Purpose | Key flags |
 |---|---|---|
@@ -136,7 +136,7 @@ Use this skill to query and manage YourDomain resources using the `cx your-domai
 2. Use `cx your-domain get <id> -o json` for full details
 3. Use `-o json | jq '...'` for filtering and transformation
 
-## Key Principles
+## Key principles
 
 - **Use `-o json` with `jq`** for filtering and transformation
 - **Multi-profile queries** add a Profile column automatically
@@ -147,7 +147,7 @@ Use this skill to query and manage YourDomain resources using the `cx your-domai
 
 ---
 
-## PR Checklist
+## PR checklist
 
 ```markdown
 ## Checklist

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,7 +2,7 @@
 
 > Contributor-facing architecture reference for `cx`. Start here before adding a command, debugging the execution pipeline, or reviewing a PR.
 
-## Execution Flow
+## Execution flow
 
 Every `cx` invocation follows a seven-step pipeline:
 
@@ -36,7 +36,7 @@ CLI parsing ──> Config resolution ──> Target building ──> Fan-out
 
 **5-7.** Merging, rendering, and spilling differ by command archetype. See below.
 
-## Command Archetypes
+## Command archetypes
 
 Commands fall into two patterns. New commands should follow one of these.
 
@@ -103,7 +103,7 @@ pub async fn run_list(targets, ..., output) -> Result<()> {
 
 **Reference:** `src/commands/alerts.rs` -- full example with list, get, create, enable, disable subcommands.
 
-## Output Rendering
+## Output rendering
 
 All commands support three output formats controlled by `--output` / `OutputFormat`:
 
@@ -127,7 +127,7 @@ Token-optimized format for AI consumers:
 2. **Metadata stripping** (DataPrime only) -- `transform_for_agents()` renames keys (`metadata` -> `$m`, `labels` -> `$l`, `userData` -> `$d`) and removes noisy metadata fields (`branchid`, `priorityclass`, `*TimestampMicros`, etc.)
 3. **Spilling** (DataPrime non-aggregates only) -- `maybe_spill()` checks serialized size against `max_dataprime_direct_output_size` (default 100 KiB). If exceeded, writes to `cx_results_<hash>.json` in `temp_dir` and prints the path instead.
 
-## Multi-Profile Pattern
+## Multi-profile pattern
 
 A single boolean controls profile-aware behavior throughout the codebase:
 
@@ -147,7 +147,7 @@ When `false`:
 
 The generic version lives in `execution.rs` (`tag_rows`, `merge_tagged_results`). DataPrime commands use a specialized `dataprime::merge_results()` that also handles `is_aggregate` detection and warning collection.
 
-## Error Handling
+## Error handling
 
 Two error systems coexist, each serving a different layer:
 
@@ -188,7 +188,7 @@ Errors during fan-out are **per-profile** and **non-fatal**:
 - Successful profiles continue normally
 - The command exits 0 if at least one profile succeeds
 
-## The API Client
+## The API client
 
 `CxClient` (`src/api/client.rs`) is a thin `reqwest` wrapper pre-configured with Bearer auth:
 
@@ -214,7 +214,7 @@ impl<'a> AlertsApi<'a> {
 }
 ```
 
-## Naming Conventions
+## Naming conventions
 
 | Element | Convention | Example |
 |---------|-----------|---------|
@@ -225,7 +225,7 @@ impl<'a> AlertsApi<'a> {
 | Command modules | `src/commands/<resource>.rs` | mirrors `src/api/<resource>.rs` |
 | Error types | `CxError` for API, `anyhow::Result` for commands | -- |
 
-## Module Map
+## Module map
 
 ```
 src/

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development
 
-## Build & Test
+## Build and test
 
 ```bash
 cargo build                         # Dev build
@@ -8,16 +8,22 @@ cargo build --release               # Release build (stripped, LTO)
 cargo fmt                           # Format code
 cargo clippy                        # Lint
 cargo test                          # Run all tests
-cargo test -- --ignored             # Run integration tests (requires ~/.cx)
+cargo test -- --ignored             # Run integration tests (system keyring required)
 cargo run -- <args>                 # Run CLI in dev mode
 ```
 
 Rust toolchain is pinned to **1.94.1** via `rust-toolchain.toml`.
 
+Before submitting a PR, verify:
+
+- `cargo fmt --check` is clean
+- `cargo clippy` produces no warnings
+- `cargo test` passes
+
 ## DataPrime documentation bundle
 
-The `cx dataprime` subcommands read command and function help from **`assets/dataprime_docs.yaml`**, which is **compiled into the binary** at build time (`include_str!` in `src/commands/dataprime.rs`). Nothing is loaded from disk at runtime.
+The `cx dataprime` subcommands read command and function help from `assets/dataprime_docs.yaml`, which is compiled into the binary at build time via `include_str!` in `src/commands/dataprime.rs`. Nothing is loaded from disk at runtime.
 
 ## Architecture
 
-See `CLAUDE.md` for a detailed architecture overview including execution flow, key modules, and output modes.
+See [architecture.md](architecture.md) for the execution flow, command archetypes, error handling, and module map.


### PR DESCRIPTION
AIAG-650

## Summary

Light-touch style-guide pass on the four contributor-facing docs: `development.md`, `architecture.md`, `adding-a-command.md`, `adding-a-skill.md`. Paired with #35 (README rewrite) and #36 (user-facing reference docs), which cover the bulk of the content-level edits.

These docs are already source-accurate — this PR does not rewrite technical content, only formatting.

## Changes

### `development.md`
- Sentence-case headings.
- Added a "before submitting a PR" quick-check list that mirrors the cargo verification commands listed in `CLAUDE.md`.
- Corrected the `cargo test -- --ignored` note. The flag doesn't require `~/.cx` — it runs tests that are `#[ignore]`-annotated, which in this repo are the keyring tests (`src/keyring_store.rs:80,90,97`) that need system keyring access.
- Replaced "See `CLAUDE.md` for architecture" pointer with a link to `architecture.md`, which is the public-facing architecture reference.

### `architecture.md`
- Sentence-case headings: "Execution flow", "Command archetypes", "Output rendering", "Multi-profile pattern", "Error handling", "The API client", "Naming conventions", "Module map".
- No content changes — architecture content was already accurate against `src/` (Module Map matches `src/` layout, Execution Flow matches `main.rs`/`config.rs`/`execution.rs`, Archetype A/B descriptions match `src/commands/logs.rs` and `src/commands/alerts.rs`).

### `adding-a-command.md`
- Sentence-case headings across all step numbers ("Step 1: Command module", etc.) and section titles.
- No content changes — the step-by-step instructions match current patterns in `src/api/` and `src/commands/`.

### `adding-a-skill.md`
- Sentence-case headings.
- No content changes — the skill template and PR checklist match current skills in `skills/`.

## Style guide source

`.claude/docs-style.md` from the Coralogix docs repo, rule: *"Sentence-style capitalization. Short, specific, action-oriented."* Acronyms (CLI, API, REST, SKILL.md, PR) preserved in uppercase; product names (DataPrime) preserved.

## Test plan

- [ ] Render each doc on the PR page and confirm headings look consistent
- [ ] Spot-check `adding-a-command.md` steps against a real command addition (e.g., compare Step 3 wiring against `src/main.rs`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)