### PR TITLE
feat: support storing OAuth tokens in profile file (now default)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,8 +21,12 @@ jobs:
       contents: read
       actions: read
     steps:
+      # Path filter only applies on pull_request - on push to master we always
+      # build (so the binary-size baseline gets refreshed). dorny/paths-filter
+      # is unreliable outside the pull_request context.
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
+        if: github.event_name == 'pull_request'
         with:
           filters: |
             code:
@@ -32,26 +36,26 @@ jobs:
               - 'rust-toolchain.toml'
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         with:
           toolchain: "1.94.1"
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
 
       - name: Install Linux system dependencies
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
       - name: Build release binary
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: cargo build --release --locked
 
       - name: Report binary size
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: |
           BINARY="target/release/cx"
           SIZE_BYTES=$(stat -c%s "$BINARY")
@@ -63,7 +67,7 @@ jobs:
           echo "| \`cx\` | $SIZE_HUMAN ($SIZE_BYTES bytes) |" >> $GITHUB_STEP_SUMMARY
 
       - name: Upload binary size baseline
-        if: steps.filter.outputs.code == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: binary-size-baseline
@@ -71,7 +75,7 @@ jobs:
           retention-days: 90
 
       - name: Check binary size regression
-        if: steps.filter.outputs.code == 'true' && github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.filter.outputs.code == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -131,6 +135,7 @@ jobs:
     steps:
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         id: filter
+        if: github.event_name == 'pull_request'
         with:
           filters: |
             code:
@@ -140,23 +145,23 @@ jobs:
               - 'rust-toolchain.toml'
 
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         with:
           toolchain: "1.94.1"
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         with:
           key: ${{ matrix.target }}
 
       - name: Install cross
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: cargo install cross --git https://github.com/cross-rs/cross
 
       - name: Build
