### PR TITLE
fix: distinguish 401, 403, and 429 HTTP errors in API client

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -117,9 +117,14 @@ impl CxClient {
     /// Validate the HTTP status of a response and read the body as text.
     async fn checked_text(&self, resp: reqwest::Response) -> Result<String> {
         let status = resp.status();
-        if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+        if status == StatusCode::UNAUTHORIZED {
             return Err(CxError::Auth(
                 "Invalid or expired API key. Run `cx profiles add` to update credentials.".into(),
+            ));
+        }
+        if status == StatusCode::FORBIDDEN {
+            return Err(CxError::Auth(
+                "Permission denied: your API key does not have the required scope for this operation.".into(),
             ));
         }
         if !status.is_success() {

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -123,9 +123,30 @@ impl CxClient {
             ));
         }
         if status == StatusCode::FORBIDDEN {
-            return Err(CxError::Auth(
-                "Permission denied: your API key does not have the required scope for this operation.".into(),
-            ));
+            let body = resp.text().await.unwrap_or_default();
+            let detail = serde_json::from_str::<Value>(&body)
+                .ok()
+                .and_then(|v| v["message"].as_str().map(String::from));
+            let msg = match detail {
+                Some(d) => format!("Permission denied: {d}. Check your API key's scopes."),
+                None => "Permission denied: your API key does not have the required scope for this operation.".into(),
+            };
+            return Err(CxError::Auth(msg));
+        }
+        if status == StatusCode::TOO_MANY_REQUESTS {
+            let retry_after = resp
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .map(String::from);
+            let msg = match retry_after {
+                Some(secs) => format!("Rate limited by the API. Retry after {secs} seconds."),
+                None => "Rate limited by the API. Wait and retry.".into(),
+            };
+            return Err(CxError::Api {
+                status: 429,
+                message: msg,
+            });
         }
         if !status.is_success() {
             let code = status.as_u16();

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -117,49 +117,43 @@ impl CxClient {
     /// Validate the HTTP status of a response and read the body as text.
     async fn checked_text(&self, resp: reqwest::Response) -> Result<String> {
         let status = resp.status();
-        if status == StatusCode::UNAUTHORIZED {
-            return Err(CxError::Auth(
-                "Invalid or expired API key. Run `cx profiles add` to update credentials.".into(),
-            ));
+        if status.is_success() {
+            return Ok(resp.text().await?);
         }
-        if status == StatusCode::FORBIDDEN {
-            let body = resp.text().await.unwrap_or_default();
-            let detail = serde_json::from_str::<Value>(&body)
-                .ok()
-                .and_then(|v| v["message"].as_str().map(String::from));
-            let msg = match detail {
+
+        let code = status.as_u16();
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        let body = resp.text().await.unwrap_or_default();
+        let detail = serde_json::from_str::<Value>(&body)
+            .ok()
+            .and_then(|v| v["message"].as_str().map(String::from));
+
+        match status {
+            StatusCode::UNAUTHORIZED => Err(CxError::Auth(
+                "Invalid or expired API key. Run `cx profiles add` to update credentials."
+                    .into(),
+            )),
+            StatusCode::FORBIDDEN => Err(CxError::Auth(match detail {
                 Some(d) => format!("Permission denied: {d}. Check your API key's scopes."),
                 None => "Permission denied: your API key does not have the required scope for this operation.".into(),
-            };
-            return Err(CxError::Auth(msg));
-        }
-        if status == StatusCode::TOO_MANY_REQUESTS {
-            let retry_after = resp
-                .headers()
-                .get("retry-after")
-                .and_then(|v| v.to_str().ok())
-                .map(String::from);
-            let msg = match retry_after {
-                Some(secs) => format!("Rate limited by the API. Retry after {secs} seconds."),
-                None => "Rate limited by the API. Wait and retry.".into(),
-            };
-            return Err(CxError::Api {
-                status: 429,
-                message: msg,
-            });
-        }
-        if !status.is_success() {
-            let code = status.as_u16();
-            let body = resp.text().await.unwrap_or_default();
-            let message = serde_json::from_str::<Value>(&body)
-                .ok()
-                .and_then(|v| v["message"].as_str().map(String::from))
-                .unwrap_or(body);
-            return Err(CxError::Api {
+            })),
+            StatusCode::TOO_MANY_REQUESTS => Err(CxError::Api {
                 status: code,
-                message,
-            });
+                message: match retry_after {
+                    Some(secs) => {
+                        format!("Rate limited by the API. Retry after {secs} seconds.")
+                    }
+                    None => "Rate limited by the API. Wait and retry.".into(),
+                },
+            }),
+            _ => Err(CxError::Api {
+                status: code,
+                message: detail.unwrap_or(body),
+            }),
         }
-        Ok(resp.text().await?)
     }
 }

--- a/tests/api_client/main.rs
+++ b/tests/api_client/main.rs
@@ -80,9 +80,7 @@ async fn error_429_with_retry_after() {
 
     Mock::given(method("GET"))
         .and(path("/test"))
-        .respond_with(
-            ResponseTemplate::new(429).append_header("Retry-After", "30"),
-        )
+        .respond_with(ResponseTemplate::new(429).append_header("Retry-After", "30"))
         .mount(&server)
         .await;
 
@@ -123,8 +121,7 @@ async fn error_500_with_json_message() {
     Mock::given(method("GET"))
         .and(path("/test"))
         .respond_with(
-            ResponseTemplate::new(500)
-                .set_body_json(json!({"message": "internal error"})),
+            ResponseTemplate::new(500).set_body_json(json!({"message": "internal error"})),
         )
         .mount(&server)
         .await;
@@ -145,9 +142,7 @@ async fn error_500_with_raw_body() {
 
     Mock::given(method("GET"))
         .and(path("/test"))
-        .respond_with(
-            ResponseTemplate::new(500).set_body_string("something went wrong"),
-        )
+        .respond_with(ResponseTemplate::new(500).set_body_string("something went wrong"))
         .mount(&server)
         .await;
 

--- a/tests/api_client/main.rs
+++ b/tests/api_client/main.rs
@@ -1,0 +1,161 @@
+use serde_json::{json, Value};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use coralogix_cli::api_client::CxClient;
+
+fn init_tls() {
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .ok();
+}
+
+#[tokio::test]
+async fn error_401_unauthorized() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(ResponseTemplate::new(401))
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Invalid or expired API key"),
+        "expected auth error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_403_with_message() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(403)
+                .set_body_json(json!({"message": "missing dashboards:write scope"})),
+        )
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Permission denied: missing dashboards:write scope"),
+        "expected server message in error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_403_without_message() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(ResponseTemplate::new(403))
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Permission denied: your API key does not have the required scope"),
+        "expected generic permission error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_429_with_retry_after() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(429).append_header("Retry-After", "30"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Retry after 30 seconds"),
+        "expected retry-after in error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_429_without_retry_after() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(ResponseTemplate::new(429))
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Wait and retry"),
+        "expected generic rate-limit error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_500_with_json_message() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(500)
+                .set_body_json(json!({"message": "internal error"})),
+        )
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("internal error"),
+        "expected server message in error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_500_with_raw_body() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(500).set_body_string("something went wrong"),
+        )
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("something went wrong"),
+        "expected raw body in error, got: {msg}"
+    );
+}


### PR DESCRIPTION
AIAG-726
## Summary
- **401 Unauthorized** - keeps existing "Invalid or expired API key" message
- **403 Forbidden** - now reads the response body and surfaces the server's specific permission message (e.g., which scope is missing), instead of showing the same auth error as 401
- **429 Too Many Requests** - new handler extracts the `Retry-After` header and tells the user how long to wait
- **Refactored** `checked_text` into early-return + match - body and detail parsed once, no duplicated logic

Previously both 401 and 403 were reported as "Invalid or expired API key", masking permission issues as authentication failures.

## Tests
Added 7 integration tests in `tests/api_client/main.rs` covering every `checked_text` branch:
- 401 unauthorized
- 403 with server message / without server message
- 429 with Retry-After header / without header
- 500 with JSON message / with raw body