### PR TITLE
Restore Homebrew install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Pin a specific version:
 CX_VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/coralogix/cx-cli/master/install.sh | sh
 ```
 
+### Homebrew
+
+```bash
+brew install coralogix/tap/cx
+```
+
 ### Cargo
 
 ```bash


### PR DESCRIPTION
## Summary
- Restores the README Homebrew installation instructions for installing `cx` via `coralogix/tap/cx`.


Made with [Cursor](https://cursor.com)