### PR TITLE
fix: support complex search field paths

### DIFF
--- a/src/commands/dataprime/semantic_search.rs
+++ b/src/commands/dataprime/semantic_search.rs
@@ -156,8 +156,7 @@ fn is_complex_key(key: &str) -> bool {
         return true;
     };
 
-    !(matches!(first, 'a'..='z' | 'A'..='Z')
-        && chars.all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_')))
+    !(first.is_ascii_alphabetic() && chars.all(|c| c.is_ascii_alphanumeric() || c == '_'))
 }
 
 fn stringify_path_key(key: &str) -> String {

--- a/src/commands/dataprime/semantic_search.rs
+++ b/src/commands/dataprime/semantic_search.rs
@@ -97,7 +97,7 @@ pub async fn semantic_field_lookup(
             }
             let top_level_key = first.clone();
             let path = r.path_array[1..].to_vec();
-            let dataprime_path = serialize_path_for_query(&r.path_array);
+            let dataprime_path = serialize_path_for_query(&r.path_array)?;
             Some(SemanticFieldResult {
                 dataprime_path,
                 top_level_key,
@@ -129,6 +129,84 @@ pub async fn semantic_metric_lookup(
     Ok(parsed.results)
 }
 
-fn serialize_path_for_query(path_array: &[String]) -> String {
-    path_array.join(".")
+fn serialize_path_for_query(path_array: &[String]) -> Option<String> {
+    let prefix = path_array.first()?;
+    if !matches!(prefix.as_str(), "$d" | "$m" | "$l") {
+        return None;
+    }
+
+    let mut path = prefix.clone();
+    for key in &path_array[1..] {
+        if is_complex_key(key) {
+            path.push_str("['");
+            path.push_str(&stringify_path_key(key));
+            path.push_str("']");
+        } else {
+            path.push('.');
+            path.push_str(key);
+        }
+    }
+
+    Some(path)
+}
+
+fn is_complex_key(key: &str) -> bool {
+    let mut chars = key.chars();
+    let Some(first) = chars.next() else {
+        return true;
+    };
+
+    !(matches!(first, 'a'..='z' | 'A'..='Z')
+        && chars.all(|c| matches!(c, 'a'..='z' | 'A'..='Z' | '0'..='9' | '_')))
+}
+
+fn stringify_path_key(key: &str) -> String {
+    key.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn path(parts: &[&str]) -> Vec<String> {
+        parts.iter().map(|part| (*part).to_string()).collect()
+    }
+
+    #[test]
+    fn serializes_simple_path_with_dot_notation() {
+        assert_eq!(
+            serialize_path_for_query(&path(&["$d", "http", "status_code"])).as_deref(),
+            Some("$d.http.status_code")
+        );
+    }
+
+    #[test]
+    fn serializes_complex_keys_with_bracket_notation() {
+        assert_eq!(
+            serialize_path_for_query(&path(&["$d", "resource.type", "service name", "_id"]))
+                .as_deref(),
+            Some("$d['resource.type']['service name']['_id']")
+        );
+    }
+
+    #[test]
+    fn treats_letter_prefixed_keys_as_simple() {
+        assert_eq!(
+            serialize_path_for_query(&path(&["$l", "service_1"])).as_deref(),
+            Some("$l.service_1")
+        );
+    }
+
+    #[test]
+    fn escapes_complex_key_literals() {
+        assert_eq!(
+            serialize_path_for_query(&path(&["$d", "service's", r"path\key"])).as_deref(),
+            Some(r"$d['service\'s']['path\\key']")
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_top_level_prefix() {
+        assert_eq!(serialize_path_for_query(&path(&["$x", "field"])), None);
+    }
 }

--- a/tests/search_fields/main.rs
+++ b/tests/search_fields/main.rs
@@ -5,6 +5,7 @@ use serde_json::json;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+use coralogix_cli::commands::dataprime::semantic_search::semantic_field_lookup;
 use coralogix_cli::commands::search_fields;
 use coralogix_cli::config::OutputFormat;
 
@@ -71,6 +72,41 @@ async fn semantic_field_search_empty_results() {
     )
     .await
     .expect("search_fields with no results should succeed");
+}
+
+#[tokio::test]
+async fn semantic_field_lookup_serializes_complex_paths() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "results": [
+            {
+                "path_array": ["$d", "resource.type", "service name"],
+                "description": "Resource service name",
+                "similarity_score": 0.91,
+                "dataset_scope": null,
+                "labels": {}
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/semantic-search/fields"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let results = semantic_field_lookup(&target.client, "service name", "logs", 10)
+        .await
+        .expect("semantic_field_lookup should succeed");
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(
+        results[0].dataprime_path,
+        "$d['resource.type']['service name']"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Fixes AGE-863 by serializing semantic search `path_array` values as valid DataPrime paths.
- Uses bracket notation for complex keys and escapes quoted/backslash key literals.
- Adds unit and integration coverage for simple, complex, escaped, and invalid path prefixes.

## Linear
- https://linear.app/coralogix/issue/AGE-863/fix-search-fields-support-for-complex-key-paths

## Test plan
- `cargo fmt`
- `cargo test --lib semantic_search::tests`
- `cargo test --test search_fields`

Made with [Cursor](https://cursor.com)