### PR TITLE
Fix: remove unnecessary empty string push in banner rendering

### DIFF
--- a/src/banner.rs
+++ b/src/banner.rs
@@ -73,7 +73,6 @@ pub fn render() -> String {
     let separator: String = "─".repeat(sep_width);
     out.push(format!("{}{}", sep_pad, separator.truecolor(0, 90, 60)));
 
-    out.push(String::new());
     out.join("\n")
 }
 


### PR DESCRIPTION
- Eliminated the redundant `out.push(String::new())` line in the `render` function of `banner.rs`, streamlining the output generation process.