### PR TITLE
fix: support per-profile default output format

### DIFF
--- a/src/commands/profiles/mod.rs
+++ b/src/commands/profiles/mod.rs
@@ -83,26 +83,31 @@ pub fn run_list() -> Result<()> {
         .max()
         .unwrap_or(6)
         .max(6);
+    let output_w = 6; // "OUTPUT" header length
 
     println!(
-        "{:<name_w$}  {:<label_w$}  {:<region_w$}  {:<8}  DEFAULT",
+        "{:<name_w$}  {:<label_w$}  {:<region_w$}  {:<8}  {:<output_w$}  DEFAULT",
         "NAME",
         "LABEL",
         "REGION",
         "AUTH",
+        "OUTPUT",
         name_w = name_w,
         label_w = label_w,
         region_w = region_w,
+        output_w = output_w,
     );
     println!(
-        "{:<name_w$}  {:<label_w$}  {:<region_w$}  {:<8}  -------",
+        "{:<name_w$}  {:<label_w$}  {:<region_w$}  {:<8}  {:<output_w$}  -------",
         "-".repeat(name_w),
         "-".repeat(label_w),
         "-".repeat(region_w),
         "--------",
+        "-".repeat(output_w),
         name_w = name_w,
         label_w = label_w,
         region_w = region_w,
+        output_w = output_w,
     );
 
     for (name, profile) in &entries {
@@ -112,21 +117,27 @@ pub fn run_list() -> Result<()> {
             AuthKind::OAuth => "oauth",
             AuthKind::ApiKey => "api-key",
         };
+        let output_fmt = profile
+            .default_output_format
+            .map(|f| f.as_str())
+            .unwrap_or("-");
         let is_default = if *name == global_config.default_profile {
             "yes"
         } else {
             ""
         };
         println!(
-            "{:<name_w$}  {:<label_w$}  {:<region_w$}  {:<8}  {}",
+            "{:<name_w$}  {:<label_w$}  {:<region_w$}  {:<8}  {:<output_w$}  {}",
             name,
             label,
             region,
             auth,
+            output_fmt,
             is_default,
             name_w = name_w,
             label_w = label_w,
             region_w = region_w,
+            output_w = output_w,
         );
     }
 
@@ -151,29 +162,31 @@ pub async fn run_add(profile_name: Option<String>) -> Result<()> {
 
     let use_oauth = auth_choice.starts_with("OAuth");
 
-    let (profile, storage_desc) = if use_oauth {
+    let (mut profile, storage_desc) = if use_oauth {
         configure_oauth(&name).await?
     } else {
         configure_api_key(&name)?
     };
 
-    save_profile(&name, &profile)?;
-
-    // ── Common: default output format ──────────────────────────────────────────
-    let mut global_config = load_config().unwrap_or_default();
+    // ── Common: default output format (per-profile) ────────────────────────────
+    let global_config = load_config().unwrap_or_default();
+    let current_fmt = profile
+        .default_output_format
+        .unwrap_or(global_config.default_output_format);
     let current_idx = OUTPUT_FORMATS
         .iter()
-        .position(|&f| f == global_config.default_output_format.as_str())
+        .position(|&f| f == current_fmt.as_str())
         .unwrap_or(0);
     let format_str = Select::new("Default output format:", OUTPUT_FORMATS.to_vec())
         .with_starting_cursor(current_idx)
         .prompt()?;
-    global_config.default_output_format = match format_str {
+    profile.default_output_format = Some(match format_str {
         "json" => OutputFormat::Json,
         "agents" => OutputFormat::Agents,
         _ => OutputFormat::Text,
-    };
-    save_config(&global_config)?;
+    });
+
+    save_profile(&name, &profile)?;
 
     let cx_dir = crate::config::config_dir()?;
     println!(
@@ -316,6 +329,7 @@ async fn configure_oauth(name: &str) -> Result<(Profile, &'static str)> {
         label,
         oauth_client_id: oauth_client_id_for_profile,
         oauth_base_url: oauth_base_url_for_profile,
+        default_output_format: None,
     };
 
     Ok((profile, "OS credential store (OAuth tokens)"))
@@ -371,6 +385,7 @@ fn configure_api_key(name: &str) -> Result<(Profile, &'static str)> {
                 label,
                 oauth_client_id: None,
                 oauth_base_url: None,
+                default_output_format: None,
             };
             (profile, "OS credential store")
         }
@@ -385,6 +400,7 @@ fn configure_api_key(name: &str) -> Result<(Profile, &'static str)> {
                 label,
                 oauth_client_id: None,
                 oauth_base_url: None,
+                default_output_format: None,
             };
             (profile, "profile file")
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -256,6 +256,10 @@ pub struct Profile {
     /// When `None`, `region.api_endpoint()` is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth_base_url: Option<String>,
+    /// Per-profile default output format. When set, takes precedence over the
+    /// global `default_output_format` in config.toml.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_output_format: Option<OutputFormat>,
 }
 
 /// Resolved configuration ready for use at runtime.
@@ -332,6 +336,18 @@ pub fn save_config(config: &Config) -> Result<()> {
     std::fs::write(&path, content)
         .with_context(|| format!("Failed to write {}", path.display()))?;
     Ok(())
+}
+
+/// Load the output format preference from the first of the given profile names.
+/// Returns `None` if no profile specifies one, or if the profile cannot be loaded.
+pub fn first_profile_output_format(profiles: &[String]) -> Option<OutputFormat> {
+    let name = if profiles.is_empty() {
+        load_config().ok().map(|c| c.default_profile)
+    } else {
+        Some(profiles[0].clone())
+    };
+    name.and_then(|n| load_profile(&n).ok())
+        .and_then(|p| p.default_output_format)
 }
 
 /// Load a named profile.
@@ -662,6 +678,7 @@ api_key = "mykey"
             label: Some("prod".to_string()),
             oauth_client_id: None,
             oauth_base_url: None,
+            default_output_format: None,
         };
         let toml = toml::to_string_pretty(&profile).unwrap();
         let restored: Profile = toml::from_str(&toml).unwrap();
@@ -683,6 +700,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: Some("abc-123".to_string()),
             oauth_base_url: None,
+            default_output_format: None,
         };
         let toml = toml::to_string_pretty(&profile).unwrap();
         let restored: Profile = toml::from_str(&toml).unwrap();
@@ -745,6 +763,7 @@ api_key = "mykey"
                 label: None,
                 oauth_client_id: None,
                 oauth_base_url: None,
+                default_output_format: None,
             };
             save_profile(name, &profile).unwrap();
         }
