### PR TITLE
fix: support env-only credentials when no profile file exists

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: E2E (test team)
 
 on:
   push:
-    branches: [master, yonatanbeker/age-780-fix-e2e-in-ci]
+    branches: [master]
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,7 +2,7 @@ name: E2E (test team)
 
 on:
   push:
-    branches: [master]
+    branches: [master, yonatanbeker/age-780-fix-e2e-in-ci]
   workflow_dispatch:
 
 concurrency:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -193,6 +193,8 @@ Environment variables override profile file values:
 
 > **Note:** `CX_API_KEY` / `--api-key` always win, even for OAuth profiles. This lets scripts and CI systems inject tokens directly without going through the browser login flow.
 
+> **Env-only mode:** when no profile file exists on disk but both `CX_API_KEY` (or `--api-key`) and `CX_REGION` (or `--region`) are supplied, `cx` runs without a profile file. This is convenient for ephemeral environments (CI runners, containers, ad-hoc scripts) where running `cx profiles add` first would be a paper-cut.
+
 ## OAuth callback ports
 
 The local HTTP callback listener used during `cx profiles add` (OAuth path) binds one port from the following fixed allow-list, chosen at random:

--- a/src/commands/dataprime/api.rs
+++ b/src/commands/dataprime/api.rs
@@ -577,7 +577,7 @@ mod tests {
     #[test]
     fn aggregate_rows_from_groupby_example() {
         // Mirror of the example provided in the task description
-        let rows = vec![
+        let rows = [
             json!({"metadata": [], "labels": [], "userData": r#"{"region":"us1","total_logs":16}"#}),
             json!({"metadata": [], "labels": [], "userData": r#"{"region":"us2","total_logs":20}"#}),
             json!({"metadata": [], "labels": [], "userData": r#"{"region":"us3","total_logs":12}"#}),

--- a/src/config.rs
+++ b/src/config.rs
@@ -308,11 +308,28 @@ pub fn load_profile(name: &str) -> Result<Profile> {
 ///   2. `AuthKind::ApiKey` — reads the key from OS keyring or profile file
 ///   3. `AuthKind::OAuth`  — loads the cached access token; refreshes via the
 ///      refresh token if the access token has expired (or is missing)
+///
+/// Env-only mode: when no profile file exists on disk but both an API key
+/// override (`--api-key` / `CX_API_KEY`) and a region override (`--region` /
+/// `CX_REGION`) are supplied, a `ResolvedConfig` is synthesised directly. This
+/// lets ephemeral environments (CI runners, containers, ad-hoc scripts) run
+/// `cx` without first invoking `cx profiles add`.
 async fn resolve_single(
     profile_name: &str,
     api_key_override: Option<&str>,
     region_override: Option<&str>,
 ) -> Result<ResolvedConfig> {
+    if !profile_file(profile_name)?.exists() {
+        if let (Some(key), Some(region)) = (api_key_override, region_override) {
+            let region: Region = region.parse()?;
+            return Ok(ResolvedConfig {
+                profile_name: profile_name.to_string(),
+                endpoint: region.api_endpoint().to_string(),
+                api_key: key.to_string(),
+            });
+        }
+    }
+
     let mut profile = load_profile(profile_name)?;
 
     if let Some(region) = region_override {
@@ -519,6 +536,34 @@ api_key = "mykey"
             None,
         )
         .await;
+        assert!(result.is_err());
+    }
+
+    // ── env-only mode (no filesystem) ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn resolve_single_env_only_synthesises_when_profile_file_missing() {
+        let cfg = resolve_single(
+            "cx_envonly_missing_profile_xyz",
+            Some("env-key"),
+            Some("eu1"),
+        )
+        .await
+        .unwrap();
+        assert_eq!(cfg.profile_name, "cx_envonly_missing_profile_xyz");
+        assert_eq!(cfg.api_key, "env-key");
+        assert_eq!(cfg.endpoint, "https://api.eu1.coralogix.com");
+    }
+
+    #[tokio::test]
+    async fn resolve_single_env_only_requires_api_key_override() {
+        let result = resolve_single("cx_envonly_no_key_xyz", None, Some("eu1")).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn resolve_single_env_only_requires_region_override() {
+        let result = resolve_single("cx_envonly_no_region_xyz", Some("env-key"), None).await;
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
AIAG-663

## Summary
- `cx` now synthesises a `ResolvedConfig` directly when no profile TOML exists on disk, *provided* both `CX_API_KEY` (or `--api-key`) and `CX_REGION` (or `--region`) are supplied. Useful for ephemeral/CI environments — and unblocks the `e2e.yml` workflow on master, which was failing because the runner has no `~/.cx/profiles/default.toml`.
- Behaviour is unchanged when only one override is given (or neither): the existing "Profile not found, run `cx profiles add`" error still surfaces, so single-flag misconfigurations aren't silently masked.
- Drive-by: silenced a pre-existing `clippy::useless_vec` warning in `src/commands/dataprime/api.rs` test code (caught only with `--all-targets`, which is why CI lint missed it).
- Updated `docs/configuration.md` with an "Env-only mode" note under the precedence table.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --locked --all-targets -- -D warnings` (clean)
- [x] `cargo test --locked` — all suites pass; 3 new unit tests in `src/config.rs::tests` cover the success path and the two single-override failure paths
- [x] Verified end-to-end by temporarily wiring this branch into `e2e.yml`'s push trigger; the e2e job ran green against the test team. Trigger has been reverted to `master` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)