### PR TITLE
Hide internal development skills from npx skills discovery

### DIFF
--- a/.claude/skills/add-command/SKILL.md
+++ b/.claude/skills/add-command/SKILL.md
@@ -2,6 +2,8 @@
 name: add-command
 description: Use this skill when the user asks to "add a command", "implement cx <something>", "new subcommand", "new CLI command", "add a new cx command", "create a command", "add subcommand", "implement a new command", "build a cx command", "wire up a new command", "extend the CLI", "add an API to cx", "new cx feature", "integrate a Coralogix API", or wants to add new functionality to the cx CLI. Use this even when the user describes a feature that implies a new command without saying "command" explicitly.
 version: 0.1.0
+metadata:
+  internal: true
 ---
 
 # Add a CLI Command

--- a/.claude/skills/add-skill/SKILL.md
+++ b/.claude/skills/add-skill/SKILL.md
@@ -2,6 +2,8 @@
 name: add-skill
 description: Use this skill when the user asks to "add a skill", "create a skill", "new skill", "write a skill for", "skill for cx <something>", "add a user-facing skill", "create a SKILL.md", "teach an agent how to use", "agent skill for", "document a command as a skill", "make a skill", "add skill to skills/", "create agent instructions for", "build a skill", or wants to create a new user-facing skill in the skills/ directory that teaches AI agents how to use a cx CLI command. Use this even when the user is following the add-command workflow and reaches the skill creation step.
 version: 0.1.0
+metadata:
+  internal: true
 ---
 
 # Add a User-Facing Skill

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: create-pr
 description: Creates GitHub pull requests with auto-generated summaries. Use this skill whenever the user wants to create a PR, open a pull request, submit changes for review, or push their branch for review - even if they don't explicitly say "PR".
+metadata:
+  internal: true
 ---
 
 # Create Pull Request

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -2,6 +2,8 @@
 name: run-tests
 description: Use this skill when the user asks to "run tests", "test this", "check if tests pass", "cargo test", "run clippy", "lint this", "check formatting", "cargo fmt", "CI checks", "verify changes", "does this pass tests", "run the full check", "pre-commit check", or wants to verify that code changes are correct. Use this even when the user says something like "make sure this works" or "check for issues" in the context of code changes.
 version: 0.1.0
+metadata:
+  internal: true
 ---
 
 # Run Tests & Verify


### PR DESCRIPTION
## Summary
- Add `metadata.internal: true` to all four development skills under `.claude/skills/` (`add-command`, `add-skill`, `create-pr`, `run-tests`)
- These skills are for contributors developing the CLI, not for end users installing via `npx skills add coralogix/cx-cli`
- The `vercel-labs/skills` package has built-in support for this field: skills with `metadata.internal: true` are skipped during public discovery unless `INSTALL_INTERNAL_SKILLS=1` is set