@@ -779,6 +798,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            default_output_format: None,
         };
         save_profile("default", &profile).unwrap();
 
@@ -799,6 +819,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            default_output_format: None,
         };
         save_profile(name, &profile).unwrap();
 
@@ -820,6 +841,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            default_output_format: None,
         };
         save_profile(name, &profile).unwrap();
 
@@ -841,6 +863,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            default_output_format: None,
         };
         save_profile(name, &profile).unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2156,7 +2156,10 @@ async fn main() -> Result<()> {
 
     // Load global config for defaults (non-fatal - fall back to defaults).
     let global_config = config::load_config().unwrap_or_default();
-    let output = cli.output.unwrap_or(global_config.default_output_format);
+    let output = cli
+        .output
+        .or_else(|| config::first_profile_output_format(&cli.profile))
+        .unwrap_or(global_config.default_output_format);
     let max_direct = global_config.max_dataprime_direct_output_size;
     let temp_dir = global_config.temp_dir.clone();
 


### PR DESCRIPTION
## Summary
- Each profile now stores its own `default_output_format` in its TOML file instead of a single global setting
- Resolution order: CLI flag (`--output`) > first profile's format > global config > hard default (`text`)
- `cx profiles add` saves output format to the profile, not to global config
- `cx profiles list` now shows an OUTPUT column with each profile's configured format

## Test plan
- [x] `cargo fmt` - passes
- [x] `cargo clippy` - no new warnings
- [x] `cargo test` - all 32 tests pass
- [ ] Manual: `cx profiles add` prompts for output format and saves to profile TOML
- [ ] Manual: `cx profiles list` shows OUTPUT column
- [ ] Manual: existing profiles without `default_output_format` fall through to global/hard default

🤖 Generated with [Claude Code](https://claude.com/claude-code)