### PR TITLE
chore: add nix flake support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,44 @@ cargo build --release
 cp target/release/cx /usr/local/bin/
 ```
 
+### Nix
+
+```bash
+nix run    github:coralogix/cx-cli -- --help     # try without installing
+nix profile install github:coralogix/cx-cli      # install into your profile
+```
+
+Consume from another flake — both the `cx` binary and the agent skill bundle are exposed as outputs:
+
+```nix
+{
+  inputs.cx-cli.url = "github:coralogix/cx-cli";
+
+  outputs = { self, nixpkgs, cx-cli, ... }: {
+    # cx-cli.packages.${system}.default -> the `cx` binary
+    # cx-cli.packages.${system}.skills  -> store path with all cx-* skills
+  };
+}
+```
+
+#### Home Manager
+
+Symlink each skill into `~/.claude/skills/` (adjust the target path for other agents):
+
+```nix
+# home.nix
+{ inputs, pkgs, lib, ... }:
+let
+  skills = inputs.cx-cli.packages.${pkgs.system}.skills;
+in {
+  home.packages = [ inputs.cx-cli.packages.${pkgs.system}.default ];
+
+  home.file = lib.mapAttrs'
+    (name: _: lib.nameValuePair ".claude/skills/${name}" { source = "${skills}/${name}"; })
+    (lib.filterAttrs (_: t: t == "directory") (builtins.readDir skills));
+}
+```
+
 ## Quick start
 
 Follow these steps to go from a fresh install to a working query.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1777578337,
+        "narHash": "sha256-Ad49moKWeXtKBJNy2ebiTQUEgdLyvGmTeykAQ9xM+Z4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "15f4ee454b1dce334612fa6843b3e05cf546efab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  description = "cx - Coralogix CLI";
+
+  # Unstable channel: tracks the rustc version pinned in rust-toolchain.toml
+  # (1.94.1). Stable channels lag behind and would mismatch the toolchain file.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in {
+      packages = forAllSystems (system:
+        let pkgs = pkgsFor system; in {
+          skills = pkgs.runCommandLocal "cx-cli-skills" { } ''
+            cp -r ${./skills} $out
+          '';
+
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = "coralogix-cli";
+            version = (nixpkgs.lib.importTOML ./Cargo.toml).package.version;
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+
+            nativeBuildInputs = [ pkgs.pkg-config ];
+            buildInputs = nixpkgs.lib.optionals pkgs.stdenv.isLinux [ pkgs.dbus ];
+
+            # Tests need network / real Coralogix endpoints.
+            doCheck = false;
+
+            meta = {
+              description = "Coralogix CLI - the observability backbone for AI agents and engineering teams";
+              homepage = "https://github.com/coralogix/cx-cli";
+              license = nixpkgs.lib.licenses.asl20;
+              mainProgram = "cx";
+            };
+          };
+        });
+
+      devShells = forAllSystems (system:
+        let pkgs = pkgsFor system; in {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+            packages = with pkgs; [ rustc cargo clippy rustfmt rust-analyzer ];
+          };
+        });
+    };
+}


### PR DESCRIPTION
This adds a simple way for us nix users to consume `cx-cli` <3
