### PR TITLE
docs: add TW as blocking reviewer for README.md

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,72 +17,27 @@
 # === traces (logs, spans, RUM) ===
 **/logs/                               @coralogix/team-cxai
 **/spans/                              @coralogix/team-cxai
-/skills/cx-query-logs/                 @coralogix/team-cxai
-/skills/cx-query-spans/                @coralogix/team-cxai
-/skills/cx-rum/                        @coralogix/team-cxai
+/skills/query-logs/                    @coralogix/team-cxai
+/skills/query-spans/                   @coralogix/team-cxai
+/skills/rum/                           @coralogix/team-cxai
 
 # === metrics ===
 **/metrics/                            @coralogix/team-cxai
-/skills/cx-metrics-query/              @coralogix/team-cxai
+/skills/metrics-query/                 @coralogix/team-cxai
 
 # === dataprime (DataPrime query language + semantic search + embedded docs) ===
 **/dataprime/                          @coralogix/team-cxai
-/skills/cx-telemetry-querying/         @coralogix/team-cxai
-/skills/cx-dataprime/                  @coralogix/team-cxai
+/skills/telemetry-querying/            @coralogix/team-cxai
 /assets/                               @coralogix/team-cxai
 
 # === config-surface (alerts, dashboards) ===
 **/alerts/                             @coralogix/team-cxai
 **/dashboards/                         @coralogix/team-cxai
 /skills/cx-alerts/                     @coralogix/team-cxai
-/skills/cx-create-dashboard/           @coralogix/team-cxai
-
-# === incident management (incidents, SLOs) ===
-**/incidents/                          @coralogix/team-cxai
-**/slos/                               @coralogix/team-cxai
-/skills/cx-incident-management/        @coralogix/team-cxai
-
-# === cost & storage (usage, TCO, retentions, quotas, archive) ===
-**/data_usage/                         @coralogix/team-cxai
-**/tco_policies/                       @coralogix/team-cxai
-**/retentions/                         @coralogix/team-cxai
-**/quota_rules/                        @coralogix/team-cxai
-**/data_archive/                       @coralogix/team-cxai
-/skills/cx-cost-optimization/          @coralogix/team-cxai
-
-# === data pipeline (parsing-rules, enrichments, e2m, recording-rules) ===
-**/parsing_rules/                      @coralogix/team-cxai
-**/enrichments/                        @coralogix/team-cxai
-**/custom_enrichments/                 @coralogix/team-cxai
-**/e2m/                                @coralogix/team-cxai
-**/recording_rules/                    @coralogix/team-cxai
-**/suppression_rules/                  @coralogix/team-cxai
-/skills/cx-data-pipeline/              @coralogix/team-cxai
-
-# === observability setup (views, webhooks, notifications, integrations) ===
-**/views/                              @coralogix/team-cxai
-**/webhooks/                           @coralogix/team-cxai
-**/actions/                            @coralogix/team-cxai
-**/connectors/                         @coralogix/team-cxai
-**/routers/                            @coralogix/team-cxai
-**/presets/                            @coralogix/team-cxai
-**/notification_testing/               @coralogix/team-cxai
-**/integrations/                       @coralogix/team-cxai
-**/extensions/                         @coralogix/team-cxai
-**/contextual_data/                    @coralogix/team-cxai
-/skills/cx-observability-setup/        @coralogix/team-cxai
-
-# === platform & access (IAM) ===
-**/api_keys/                           @coralogix/team-cxai
-**/roles/                              @coralogix/team-cxai
-**/scopes/                             @coralogix/team-cxai
-**/users/                              @coralogix/team-cxai
-**/team_groups/                        @coralogix/team-cxai
-**/saml/                               @coralogix/team-cxai
-**/ip_access/                          @coralogix/team-cxai
-/skills/cx-platform-admin/             @coralogix/team-cxai
+/skills/create-dashboard/              @coralogix/team-cxai
 
 # === docs ===
+README.md                              @coralogix/team-technical-writers @coralogix/team-cxai
 /docs/                                 @coralogix/team-technical-writers @coralogix/team-cxai
 
 # Everything else (shared infra, profiles, cleanup, search-fields, CI,


### PR DESCRIPTION
## Why

\`README.md\` is synced automatically into the Coralogix documentation portal via \`external_repos.json\`. Any change to this file triggers an immediate docs redeploy (once [#41](https://github.com/coralogix/cx-cli/pull/41) merges).

\`/docs/\` already had \`@coralogix/team-technical-writers\` as a reviewer. This PR adds the same coverage to \`README.md\` so all synced files require TW sign-off before merging.