### PR TITLE
docs(readme): rename H1 from cx to cx-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cx
+# cx-cli
 
 The Coralogix CLI. Query logs, metrics, spans, and Real User Monitoring (RUM) data from the terminal using DataPrime and PromQL—built for humans and AI agents.
 


### PR DESCRIPTION
## Summary
- Rename README H1 from `# cx` to `# cx-cli` so the Coralogix docs portal renders the page title as `cx-cli`, matching how the tool is referenced in nav, breadcrumbs, and the wider docs ecosystem.

Jira: [CX-39424](https://coralogix.atlassian.net/browse/CX-39424)

## Test plan
- [ ] Re-sync external repos in the docs portal and confirm the cx CLI page H1 renders as `cx-cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CX-39424]: https://coralogix.atlassian.net/browse/CX-39424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