### PR TITLE
fix: correct DataPrime string quoting in shell examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Follow these steps to go from a fresh install to a working query.
 2. Query logs. The positional argument is a DataPrime query:
 
     ```bash
-    cx logs 'filter $m.severity == "ERROR"'
+    cx logs 'filter $m.severity == ERROR'
     ```
 
 3. Query metrics. `cx metrics query` takes a PromQL expression:
@@ -139,7 +139,7 @@ Follow these steps to go from a fresh install to a working query.
 4. Search distributed spans. The positional argument is a DataPrime filter; `source spans` is prepended automatically:
 
     ```bash
-    cx spans 'filter $l.serviceName == "checkout"' --start now-2h --limit 50
+    cx spans "filter \$l.serviceName == 'checkout'" --start now-2h --limit 50
     ```
 
 5. List dashboards to confirm the API is reachable:
@@ -298,7 +298,7 @@ Available skills: `cx-query-logs`, `cx-query-spans`, `cx-metrics-query`, `cx-ale
 Repeat `-p` to run a command across multiple profiles in parallel. Results are merged and tagged with the profile name:
 
 ```bash
-cx -p prod-eu -p prod-us logs 'filter $m.severity == "ERROR"'
+cx -p prod-eu -p prod-us logs 'filter $m.severity == ERROR'
 ```
 
 See [docs/multi-profile.md](docs/multi-profile.md) for more examples.

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cargo install coralogix-cli
 
 Download the latest release for your platform from [GitHub Releases](https://github.com/coralogix/cx-cli/releases).
 
-<details>
+<details markdown="1">
 <summary>Nix</summary>
 
 ```bash
@@ -104,7 +104,7 @@ in {
 
 </details>
 
-<details>
+<details markdown="1">
 <summary>Build from source</summary>
 
 ```bash
@@ -227,7 +227,7 @@ Commands are grouped by domain. Run `cx --help` for the full organized listing, 
 | `cx completions` | Shell tab-completion: `install`, `refresh`, `generate` |
 | `cx cleanup` | Remove `cx_results*` temp files older than 30 minutes |
 
-<details>
+<details markdown="1">
 <summary>Global options</summary>
 
 ```
@@ -303,7 +303,7 @@ cx -p prod-eu -p prod-us logs 'filter $m.severity == ERROR'
 
 See [docs/multi-profile.md](docs/multi-profile.md) for more examples.
 
-<details>
+<details markdown="1">
 <summary><strong>Shell completions</strong></summary>
 
 `cx` supports tab-completion for all commands, flags, subcommands, and profile names.
@@ -378,7 +378,7 @@ COMPLETE=fish cx | source
 
 </details>
 
-<details>
+<details markdown="1">
 <summary><strong>Migrating from cxctl</strong></summary>
 
 `cx` replaces the older Scala-based `cxctl`. If you are looking for documentation on the legacy tool, see the [Coralogix CLI (legacy) docs](https://coralogix.com/docs/developer-portal/infrastructure-as-code/cli/coralogix-cli/). `cx` does not currently cover all legacy surfaces, including LiveTail and account invite flows.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Follow these steps to go from a fresh install to a working query.
 
 Run `cx <command> --help` for full syntax and examples on any command.
 
-<details open>
+<details open markdown="1">
 <summary><strong>Commands</strong></summary>
 
 Commands are grouped by domain. Run `cx --help` for the full organized listing, or `cx schema` for a machine-readable JSON tree.
@@ -291,7 +291,7 @@ Install globally for all projects:
 npx skills add coralogix/cx-cli -g
 ```
 
-Available skills: `cx-query-logs`, `cx-query-spans`, `cx-metrics-query`, `cx-alerts`, `cx-dataprime`, `cx-rum`, `cx-telemetry-querying`, `cx-create-dashboard`, `cx-cost-optimization`, `cx-incident-management`, `cx-data-pipeline`, `cx-platform-admin`, `cx-observability-setup`. See [skills/README.md](skills/README.md) for per-skill usage.
+Available skills: `cx-query-logs`, `cx-query-spans`, `cx-metrics-query`, `cx-alerts`, `cx-dataprime`, `cx-rum`, `cx-telemetry-querying`, `cx-create-dashboard`, `cx-cost-optimization`, `cx-incident-management`, `cx-data-pipeline`, `cx-platform-admin`, `cx-observability-setup`. See [skills/README.md](https://github.com/coralogix/cx-cli/blob/master/skills/README.md) for per-skill usage.
 
 ## Multi-profile fan-out
 

--- a/docs/multi-profile.md
+++ b/docs/multi-profile.md
@@ -7,7 +7,7 @@
 Repeat the `-p` (or `--profile`) flag to target multiple profiles:
 
 ```bash
-cx logs 'filter $m.severity == "ERROR"' -p prod -p staging
+cx logs 'filter $m.severity == ERROR' -p prod -p staging
 cx metrics query 'up' -p us-prod -p eu-prod
 ```
 
@@ -37,7 +37,7 @@ Text output adds a `Profile` column to tables for REST commands (alerts, dashboa
 
 ```bash
 # This will error
-cx logs 'filter $m.severity == "ERROR"' -p prod -p staging --api-key sk-...
+cx logs 'filter $m.severity == ERROR' -p prod -p staging --api-key sk-...
 ```
 
 Instead, store per-profile credentials ahead of time:

--- a/docs/time-syntax.md
+++ b/docs/time-syntax.md
@@ -50,5 +50,5 @@ cx logs 'filter $m.severity == ERROR' \
   --end 2024-01-01T01:00:00Z
 
 # Last 3 days of spans for a specific service
-cx spans 'filter $l.serviceName == "checkout"' --start now-3d
+cx spans "filter \$l.serviceName == 'checkout'" --start now-3d
 ```


### PR DESCRIPTION
## Summary

Three doc fixes based on customer report and portal QA.

### 1. DataPrime string quoting in shell examples

Shell examples use double quotes for DataPrime string literals, but DataPrime only accepts single quotes. Running the examples as written produces:

```
error from profile 'default': API request failed (400): Compilation errors:
 - malformed expression at [0:22:22-0:23:23]: `"`
 - excessive input at [0:28:28-0:29:29]: `"`
```

- Severity comparisons: remove quotes — `ERROR`, `INFO`, etc. are enum values in DataPrime and don't need quoting
- String comparisons (e.g. `serviceName`): switch to double-quoted outer shell arg with escaped `$` and single-quoted DataPrime string literal

### 2. `<details open>` → `<details open markdown="1">`

MkDocs Material requires `markdown="1"` on `<details>` elements to render Markdown content inside them correctly.

### 3. Fix 404 on `skills/README.md` link

The relative `skills/README.md` link in the AI agent skills section resolves correctly on GitHub but 404s on the Coralogix docs portal (the `skills/` directory is not synced). Changed to an absolute GitHub URL.

**Files changed:** `README.md`, `docs/multi-profile.md`, `docs/time-syntax.md`

Reported via Coralogix support (DOCS-23).