-        if: steps.filter.outputs.code == 'true'
+        if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         run: cross build --release --locked --target ${{ matrix.target }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: Test
 
 on:
-  push:
-    branches: [master]
   pull_request:
     branches: [master]
 

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Configuration lives in `~/.cx/`:
     default.toml           # Credentials and region per profile
 ```
 
-Credentials are stored in the OS keyring on macOS (Keychain) and Windows (Credential Manager). On Linux, keyring support (Secret Service) requires a glibc build; the default install script and release binaries use musl, which has no keyring backend-credentials fall back to file storage. If you need keyring support on Linux, build from source with a glibc toolchain.
+Credentials (API keys or OAuth tokens) are stored either inline in the profile TOML with `0600` permissions (`credential_storage = "file"`, the default) or in the OS keyring (`credential_storage = "os_store"` - macOS Keychain, Windows Credential Manager, or D-Bus Secret Service on Linux). `cx profiles add` prompts for the choice. On Linux, keyring support requires a glibc build; the default install script and release binaries use musl, which has no keyring backend, so `os_store` is unavailable there.
 
 Environment variables override profile settings: `CX_PROFILE`, `CX_API_KEY`, and `CX_REGION`.
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ The observability backbone for AI agents and engineering teams. `cx` gives you-a
 Install the latest release with the install script:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/coralogix/cx-cli/master/install.sh | sh
+curl -fsSL https://get.coralogix.dev/cli | sh
 ```
 
 Pin a specific version:
 
 ```bash
-CX_VERSION=0.1.0 curl -fsSL https://raw.githubusercontent.com/coralogix/cx-cli/master/install.sh | sh
+CX_VERSION=0.1.0 curl -fsSL https://get.coralogix.dev/cli | sh
 ```
 
 ### Homebrew

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,7 +15,7 @@
 
 ## Quick start
 
-Run `cx profiles add` to create or update the default profile. OAuth (browser login) is selected by default and is the recommended option - it opens your browser, captures the callback automatically, and stores tokens securely in the OS keyring.
+Run `cx profiles add` to create or update the default profile. OAuth (browser login) is selected by default and is the recommended option - it opens your browser, captures the callback automatically, and persists the resulting tokens.
 
 ```
 $ cx profiles add
@@ -30,9 +30,12 @@ Waiting for browser callback...
 Authorization code received, exchanging for tokens...
 Login successful!
 
+Where should OAuth tokens be stored? file
 Profile 'default' saved to /Users/you/.cx
-Credentials stored in OS credential store (OAuth tokens)
+Credentials stored in profile file (OAuth tokens)
 ```
+
+You will be asked where to store the credentials: `file` (default - saved inline in the profile TOML with `0600` permissions) or `os-store` (the OS credential store - macOS Keychain, Windows Credential Manager, etc.). Pick `os-store` if your threat model assumes other processes running as your user could read the profile file.
 
 To use a plain API key instead, select `API key (paste manually)` at the first prompt. The API key must be a [Team Key](https://coralogix.com/docs/user-guides/account-management/api-keys/api-keys/#team-keys) or a [Personal Key](https://coralogix.com/docs/user-guides/account-management/api-keys/api-keys/#personal-keys) - see [API Key](#api-key) below for where to generate one. [Send-Your-Data](https://coralogix.com/docs/user-guides/account-management/api-keys/send-your-data-api-key/) / ingress keys will not work for querying.
 
@@ -42,8 +45,8 @@ To use a plain API key instead, select `API key (paste manually)` at the first p
 
 OAuth uses the standard browser-based Authorization Code + PKCE flow.
 
-- Tokens (`access_token`, `refresh_token`, `id_token`) are stored in the OS keyring and are **never written to the profile TOML**.
-- The access token is silently refreshed on each `cx` invocation when it is within 30 seconds of expiry.
+- Tokens (`access_token`, `refresh_token`, `id_token`) are persisted using the chosen `credential_storage` backend - either inline in the profile TOML (`file`, the default) or in the OS keyring (`os_store`).
+- The access token is silently refreshed on each `cx` invocation when it is within 30 seconds of expiry. The refreshed token set is written back to the same backend.
 - If the refresh token is also expired, `cx` exits with an actionable message:
 
   ```
@@ -104,7 +107,7 @@ temp_dir = "/tmp/"
 
 ## Profile files (`~/.cx/profiles/<name>.toml`)
 
-Each profile stores credentials and endpoint configuration. Sensitive secrets (API key, OAuth tokens) live in the OS keyring when `credential_storage = "os_store"` and are **not** written to the TOML.
+Each profile stores credentials and endpoint configuration. `credential_storage` selects where secrets live for both auth modes: with `"file"` (the default) the API key or OAuth token set is written inline in the TOML (`0600` perms on Unix); with `"os_store"` the secrets live in the OS keyring and the inline fields are absent.
 
 ### Common fields
 
@@ -121,8 +124,25 @@ Each profile stores credentials and endpoint configuration. Sensitive secrets (A
 |---|---|---|
 | `oauth_client_id` | Custom environments | OAuth client ID. Omitted for known regions (hard-coded in the binary). |
 | `oauth_base_url` | Rarely | Overrides the base URL for OpenID discovery. Defaults to `region.api_endpoint()`. |
+| `oauth_tokens` | `credential_storage = "file"` | Cached access/refresh/id tokens and expiry. Absent when tokens live in the OS keyring. |
 
-### Example: OAuth profile (known region)
+### Example: OAuth profile (known region, file storage - default)
+
+```toml
+auth = "oauth"
+credential_storage = "file"
+region = "eu2"
+label = "production"
+
+[oauth_tokens]
+access_token = "..."
+refresh_token = "..."
+expiry = 1700000000
+```
+
+The token set is rewritten in place each time `cx` refreshes. The file is created with `0600` permissions on Unix.
+
+### Example: OAuth profile (known region, OS keyring)
 
 ```toml
 auth = "oauth"
@@ -137,7 +157,7 @@ Tokens live in the OS keyring; nothing sensitive is in this file.
 
 ```toml
 auth = "oauth"
-credential_storage = "os_store"
+credential_storage = "file"
 region = "https://api.myenv.example.com"
 oauth_client_id = "abc123-my-client"
 label = "custom-env"

--- a/src/commands/profiles/mod.rs
+++ b/src/commands/profiles/mod.rs
@@ -29,7 +29,26 @@ const OAUTH_REGIONS: &[&str] = &[
 
 const OUTPUT_FORMATS: &[&str] = &["text", "json", "agents"];
 
-const CREDENTIAL_STORAGE_OPTIONS: &[&str] = &["file", "os-store (encrypted)"];
+/// Storage backend choices presented to the user. The first element is the
+/// label shown in the prompt; the second is the variant it maps to. Order
+/// matters: the first entry is the default cursor position.
+const CREDENTIAL_STORAGE_OPTIONS: &[(&str, CredentialStorage)] = &[
+    ("file", CredentialStorage::File),
+    ("os-store (encrypted)", CredentialStorage::OsStore),
+];
+
+fn select_credential_storage(prompt: &str, help_message: &str) -> Result<CredentialStorage> {
+    let labels: Vec<&str> = CREDENTIAL_STORAGE_OPTIONS.iter().map(|(l, _)| *l).collect();
+    let chosen = Select::new(prompt, labels)
+        .with_help_message(help_message)
+        .with_starting_cursor(0)
+        .prompt()?;
+    Ok(CREDENTIAL_STORAGE_OPTIONS
+        .iter()
+        .find(|(label, _)| *label == chosen)
+        .map(|(_, storage)| *storage)
+        .expect("inquire returns one of the labels we passed in"))
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -303,7 +322,8 @@ async fn configure_oauth(name: &str) -> Result<(Profile, &'static str)> {
     let label = Text::new("Label (e.g. 'prod'):").prompt_skippable()?;
     let label = label.filter(|s| !s.is_empty());
 
-    // Clean up any existing secrets before writing new ones.
+    // Clean up any existing keyring entries before writing new ones, regardless
+    // of which storage backend the user picks below.
     keyring_store::delete_profile(name);
 
     // ── Browser login ──────────────────────────────────────────────────────────
@@ -311,8 +331,11 @@ async fn configure_oauth(name: &str) -> Result<(Profile, &'static str)> {
     let tokens = oauth::browser_login(&base_url, &client_id).await?;
     println!("Login successful!");
 
-    // Store tokens in the OS keyring.
-    oauth::store_tokens(name, &tokens)?;
+    let credential_storage = select_credential_storage(
+        "Where should OAuth tokens be stored?",
+        "'file' stores tokens in the profile config (0600 perms). \
+         'os-store' uses the OS credential store (macOS Keychain, Windows Credential Manager).",
+    )?;
 
     // For custom environments, explicitly store the base URL so that token
     // refresh can reach the correct OIDC discovery endpoint even if the
@@ -320,19 +343,30 @@ async fn configure_oauth(name: &str) -> Result<(Profile, &'static str)> {
     // is derived from `region.api_endpoint()` at runtime and need not be stored.
     let oauth_base_url_for_profile = if is_custom { Some(base_url) } else { None };
 
+    let (oauth_tokens, storage_desc): (Option<_>, &'static str) = match credential_storage {
+        CredentialStorage::OsStore => {
+            oauth::store_tokens_keyring(name, &tokens)?;
+            (None, "OS credential store (OAuth tokens)")
+        }
+        CredentialStorage::File => (
+            Some(oauth::tokens_to_stored(&tokens)),
+            "profile file (OAuth tokens)",
+        ),
+    };
+
     let profile = Profile {
         auth: AuthKind::OAuth,
-        // OAuth profiles always use the OS keyring; tokens are never in the TOML.
-        credential_storage: CredentialStorage::OsStore,
+        credential_storage,
         api_key: None,
         region,
         label,
         oauth_client_id: oauth_client_id_for_profile,
         oauth_base_url: oauth_base_url_for_profile,
+        oauth_tokens,
         default_output_format: None,
     };
 
-    Ok((profile, "OS credential store (OAuth tokens)"))
+    Ok((profile, storage_desc))
 }
 
 // ── API key configure path ────────────────────────────────────────────────────
@@ -357,22 +391,11 @@ fn configure_api_key(name: &str) -> Result<(Profile, &'static str)> {
     let label = Text::new("Label (e.g. 'prod'):").prompt_skippable()?;
     let label = label.filter(|s| !s.is_empty());
 
-    let storage_choice = Select::new(
+    let credential_storage = select_credential_storage(
         "Where should API keys be stored?",
-        CREDENTIAL_STORAGE_OPTIONS.to_vec(),
-    )
-    .with_help_message(
         "'file' stores in profile config (0600 perms). \
          'os-store' uses the OS credential store (macOS Keychain, Windows Credential Manager).",
-    )
-    .with_starting_cursor(0)
-    .prompt()?;
-
-    let credential_storage = if storage_choice.starts_with("os-store") {
-        CredentialStorage::OsStore
-    } else {
-        CredentialStorage::File
-    };
+    )?;
 
     let (profile, storage_desc) = match credential_storage {
         CredentialStorage::OsStore => {
@@ -385,6 +408,7 @@ fn configure_api_key(name: &str) -> Result<(Profile, &'static str)> {
                 label,
                 oauth_client_id: None,
                 oauth_base_url: None,
+                oauth_tokens: None,
                 default_output_format: None,
             };
             (profile, "OS credential store")
@@ -400,6 +424,7 @@ fn configure_api_key(name: &str) -> Result<(Profile, &'static str)> {
                 label,
                 oauth_client_id: None,
                 oauth_base_url: None,
+                oauth_tokens: None,
                 default_output_format: None,
             };
             (profile, "profile file")

--- a/src/config.rs
+++ b/src/config.rs
@@ -224,24 +224,42 @@ mod max_size_serde {
     }
 }
 
+/// OAuth token set persisted inline in the profile TOML when
+/// `credential_storage = "file"`. Mirrors the keyring-backed layout used by
+/// `oauth::store_tokens_keyring`.
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq, Eq)]
+pub struct StoredOAuthTokens {
+    pub access_token: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id_token: Option<String>,
+    /// Unix timestamp (seconds). Absent when the IdP did not return `expires_in`;
+    /// callers fall back to parsing the JWT `exp` claim.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expiry: Option<u64>,
+}
+
 /// A named profile storing credentials and endpoint info.
 ///
-/// API keys are stored inline in the TOML by default (`credential_storage = "file"`).
-/// When `credential_storage = "os_store"`, keys are stored in the OS credential
-/// store and `api_key` is `None` in the TOML.
-///
-/// OAuth profiles always use `credential_storage = "os_store"`; tokens are stored
-/// in the OS keyring and never written to the profile TOML.
+/// `credential_storage` selects where secrets live for both auth modes:
+///   - `"file"` (default): API keys / OAuth tokens are written inline in the
+///     TOML, which is created with `0600` permissions.
+///   - `"os_store"`: secrets are stored in the OS credential store
+///     (macOS Keychain, Windows Credential Manager, etc.) and the inline
+///     fields are absent from the TOML.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Profile {
     /// Authentication method for this profile.
     /// Defaults to `ApiKey` so that existing profiles without this field continue to work.
     #[serde(default)]
     pub auth: AuthKind,
-    /// Where API keys for this profile are stored.
+    /// Where credentials for this profile are stored (applies to both API keys
+    /// and OAuth tokens).
     #[serde(default)]
     pub credential_storage: CredentialStorage,
-    /// Coralogix API key. Present when `credential_storage = "file"`.
+    /// Coralogix API key. Present when `auth = "api_key"` and
+    /// `credential_storage = "file"`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub api_key: Option<String>,
     pub region: Region,
@@ -256,6 +274,10 @@ pub struct Profile {
     /// When `None`, `region.api_endpoint()` is used.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub oauth_base_url: Option<String>,
+    /// OAuth: cached token set. Present only when `auth = "oauth"` and
+    /// `credential_storage = "file"`. For `os_store`, tokens live in the OS keyring.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub oauth_tokens: Option<StoredOAuthTokens>,
     /// Per-profile default output format. When set, takes precedence over the
     /// global `default_output_format` in config.toml.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -413,12 +435,12 @@ async fn resolve_single(
                 let region_name = profile.region.to_string();
                 let base_url = profile
                     .oauth_base_url
-                    .as_deref()
-                    .unwrap_or_else(|| profile.region.api_endpoint());
+                    .clone()
+                    .unwrap_or_else(|| profile.region.api_endpoint().to_string());
                 let client_id = profile
                     .oauth_client_id
-                    .as_deref()
-                    .or_else(|| oauth::client_id_for_region(&region_name))
+                    .clone()
+                    .or_else(|| oauth::client_id_for_region(&region_name).map(str::to_string))
                     .ok_or_else(|| {
                         anyhow::anyhow!(
                             "No OAuth client ID configured for profile '{profile_name}' \
@@ -426,7 +448,21 @@ async fn resolve_single(
                              Run `cx profiles add {profile_name}` to reconfigure."
                         )
                     })?;
-                oauth::resolve_token(profile_name, base_url, client_id).await?
+                let storage = profile.credential_storage;
+                let (bearer, refreshed) = oauth::resolve_token(
+                    profile_name,
+                    &base_url,
+                    &client_id,
+                    storage,
+                    profile.oauth_tokens.as_ref(),
+                )
+                .await?;
+                if let Some(new_tokens) = refreshed {
+                    // File-storage profile: persist refreshed tokens back to disk.
+                    profile.oauth_tokens = Some(new_tokens);
+                    save_profile(profile_name, &profile)?;
+                }
+                bearer
             }
         }
     };
@@ -678,6 +714,7 @@ api_key = "mykey"
             label: Some("prod".to_string()),
             oauth_client_id: None,
             oauth_base_url: None,
+            oauth_tokens: None,
             default_output_format: None,
         };
         let toml = toml::to_string_pretty(&profile).unwrap();
@@ -687,6 +724,36 @@ api_key = "mykey"
         assert!(restored.api_key.is_none());
         // oauth_client_id / oauth_base_url are skip_serializing_if = None, so absent
         assert!(restored.oauth_client_id.is_none());
+        assert!(restored.oauth_tokens.is_none());
+    }
+
+    /// OAuth profile with file-stored tokens round-trips through TOML.
+    #[test]
+    fn oauth_profile_file_storage_round_trips() {
+        let profile = Profile {
+            auth: AuthKind::OAuth,
+            credential_storage: CredentialStorage::File,
+            api_key: None,
+            region: Region::Eu2,
+            label: Some("prod".to_string()),
+            oauth_client_id: None,
+            oauth_base_url: None,
+            oauth_tokens: Some(StoredOAuthTokens {
+                access_token: "access-abc".to_string(),
+                refresh_token: Some("refresh-xyz".to_string()),
+                id_token: None,
+                expiry: Some(1_700_000_000),
+            }),
+            default_output_format: None,
+        };
+        let toml = toml::to_string_pretty(&profile).unwrap();
+        let restored: Profile = toml::from_str(&toml).unwrap();
+        assert_eq!(restored.credential_storage, CredentialStorage::File);
+        let tokens = restored.oauth_tokens.expect("oauth_tokens persisted");
+        assert_eq!(tokens.access_token, "access-abc");
+        assert_eq!(tokens.refresh_token.as_deref(), Some("refresh-xyz"));
+        assert!(tokens.id_token.is_none());
+        assert_eq!(tokens.expiry, Some(1_700_000_000));
     }
 
     /// Custom OAuth profile (with explicit client ID) round-trips.
@@ -700,6 +767,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: Some("abc-123".to_string()),
             oauth_base_url: None,
+            oauth_tokens: None,
             default_output_format: None,
         };
         let toml = toml::to_string_pretty(&profile).unwrap();
@@ -763,6 +831,7 @@ api_key = "mykey"
                 label: None,
                 oauth_client_id: None,
                 oauth_base_url: None,
+                oauth_tokens: None,
                 default_output_format: None,
             };
             save_profile(name, &profile).unwrap();
@@ -798,6 +867,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            oauth_tokens: None,
             default_output_format: None,
         };
         save_profile("default", &profile).unwrap();
@@ -819,6 +889,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            oauth_tokens: None,
             default_output_format: None,
         };
         save_profile(name, &profile).unwrap();
@@ -841,6 +912,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            oauth_tokens: None,
             default_output_format: None,
         };
         save_profile(name, &profile).unwrap();
@@ -863,6 +935,7 @@ api_key = "mykey"
             label: None,
             oauth_client_id: None,
             oauth_base_url: None,
+            oauth_tokens: None,
             default_output_format: None,
         };
         save_profile(name, &profile).unwrap();

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -6,7 +6,8 @@
 //!   - Callback HTTP listener on a randomised port from a fixed allow-list
 //!   - Authorization code exchange
 //!   - Token refresh
-//!   - Keyring-backed token persistence
+//!   - Token persistence in either the OS keyring or the profile TOML
+//!     (selected by `Profile::credential_storage`)
 
 use anyhow::{bail, Context, Result};
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
@@ -18,6 +19,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::{TcpListener, TcpStream};
 use std::time::Duration;
 
+use crate::config::{CredentialStorage, StoredOAuthTokens};
 use crate::keyring_store;
 
 // ── Constants ─────────────────────────────────────────────────────────────────
@@ -104,6 +106,15 @@ pub fn client_id_for_region(region_name: &str) -> Option<&'static str> {
         .map(|e| e.client_id)
 }
 
+/// Current Unix timestamp in seconds. The system clock is assumed to be after
+/// 1970; if it isn't, OAuth refresh wouldn't work anyway.
+fn unix_now_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
+}
+
 /// Seconds until the JWT access token expires (`> 0` = still valid, `< 0` = expired).
 /// Returns `None` when the JWT structure or `exp` claim is not parseable.
 pub fn token_seconds_remaining(access_token: &str) -> Option<i64> {
@@ -114,11 +125,7 @@ pub fn token_seconds_remaining(access_token: &str) -> Option<i64> {
     let payload = URL_SAFE_NO_PAD.decode(parts[1]).ok()?;
     let json: serde_json::Value = serde_json::from_slice(&payload).ok()?;
     let exp = json.get("exp")?.as_u64()?;
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_secs();
-    Some(exp as i64 - now as i64)
+    Some(exp as i64 - unix_now_secs() as i64)
 }
 
 // ── OAuth protocol helpers ────────────────────────────────────────────────────
@@ -375,11 +382,26 @@ pub async fn browser_login(base_url: &str, client_id: &str) -> Result<TokenRespo
     .await
 }
 
+/// Convert a freshly received `TokenResponse` into the form persisted in the
+/// profile TOML when `credential_storage = "file"`.
+///
+/// `expiry` is computed from `expires_in` when present. When absent, it stays
+/// `None` and `resolve_token` falls back to parsing the JWT `exp` claim.
+pub fn tokens_to_stored(tokens: &TokenResponse) -> StoredOAuthTokens {
+    let expiry = tokens.expires_in.map(|exp_in| unix_now_secs() + exp_in);
+    StoredOAuthTokens {
+        access_token: tokens.access_token.clone(),
+        refresh_token: tokens.refresh_token.clone(),
+        id_token: tokens.id_token.clone(),
+        expiry,
+    }
+}
+
 /// Persist an OAuth token set to the OS keyring for `profile`.
 ///
 /// Stores: `oauth_access_token`, `oauth_refresh_token`, `oauth_id_token`,
 /// `oauth_token_expiry` (Unix timestamp, computed from `expires_in`).
-pub fn store_tokens(profile: &str, tokens: &TokenResponse) -> Result<()> {
+pub fn store_tokens_keyring(profile: &str, tokens: &TokenResponse) -> Result<()> {
     keyring_store::store_secret(profile, "oauth_access_token", &tokens.access_token)?;
     if let Some(ref rt) = tokens.refresh_token {
         keyring_store::store_secret(profile, "oauth_refresh_token", rt)?;
@@ -391,56 +413,75 @@ pub fn store_tokens(profile: &str, tokens: &TokenResponse) -> Result<()> {
     // When absent, `resolve_token` falls back to parsing the JWT `exp` claim directly.
     // Storing a sentinel `0` would make every cached token appear permanently expired.
     if let Some(exp_in) = tokens.expires_in {
-        let expiry = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            + exp_in;
+        let expiry = unix_now_secs() + exp_in;
         keyring_store::store_secret(profile, "oauth_token_expiry", &expiry.to_string())?;
     }
     Ok(())
 }
 
+fn cached_token_is_valid(token: &str, expiry: Option<u64>) -> bool {
+    if let Some(exp) = expiry {
+        exp > unix_now_secs() + 30
+    } else {
+        token_seconds_remaining(token)
+            .map(|s| s > 30)
+            .unwrap_or(false)
+    }
+}
+
 /// Resolve a usable bearer token for an OAuth profile.
 ///
-/// Returns the cached access token if it is still valid (≥ 30 s remaining).
-/// Otherwise, uses the stored refresh token to obtain a fresh token set,
-/// persists the new tokens, and returns the new access token.
+/// Reads the cached access token from the chosen storage backend and returns it
+/// if it is still valid (≥ 30 s remaining). Otherwise, uses the cached refresh
+/// token to obtain a fresh token set.
+///
+/// For `OsStore`, the keyring is updated in place and the returned
+/// `Option<StoredOAuthTokens>` is always `None`. For `File`, the caller is
+/// responsible for persisting the returned `Some(StoredOAuthTokens)` to the
+/// profile TOML when a refresh occurred.
 ///
 /// Errors with an actionable message when re-authentication is required.
-pub async fn resolve_token(profile_name: &str, base_url: &str, client_id: &str) -> Result<String> {
-    let access_token = keyring_store::get_secret(profile_name, "oauth_access_token")?;
-
-    let is_valid = if let Some(ref token) = access_token {
-        let expiry = keyring_store::get_secret(profile_name, "oauth_token_expiry")?
-            .and_then(|s| s.parse::<u64>().ok());
-        if let Some(exp) = expiry {
-            let now = std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .unwrap()
-                .as_secs();
-            exp > now + 30
-        } else {
-            // Fall back to parsing the JWT's `exp` claim.
-            token_seconds_remaining(token)
-                .map(|s| s > 30)
-                .unwrap_or(false)
+pub async fn resolve_token(
+    profile_name: &str,
+    base_url: &str,
+    client_id: &str,
+    storage: CredentialStorage,
+    file_tokens: Option<&StoredOAuthTokens>,
+) -> Result<(String, Option<StoredOAuthTokens>)> {
+    let (cached_access, cached_expiry, cached_refresh) = match storage {
+        CredentialStorage::OsStore => (
+            keyring_store::get_secret(profile_name, "oauth_access_token")?,
+            keyring_store::get_secret(profile_name, "oauth_token_expiry")?
+                .and_then(|s| s.parse::<u64>().ok()),
+            keyring_store::get_secret(profile_name, "oauth_refresh_token")?,
+        ),
+        CredentialStorage::File => {
+            let t = file_tokens.ok_or_else(|| {
+                anyhow::anyhow!(
+                    "OAuth tokens missing for profile '{profile_name}'.\n\
+                     Run `cx profiles add {profile_name}` to re-authenticate."
+                )
+            })?;
+            (
+                Some(t.access_token.clone()),
+                t.expiry,
+                t.refresh_token.clone(),
+            )
         }
-    } else {
-        false
     };
 
-    if is_valid {
-        return Ok(access_token.unwrap());
+    if let Some(ref token) = cached_access {
+        if cached_token_is_valid(token, cached_expiry) {
+            return Ok((token.clone(), None));
+        }
     }
 
-    let refresh_token = keyring_store::get_secret(profile_name, "oauth_refresh_token")?
-        .ok_or_else(|| {
-            anyhow::anyhow!(
-                "OAuth session expired for profile '{profile_name}'.\n\
-                 Run `cx profiles add {profile_name}` to re-authenticate."
-            )
-        })?;
+    let refresh_token = cached_refresh.ok_or_else(|| {
+        anyhow::anyhow!(
+            "OAuth session expired for profile '{profile_name}'.\n\
+             Run `cx profiles add {profile_name}` to re-authenticate."
+        )
+    })?;
 
     let oidc = fetch_openid_config(base_url).await.with_context(|| {
         format!(
@@ -457,6 +498,126 @@ pub async fn resolve_token(profile_name: &str, base_url: &str, client_id: &str) 
             )
         })?;
 
-    store_tokens(profile_name, &tokens)?;
-    Ok(tokens.access_token)
+    match storage {
+        CredentialStorage::OsStore => {
+            store_tokens_keyring(profile_name, &tokens)?;
+            Ok((tokens.access_token, None))
+        }
+        CredentialStorage::File => {
+            let stored = tokens_to_stored(&tokens);
+            Ok((tokens.access_token, Some(stored)))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_token_response(expires_in: Option<u64>, refresh: Option<&str>) -> TokenResponse {
+        TokenResponse {
+            access_token: "access-abc".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in,
+            refresh_token: refresh.map(str::to_string),
+            id_token: Some("id-xyz".to_string()),
+            scope: None,
+        }
+    }
+
+    #[test]
+    fn tokens_to_stored_sets_expiry_when_expires_in_present() {
+        let before = unix_now_secs();
+        let stored = tokens_to_stored(&sample_token_response(Some(3600), Some("refresh-1")));
+        let after = unix_now_secs();
+
+        let expiry = stored.expiry.expect("expiry computed from expires_in");
+        assert!(expiry >= before + 3600 && expiry <= after + 3600);
+        assert_eq!(stored.access_token, "access-abc");
+        assert_eq!(stored.refresh_token.as_deref(), Some("refresh-1"));
+        assert_eq!(stored.id_token.as_deref(), Some("id-xyz"));
+    }
+
+    #[test]
+    fn tokens_to_stored_leaves_expiry_none_when_expires_in_absent() {
+        let stored = tokens_to_stored(&sample_token_response(None, None));
+        assert!(stored.expiry.is_none());
+        assert!(stored.refresh_token.is_none());
+    }
+
+    #[test]
+    fn cached_token_is_valid_uses_expiry_when_present() {
+        let now = unix_now_secs();
+        // 5 minutes left -> valid.
+        assert!(cached_token_is_valid("ignored", Some(now + 300)));
+        // Inside the 30 s skew window -> not valid.
+        assert!(!cached_token_is_valid("ignored", Some(now + 10)));
+        // Already expired.
+        assert!(!cached_token_is_valid("ignored", Some(now - 1)));
+    }
+
+    #[test]
+    fn cached_token_is_valid_falls_back_to_jwt_exp_without_expiry() {
+        // Token is not a JWT and there's no separate expiry -> conservatively invalid.
+        assert!(!cached_token_is_valid("not-a-jwt", None));
+    }
+
+    #[tokio::test]
+    async fn resolve_token_file_mode_errors_when_tokens_missing() {
+        let err = resolve_token(
+            "myprofile",
+            "https://example.invalid",
+            "client-id",
+            CredentialStorage::File,
+            None,
+        )
+        .await
+        .expect_err("missing file_tokens must error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("OAuth tokens missing"), "got: {msg}");
+        assert!(msg.contains("myprofile"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn resolve_token_file_mode_returns_cached_when_valid() {
+        let tokens = StoredOAuthTokens {
+            access_token: "still-good".to_string(),
+            refresh_token: Some("refresh".to_string()),
+            id_token: None,
+            expiry: Some(unix_now_secs() + 600),
+        };
+        // base_url is never contacted because the cached token is valid.
+        let (bearer, refreshed) = resolve_token(
+            "myprofile",
+            "https://example.invalid",
+            "client-id",
+            CredentialStorage::File,
+            Some(&tokens),
+        )
+        .await
+        .expect("cached path must not hit the network");
+        assert_eq!(bearer, "still-good");
+        assert!(refreshed.is_none());
+    }
+
+    #[tokio::test]
+    async fn resolve_token_file_mode_errors_when_expired_without_refresh() {
+        let tokens = StoredOAuthTokens {
+            access_token: "expired".to_string(),
+            refresh_token: None,
+            id_token: None,
+            expiry: Some(unix_now_secs() - 1),
+        };
+        let err = resolve_token(
+            "myprofile",
+            "https://example.invalid",
+            "client-id",
+            CredentialStorage::File,
+            Some(&tokens),
+        )
+        .await
+        .expect_err("expired access + no refresh token must error");
+        let msg = format!("{err:#}");
+        assert!(msg.contains("OAuth session expired"), "got: {msg}");
+    }
 }


### PR DESCRIPTION
## Summary
- OAuth profiles can now persist tokens either inline in the profile TOML (`credential_storage = "file"`, the new default) or in the OS keyring (`os_store`), mirroring the existing API-key flow. `cx profiles add` prompts for the choice.
- Adds `StoredOAuthTokens` to the profile schema (`access_token`, `refresh_token`, `id_token`, `expiry`), serialized inline only when `credential_storage = "file"` and skipped otherwise. File-mode profile TOMLs are still written with `0600` perms.
- `oauth::resolve_token` now takes the chosen storage backend and any cached file tokens, and returns refreshed tokens to the caller so `resolve_single` can persist them back to disk after a refresh. Keyring path is unchanged in behavior.
- Refactors: extracted `unix_now_secs()` helper (replaces 4 inline `SystemTime` calls); replaced the `&[&str]` storage-options array + `starts_with` lookup with a paired `&[(&str, CredentialStorage)]` table and a `select_credential_storage()` helper used by both configure paths.
- Tests: 7 new unit tests in `oauth.rs` covering `tokens_to_stored` (with/without `expires_in`), `cached_token_is_valid` (expiry path + JWT-fallback path), and three `resolve_token` File-mode paths (cached-valid no-network, missing-tokens error, expired-no-refresh error). New TOML round-trip test for OAuth profiles with file-stored tokens.
- Docs: `docs/configuration.md` updated (quick-start example output, OAuth section, profile-fields table, new file-storage example with sample `[oauth_tokens]`); `README.md` credential-storage paragraph rewritten.

## Test plan
- [x] `cargo test --lib` (286 + 7 new = 293 passing)
- [x] `cargo fmt`
- [x] `cargo clippy --lib` clean
- [ ] Manual: `cx profiles add` -> OAuth -> pick `file` -> verify TOML contains `[oauth_tokens]`, run a query, force token expiry, verify refresh updates the file in place
- [ ] Manual: `cx profiles add` -> OAuth -> pick `os-store` -> verify TOML has no `[oauth_tokens]`, refresh still works against keyring
- [ ] Manual: re-add an existing profile and switch storage backend in both directions; verify no stale state in keyring or TOML

## Known follow-up
- Concurrent `cx` invocations on the same file-mode OAuth profile can race when both find the access token expired and both refresh; the loser's rotated refresh token gets clobbered by the non-atomic `fs::write` in `save_profile`. Low likelihood in normal interactive use, more plausible under fan-out / scripts. Worth a follow-up to use atomic rename or a file lock.
- If the IdP omits `refresh_token` from a refresh response (some don't rotate), both backends currently lose the cached refresh token. Pre-existing bug for the keyring path; file path inherits it.