### PR TITLE
Remove Homebrew install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,6 @@ Pin a specific version:
 CX_VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/coralogix/cx-cli/master/install.sh | sh
 ```
 
-### Homebrew
-
-```bash
-brew install coralogix/tap/cx
-```
-
 ### Cargo
 
 ```bash


### PR DESCRIPTION
## Summary
- Remove the Homebrew installation section from the README.
- Keep the remaining install paths focused on the curl installer and Cargo.


Made with [Cursor](https://cursor.com)