### PR TITLE
feat: add global config guards for risky, costly, and read-only commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "coralogix-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Coralogix CLI - the observability backbone for AI agents and engineering teams."
 repository = "https://github.com/coralogix/cx-cli"

--- a/README.md
+++ b/README.md
@@ -48,12 +48,6 @@ curl -fsSL https://get.coralogix.dev/cli | sh
 brew install coralogix/tap/cx
 ```
 
-#### Works on macOS and Linux: install script
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/coralogix/cx-cli/master/install.sh | sh
-```
-
 ### 2. Install agent skills
 
 Skills teach your AI agent how to use `cx` for observability investigations.

--- a/src/commands/profiles/mod.rs
+++ b/src/commands/profiles/mod.rs
@@ -167,6 +167,7 @@ pub fn run_list() -> Result<()> {
 
 pub async fn run_add(profile_name: Option<String>) -> Result<()> {
     let name = profile_name.unwrap_or_else(|| "default".to_string());
+    let is_first_profile = list_profile_names()?.is_empty();
 
     println!("Configuring profile '{name}'\n");
 
@@ -206,6 +207,31 @@ pub async fn run_add(profile_name: Option<String>) -> Result<()> {
     });
 
     save_profile(&name, &profile)?;
+
+    // On first profile creation, prompt for global safety settings.
+    if is_first_profile {
+        println!("\n─── Global Safety Settings ───");
+        println!("These apply to all profiles. Change later in ~/.cx/config.toml\n");
+
+        let mut global_config = load_config().unwrap_or_default();
+
+        global_config.allow_risky_commands =
+            Confirm::new("Allow risky commands? (iam, archive write operations)")
+                .with_default(true)
+                .with_help_message(
+                    "When disabled, write operations under 'iam' and 'archive' are blocked. \
+             Read operations remain available.",
+                )
+                .prompt()?;
+
+        global_config.allow_costly_commands =
+            Confirm::new("Allow costly commands? (olly ask — AI assistant queries)")
+                .with_default(true)
+                .with_help_message("When disabled, 'olly ask' is blocked.")
+                .prompt()?;
+
+        save_config(&global_config)?;
+    }
 
     let cx_dir = crate::config::config_dir()?;
     println!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,6 +166,21 @@ pub struct Config {
     #[serde(default = "default_temp_dir")]
     pub temp_dir: String,
 
+    /// Whether to allow risky commands (iam, archive write operations).
+    /// When false, write operations under these commands are hard-blocked.
+    #[serde(default = "default_true")]
+    pub allow_risky_commands: bool,
+
+    /// Whether to allow costly commands (olly ask).
+    /// When false, these commands are hard-blocked.
+    #[serde(default = "default_true")]
+    pub allow_costly_commands: bool,
+
+    /// When true, ALL write operations are blocked globally.
+    /// Equivalent to always passing --read-only.
+    #[serde(default)]
+    pub read_only: bool,
+
     /// Shell completion scripts installed and tracked by `cx completions install`.
     /// Only files recorded here are touched by `cx completions refresh`.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -174,6 +189,10 @@ pub struct Config {
 
 fn default_profile() -> String {
     "default".to_string()
+}
+
+fn default_true() -> bool {
+    true
 }
 
 fn default_max_dataprime_direct_output_size() -> Option<usize> {
@@ -191,6 +210,9 @@ impl Default for Config {
             default_output_format: OutputFormat::default(),
             max_dataprime_direct_output_size: default_max_dataprime_direct_output_size(),
             temp_dir: default_temp_dir(),
+            allow_risky_commands: true,
+            allow_costly_commands: true,
+            read_only: false,
             managed_completions: vec![],
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -317,6 +317,10 @@ pub struct ResolvedConfig {
 
 /// Returns the cx config directory: `~/.cx/`
 pub fn config_dir() -> Result<PathBuf> {
+    // CX_HOME overrides the home directory for testing and non-standard setups.
+    if let Ok(cx_home) = std::env::var("CX_HOME") {
+        return Ok(PathBuf::from(cx_home).join(".cx"));
+    }
     let home = dirs::home_dir().context("Could not determine home directory")?;
     Ok(home.join(".cx"))
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -526,6 +526,19 @@ Examples:
     },
 }
 
+impl Commands {
+    fn is_risky(&self) -> bool {
+        matches!(self, Self::Iam { .. } | Self::DataArchive { .. })
+    }
+
+    fn is_costly(&self) -> bool {
+        match self {
+            Self::Olly { cmd } => matches!(cmd, OllyCmd::Ask { .. }),
+            _ => false,
+        }
+    }
+}
+
 #[derive(Subcommand)]
 enum ProfilesCmd {
     /// List all configured profiles.
@@ -2155,7 +2168,11 @@ async fn main() -> Result<()> {
     let matches = cmd.get_matches();
     let cli = Cli::from_arg_matches(&matches)?;
 
-    let read_only = cli.read_only || safety::env_is_truthy("CX_READ_ONLY");
+    // Load global config early for read-only / risky / costly gating.
+    let global_cfg_early = config::load_config().unwrap_or_default();
+
+    let read_only =
+        cli.read_only || safety::env_is_truthy("CX_READ_ONLY") || global_cfg_early.read_only;
     if read_only {
         let top = safety::get_top_level_subcommand_name(&matches);
         let is_local = matches!(
@@ -2167,6 +2184,26 @@ async fn main() -> Result<()> {
                 safety::enforce_read_only(&leaf)?;
             }
         }
+    }
+
+    // Risky command gating (iam, archive write operations).
+    if cli.command.is_risky() && !global_cfg_early.allow_risky_commands {
+        if let Some(leaf) = safety::get_leaf_subcommand_name(&matches) {
+            if safety::is_write_verb(&leaf) {
+                bail!(
+                    "Risky write operation blocked by global configuration.\n\
+                     Set allow_risky_commands = true in ~/.cx/config.toml to enable."
+                );
+            }
+        }
+    }
+
+    // Costly command gating (olly ask).
+    if cli.command.is_costly() && !global_cfg_early.allow_costly_commands {
+        bail!(
+            "Costly operation blocked by global configuration.\n\
+             Set allow_costly_commands = true in ~/.cx/config.toml to enable."
+        );
     }
 
     // Profiles command is usually handled by the early ProfilesCli parser above,

--- a/src/main.rs
+++ b/src/main.rs
@@ -2201,8 +2201,8 @@ async fn main() -> Result<()> {
     // Costly command gating (olly ask).
     if cli.command.is_costly() && !global_cfg_early.allow_costly_commands {
         bail!(
-            "This operation can potentially incur additional costs and has been \
-             disabled by your global configuration.\n\
+            "This operation may result in additional charges and is currently \
+             disabled in your global configuration.\n\
              To enable it, set allow_costly_commands = true in ~/.cx/config.toml."
         );
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2201,8 +2201,9 @@ async fn main() -> Result<()> {
     // Costly command gating (olly ask).
     if cli.command.is_costly() && !global_cfg_early.allow_costly_commands {
         bail!(
-            "Costly operation blocked by global configuration.\n\
-             Set allow_costly_commands = true in ~/.cx/config.toml to enable."
+            "This operation can potentially incur additional costs and has been \
+             disabled by your global configuration.\n\
+             To enable it, set allow_costly_commands = true in ~/.cx/config.toml."
         );
     }
 

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -57,7 +57,7 @@ pub fn enforce_read_only(verb: &str) -> Result<()> {
     if is_write_verb(verb) {
         bail!(
             "Write operation '{verb}' is blocked in read-only mode \
-             (--read-only flag or CX_READ_ONLY env var)."
+             (--read-only flag, CX_READ_ONLY env var, or read_only = true in ~/.cx/config.toml)."
         );
     }
     Ok(())

--- a/tests/agent_mode/main.rs
+++ b/tests/agent_mode/main.rs
@@ -1,7 +1,21 @@
 use assert_cmd::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+/// Return a fresh temporary directory to use as HOME, so that tests are not
+/// affected by the user's real `~/.cx/config.toml` (which may set `read_only`).
+fn temp_home() -> std::path::PathBuf {
+    let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("cx_agent_test_{}_{id}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
 
 fn cx() -> Command {
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
+    cmd.env("HOME", temp_home());
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE");
     cmd.env_remove("CX_AGENT_MODE");

--- a/tests/agent_mode/main.rs
+++ b/tests/agent_mode/main.rs
@@ -14,8 +14,11 @@ fn temp_home() -> std::path::PathBuf {
 }
 
 fn cx() -> Command {
+    let home = temp_home();
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", temp_home());
+    cmd.env("HOME", &home);
+    #[cfg(windows)]
+    cmd.env("USERPROFILE", &home);
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE");
     cmd.env_remove("CX_AGENT_MODE");

--- a/tests/agent_mode/main.rs
+++ b/tests/agent_mode/main.rs
@@ -14,11 +14,8 @@ fn temp_home() -> std::path::PathBuf {
 }
 
 fn cx() -> Command {
-    let home = temp_home();
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", &home);
-    #[cfg(windows)]
-    cmd.env("USERPROFILE", &home);
+    cmd.env("CX_HOME", temp_home());
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE");
     cmd.env_remove("CX_AGENT_MODE");

--- a/tests/read_only/main.rs
+++ b/tests/read_only/main.rs
@@ -1,7 +1,20 @@
 use assert_cmd::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn temp_home() -> std::path::PathBuf {
+    let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("cx_ro_test_{}_{id}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
 
 fn cx() -> Command {
-    Command::cargo_bin("cx").expect("cx binary should build")
+    let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
+    cmd.env("HOME", temp_home());
+    cmd
 }
 
 #[test]

--- a/tests/read_only/main.rs
+++ b/tests/read_only/main.rs
@@ -12,8 +12,11 @@ fn temp_home() -> std::path::PathBuf {
 }
 
 fn cx() -> Command {
+    let home = temp_home();
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", temp_home());
+    cmd.env("HOME", &home);
+    #[cfg(windows)]
+    cmd.env("USERPROFILE", &home);
     cmd
 }
 

--- a/tests/read_only/main.rs
+++ b/tests/read_only/main.rs
@@ -12,11 +12,8 @@ fn temp_home() -> std::path::PathBuf {
 }
 
 fn cx() -> Command {
-    let home = temp_home();
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", &home);
-    #[cfg(windows)]
-    cmd.env("USERPROFILE", &home);
+    cmd.env("CX_HOME", temp_home());
     cmd
 }
 

--- a/tests/risky_costly_gating/main.rs
+++ b/tests/risky_costly_gating/main.rs
@@ -138,7 +138,7 @@ fn costly_disabled_blocks_olly_ask() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("incur additional costs"),
+        stderr.contains("additional charges"),
         "stderr: {stderr}"
     );
 }
@@ -160,7 +160,7 @@ fn costly_disabled_allows_olly_artifacts() {
         .expect("failed to run cx");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("incur additional costs"),
+        !stderr.contains("additional charges"),
         "artifacts should not be blocked, stderr: {stderr}"
     );
 }
@@ -182,7 +182,7 @@ fn costly_enabled_allows_olly_ask() {
         .expect("failed to run cx");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("incur additional costs"),
+        !stderr.contains("additional charges"),
         "should not be blocked when enabled, stderr: {stderr}"
     );
 }

--- a/tests/risky_costly_gating/main.rs
+++ b/tests/risky_costly_gating/main.rs
@@ -137,10 +137,7 @@ fn costly_disabled_blocks_olly_ask() {
         .expect("failed to run cx");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("additional charges"),
-        "stderr: {stderr}"
-    );
+    assert!(stderr.contains("additional charges"), "stderr: {stderr}");
 }
 
 #[test]

--- a/tests/risky_costly_gating/main.rs
+++ b/tests/risky_costly_gating/main.rs
@@ -14,20 +14,13 @@ fn temp_home() -> PathBuf {
     dir
 }
 
-fn set_home(cmd: &mut Command, home: &std::path::Path) {
-    cmd.env("HOME", home);
-    // On Windows, dirs::home_dir() reads USERPROFILE instead of HOME.
-    #[cfg(windows)]
-    cmd.env("USERPROFILE", home);
-}
-
 fn cx_with_config(home: &std::path::Path, config_toml: &str) -> Command {
     let cx_dir = home.join(".cx");
     fs::create_dir_all(&cx_dir).unwrap();
     fs::write(cx_dir.join("config.toml"), config_toml).unwrap();
 
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    set_home(&mut cmd, home);
+    cmd.env("CX_HOME", home);
     cmd
 }
 
@@ -235,7 +228,7 @@ fn no_config_file_allows_everything() {
     let tmp = temp_home();
     // No config file at all - should default to permissive.
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    set_home(&mut cmd, &tmp);
+    cmd.env("CX_HOME", &tmp);
     let output = cmd
         .args([
             "iam",

--- a/tests/risky_costly_gating/main.rs
+++ b/tests/risky_costly_gating/main.rs
@@ -1,0 +1,257 @@
+use assert_cmd::Command;
+use std::fs;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn temp_home() -> PathBuf {
+    let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    let dir = std::env::temp_dir().join(format!("cx_test_{pid}_{id}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn cx_with_config(home: &std::path::Path, config_toml: &str) -> Command {
+    let cx_dir = home.join(".cx");
+    fs::create_dir_all(&cx_dir).unwrap();
+    fs::write(cx_dir.join("config.toml"), config_toml).unwrap();
+
+    let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
+    cmd.env("HOME", home);
+    cmd
+}
+
+// ── Risky command gating ─────────────────────────────────────────────────────
+
+#[test]
+fn risky_disabled_blocks_iam_write() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "allow_risky_commands = false\n")
+        .args([
+            "iam",
+            "api-keys",
+            "delete",
+            "abc",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Risky write operation blocked"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn risky_disabled_allows_iam_read() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "allow_risky_commands = false\n")
+        .args([
+            "iam",
+            "api-keys",
+            "list",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Risky write operation blocked"),
+        "read command should not be blocked, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn risky_disabled_blocks_archive_write() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "allow_risky_commands = false\n")
+        .args([
+            "archive",
+            "metrics",
+            "enable",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Risky write operation blocked"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn risky_enabled_allows_iam_write() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "allow_risky_commands = true\n")
+        .args([
+            "iam",
+            "api-keys",
+            "delete",
+            "abc",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Risky write operation blocked"),
+        "should not be blocked when enabled, stderr: {stderr}"
+    );
+}
+
+// ── Costly command gating ────────────────────────────────────────────────────
+
+#[test]
+fn costly_disabled_blocks_olly_ask() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "allow_costly_commands = false\n")
+        .args([
+            "olly",
+            "ask",
+            "test question",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Costly operation blocked"),
+        "stderr: {stderr}"
+    );
+}
+
+#[test]
+fn costly_disabled_allows_olly_artifacts() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "allow_costly_commands = false\n")
+        .args([
+            "olly",
+            "artifacts",
+            "list",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Costly operation blocked"),
+        "artifacts should not be blocked, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn costly_enabled_allows_olly_ask() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "allow_costly_commands = true\n")
+        .args([
+            "olly",
+            "ask",
+            "test question",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Costly operation blocked"),
+        "should not be blocked when enabled, stderr: {stderr}"
+    );
+}
+
+// ── Read-only config gating ──────────────────────────────────────────────────
+
+#[test]
+fn read_only_config_blocks_write() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "read_only = true\n")
+        .args([
+            "alerts",
+            "create",
+            "--from-file",
+            "x.json",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("read-only mode"), "stderr: {stderr}");
+}
+
+#[test]
+fn read_only_config_allows_read() {
+    let tmp = temp_home();
+    let output = cx_with_config(&tmp, "read_only = true\n")
+        .args(["alerts", "list", "--api-key", "fake", "--region", "us1"])
+        .output()
+        .expect("failed to run cx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("read-only mode"),
+        "read command should not be blocked, stderr: {stderr}"
+    );
+}
+
+// ── Default behavior (no config) ─────────────────────────────────────────────
+
+#[test]
+fn no_config_file_allows_everything() {
+    let tmp = temp_home();
+    // No config file at all - should default to permissive.
+    let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
+    cmd.env("HOME", &tmp);
+    let output = cmd
+        .args([
+            "iam",
+            "api-keys",
+            "delete",
+            "abc",
+            "--api-key",
+            "fake",
+            "--region",
+            "us1",
+        ])
+        .output()
+        .expect("failed to run cx");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Risky write operation blocked"),
+        "should not be blocked without config, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("read-only mode"),
+        "should not be read-only without config, stderr: {stderr}"
+    );
+}

--- a/tests/risky_costly_gating/main.rs
+++ b/tests/risky_costly_gating/main.rs
@@ -14,13 +14,20 @@ fn temp_home() -> PathBuf {
     dir
 }
 
+fn set_home(cmd: &mut Command, home: &std::path::Path) {
+    cmd.env("HOME", home);
+    // On Windows, dirs::home_dir() reads USERPROFILE instead of HOME.
+    #[cfg(windows)]
+    cmd.env("USERPROFILE", home);
+}
+
 fn cx_with_config(home: &std::path::Path, config_toml: &str) -> Command {
     let cx_dir = home.join(".cx");
     fs::create_dir_all(&cx_dir).unwrap();
     fs::write(cx_dir.join("config.toml"), config_toml).unwrap();
 
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", home);
+    set_home(&mut cmd, home);
     cmd
 }
 
@@ -228,7 +235,7 @@ fn no_config_file_allows_everything() {
     let tmp = temp_home();
     // No config file at all - should default to permissive.
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", &tmp);
+    set_home(&mut cmd, &tmp);
     let output = cmd
         .args([
             "iam",

--- a/tests/risky_costly_gating/main.rs
+++ b/tests/risky_costly_gating/main.rs
@@ -138,7 +138,7 @@ fn costly_disabled_blocks_olly_ask() {
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Costly operation blocked"),
+        stderr.contains("incur additional costs"),
         "stderr: {stderr}"
     );
 }
@@ -160,7 +160,7 @@ fn costly_disabled_allows_olly_artifacts() {
         .expect("failed to run cx");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("Costly operation blocked"),
+        !stderr.contains("incur additional costs"),
         "artifacts should not be blocked, stderr: {stderr}"
     );
 }
@@ -182,7 +182,7 @@ fn costly_enabled_allows_olly_ask() {
         .expect("failed to run cx");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("Costly operation blocked"),
+        !stderr.contains("incur additional costs"),
         "should not be blocked when enabled, stderr: {stderr}"
     );
 }

--- a/tests/write_command_gating/main.rs
+++ b/tests/write_command_gating/main.rs
@@ -1,7 +1,19 @@
 use assert_cmd::Command;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn temp_home() -> std::path::PathBuf {
+    let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let dir = std::env::temp_dir().join(format!("cx_wgate_test_{}_{id}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
 
 fn cx_agent(args: &[&str]) -> (bool, String) {
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
+    cmd.env("HOME", temp_home());
     cmd.env("CX_AGENT_MODE", "1");
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE");

--- a/tests/write_command_gating/main.rs
+++ b/tests/write_command_gating/main.rs
@@ -12,11 +12,8 @@ fn temp_home() -> std::path::PathBuf {
 }
 
 fn cx_agent(args: &[&str]) -> (bool, String) {
-    let home = temp_home();
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", &home);
-    #[cfg(windows)]
-    cmd.env("USERPROFILE", &home);
+    cmd.env("CX_HOME", temp_home());
     cmd.env("CX_AGENT_MODE", "1");
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE");

--- a/tests/write_command_gating/main.rs
+++ b/tests/write_command_gating/main.rs
@@ -12,8 +12,11 @@ fn temp_home() -> std::path::PathBuf {
 }
 
 fn cx_agent(args: &[&str]) -> (bool, String) {
+    let home = temp_home();
     let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
-    cmd.env("HOME", temp_home());
+    cmd.env("HOME", &home);
+    #[cfg(windows)]
+    cmd.env("USERPROFILE", &home);
     cmd.env("CX_AGENT_MODE", "1");
     cmd.env_remove("CLAUDECODE");
     cmd.env_remove("CLAUDE_CODE");


### PR DESCRIPTION
## Summary
- Add three new global config fields to `~/.cx/config.toml`: `allow_risky_commands`, `allow_costly_commands`, and `read_only`
- `allow_risky_commands` (default: true) — when false, blocks write operations under `iam` and `archive` commands while still allowing reads
- `allow_costly_commands` (default: true) — when false, blocks `olly ask` (AI assistant queries)
- `read_only` (default: false) — when true, blocks ALL write operations globally (persistent equivalent of `--read-only` flag)
- Command categories defined via `is_risky()`/`is_costly()` methods on the `Commands` enum — tags live with the command definition, not in hardcoded arrays
- First profile creation (`cx profiles add`) prompts for risky/costly settings
- 10 integration tests covering all gating scenarios

## Test plan
- [x] `cargo fmt` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all tests pass (including 10 new integration tests)
- [ ] Manual: verify first-profile prompt flow with `HOME=/tmp/test-cx cx profiles add`
- [ ] Manual: verify blocked commands show clear error messages pointing to config.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)