### PR TITLE
ci: agent skills ref CI validation 

### DIFF
--- a/.claude/skills/add-skill/SKILL.md
+++ b/.claude/skills/add-skill/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: add-skill
 description: Use this skill when the user asks to "add a skill", "create a skill", "new skill", "write a skill for", "skill for cx <something>", "add a user-facing skill", "create a SKILL.md", "teach an agent how to use", "agent skill for", "document a command as a skill", "make a skill", "add skill to skills/", "create agent instructions for", "build a skill", or wants to create a new user-facing skill in the skills/ directory that teaches AI agents how to use a cx CLI command. Use this even when the user is following the add-command workflow and reaches the skill creation step.
-version: 0.1.0
 metadata:
+  version: "0.1.0"
   internal: true
 ---
 
@@ -94,7 +94,7 @@ If you're adding a new shared reference:
 
 ## Step 4: Verify
 
-1. **Frontmatter** - `name` matches directory, `description` has 10+ trigger phrases, `version` is `0.1.0`
+1. **Frontmatter** - `name` matches directory, `description` has 10+ trigger phrases, `metadata.version` is `"0.1.0"`
 2. **Body completeness** - has CLI Commands table, workflow steps, key principles, and additional resources (if references exist)
 3. **Reference links** - any `references/` paths in SKILL.md point to files that actually exist
 4. **README updated** - `skills/README.md` has the new row

--- a/.github/workflows/skills.yml
+++ b/.github/workflows/skills.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
     paths:
       - 'skills/**'
+      - '.github/workflows/skills.yml'
       - 'scripts/verify-skills.sh'
       - 'scripts/sync-shared-references.sh'
 
@@ -21,6 +22,27 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install skills-ref
+        run: pip install "skills-ref==0.1.1"
+
+      - name: Validate all skills
+        run: |
+          exit_code=0
+          while IFS= read -r skill_file; do
+            skill_dir=$(dirname "$skill_file")
+            skill_name=$(basename "$skill_dir")
+            echo "Validating $skill_name..."
+            if ! agentskills validate "$skill_dir"; then
+              echo "::error::Skill '$skill_name' failed validation"
+              exit_code=1
+            fi
+          done < <(find skills -name "SKILL.md")
+          exit $exit_code
 
       - name: Verify skills and reference sync
         run: bash scripts/verify-skills.sh

--- a/contributing/adding-a-skill.md
+++ b/contributing/adding-a-skill.md
@@ -37,7 +37,8 @@ Every `SKILL.md` starts with YAML frontmatter:
 ---
 name: cx-your-domain
 description: This skill should be used when the user asks to "verb phrase 1", "verb phrase 2", "verb phrase 3", or wants to <broad intent summary> using the cx CLI.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 ```
 
@@ -45,7 +46,7 @@ version: 0.1.0
 |-------|------------|
 | `name` | kebab-case, matches the directory name |
 | `description` | Trigger phrase list - this is how agents decide when to activate the skill |
-| `version` | Semver, start at `0.1.0` |
+| `metadata.version` | Semver, start at `0.1.0`; keep repo-specific fields under `metadata` so `agentskills validate` accepts the frontmatter |
 
 The `description` field is how agents decide when to activate a skill. Follow the pattern used by existing skills - see `skills/cx-alerts/SKILL.md` and `skills/cx-telemetry-querying/SKILL.md` for examples.
 
@@ -142,7 +143,8 @@ Copy this as a starting point for a single-command skill (`skills/cx-your-domain
 ---
 name: cx-your-domain
 description: This skill should be used when the user asks to "list items", "inspect an item", "check item status", "find items by name", "investigate item issues", "query your-domain data", or wants to interact with YourDomain resources using the cx CLI.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # YourDomain Skill
@@ -192,7 +194,8 @@ description: >
   Use this skill when the user asks to "intent phrase 1", "intent phrase 2",
   "intent phrase 3", "domain term 1", "domain term 2",
   or wants to <broad intent summary>.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Your Workflow Skill
@@ -240,7 +243,7 @@ cx command-b list -o json
 ## Checklist
 
 ### Skill definition
-- [ ] `skills/cx-your-domain/SKILL.md` - valid frontmatter (name, description, version)
+- [ ] `skills/cx-your-domain/SKILL.md` - valid Agent Skills frontmatter (`name`, `description`, `metadata.version`)
 - [ ] Frontmatter `description` includes 10+ trigger phrases covering commands, intents, and synonyms
 - [ ] Body includes CLI Commands table, workflow, and key principles
 
@@ -254,5 +257,6 @@ cx command-b list -o json
 - [ ] `skills/README.md` - new skill added to the "Available Skills" table
 
 ### Verification
-- [ ] `scripts/verify-skills.sh` - all skills pass (frontmatter, triggers, commands, cross-refs, reference sync)
+- [ ] CI runs `agentskills validate` for upstream Agent Skills spec validation
+- [ ] `scripts/verify-skills.sh` - cx-cli-specific checks pass (triggers, commands, cross-refs, reference sync)
 ```

--- a/scripts/verify-skills.sh
+++ b/scripts/verify-skills.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Verify all skills in skills/ for correctness.
-# Checks: frontmatter fields, description length (≤1024 chars), trigger phrase count,
-# command validation, cross-reference validation, and line count.
+# Verify all skills in skills/ for cx-cli-specific conventions.
+# Agent Skills spec conformance is checked separately by `agentskills validate`.
+# Checks: metadata.version, trigger phrase count, command validation,
+# cross-reference validation, line count, and shared-reference sync.
 
 SKILLS_DIR="$(cd "$(dirname "$0")/../skills" && pwd)"
 ERRORS=0
@@ -44,39 +45,33 @@ for skill_dir in "$SKILLS_DIR"/*/; do
 
     echo "Checking: $skill_name"
 
-    # 1. Frontmatter check
-    if head -1 "$skill_file" | grep -q '^---'; then
-        frontmatter=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$skill_file")
-
-        if ! echo "$frontmatter" | grep -q '^name:'; then
-            fail "missing 'name' in frontmatter"
-            skill_errors=$((skill_errors + 1))
-        fi
-        if ! echo "$frontmatter" | grep -q 'description'; then
-            fail "missing 'description' in frontmatter"
-            skill_errors=$((skill_errors + 1))
-        fi
-        if ! echo "$frontmatter" | grep -q '^version:'; then
-            echo "  WARN: missing 'version' in frontmatter"
-        fi
-    else
-        fail "no YAML frontmatter found"
-        skill_errors=$((skill_errors + 1))
+    # 1. Repo metadata check
+    frontmatter=$(awk '/^---$/{n++; next} n==1{print} n>=2{exit}' "$skill_file")
+    if ! echo "$frontmatter" | grep -q '^metadata:' || ! echo "$frontmatter" | grep -q '^  version:'; then
+        echo "  WARN: missing 'metadata.version' in frontmatter"
     fi
 
-    # 2. Description length check (must be ≤1024 characters for Codex compatibility)
-    desc_raw=$(awk '/^description/,/^(version|---)/' "$skill_file" | sed '1s/^description: |//' | sed '$d' | sed 's/^  //')
-    desc_char_count=$(echo "$desc_raw" | wc -c | tr -d ' ')
-    if [ "$desc_char_count" -gt 1024 ]; then
-        fail "description is $desc_char_count characters (max 1024 for Codex)"
-        skill_errors=$((skill_errors + 1))
-    fi
+    # 2. Extract description for cx-cli trigger coverage checks.
+    desc_raw=$(awk '
+        /^---$/ && NR == 1 { next }
+        /^---$/ { exit }
+        /^description:/ {
+            in_desc = 1
+            sub(/^description:[[:space:]]*[>|]?[[:space:]]*/, "")
+            print
+            next
+        }
+        in_desc && /^[A-Za-z0-9_-]+:/ { exit }
+        in_desc {
+            sub(/^  /, "")
+            print
+        }
+    ' "$skill_file")
 
     # 3. Trigger phrase count (quoted strings in description)
     # Some skills use quoted trigger phrases, others use prose descriptions
-    desc_block=$(awk '/^description/,/^(version|---)/' "$skill_file" | sed '$d')
-    phrase_count=$(echo "$desc_block" | { grep -o '"[^"]*"' || true; } | wc -l | tr -d ' ')
-    desc_length=$(echo "$desc_block" | wc -c | tr -d ' ' || echo 0)
+    phrase_count=$(echo "$desc_raw" | { grep -o '"[^"]*"' || true; } | wc -l | tr -d ' ')
+    desc_length=$(echo "$desc_raw" | wc -c | tr -d ' ' || echo 0)
     if [ "$phrase_count" -lt 10 ] && [ "$desc_length" -lt 100 ]; then
         fail "description too short ($desc_length chars) and only $phrase_count trigger phrases (need ≥10 phrases or ≥100 char description)"
         skill_errors=$((skill_errors + 1))

--- a/skills/cx-alerts/SKILL.md
+++ b/skills/cx-alerts/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cx-alerts
 description: This skill should be used when the user asks to "manage alerts", "create alert", "list alerts", "check alert status", "enable alert", "disable alert", "investigate firing alerts", "check which alerts are active", "find alerting rules", "set up an alert", "configure alerting", "mute an alert", "silence an alert", "see alert definitions", "check alert priority", or wants to manage Coralogix alert definitions using the cx CLI.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Alert Management Skill

--- a/skills/cx-cost-optimization/SKILL.md
+++ b/skills/cx-cost-optimization/SKILL.md
@@ -10,7 +10,8 @@ description: >
   "billing units", "plan consumption", "daily plan", "overage", "PAYG",
   "usage anomaly", "usage trend", "cx_data_usage_units",
   or wants to investigate, analyze, or reduce Coralogix data costs.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Cost Optimization Skill

--- a/skills/cx-create-dashboard/SKILL.md
+++ b/skills/cx-create-dashboard/SKILL.md
@@ -8,7 +8,8 @@ description: >
   Use whenever the user asks to create, build, generate, or deploy a Coralogix
   dashboard, monitoring dashboard, or observability dashboard for a service, app,
   or pipeline.
-version: 0.2.0
+metadata:
+  version: "0.2.0"
 ---
 
 # Create Coralogix Dashboard

--- a/skills/cx-data-pipeline/SKILL.md
+++ b/skills/cx-data-pipeline/SKILL.md
@@ -11,7 +11,8 @@ description: >
   "rule group", "enrichment settings", "E2M definition", "labels cardinality",
   "bulk delete rules", "enrichment limits", "search enrichment table",
   or wants to configure how Coralogix processes, enriches, or transforms ingested data.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Data Pipeline Skill

--- a/skills/cx-incident-management/SKILL.md
+++ b/skills/cx-incident-management/SKILL.md
@@ -9,7 +9,8 @@ description: >
   "acknowledge incident", "resolve incident", "production incident",
   "what alerts are active", "incident timeline", "on-call triage",
   or wants to triage, manage, or respond to incidents using alerts, SLOs, and notifications.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Incident Management Skill

--- a/skills/cx-observability-setup/SKILL.md
+++ b/skills/cx-observability-setup/SKILL.md
@@ -11,7 +11,8 @@ description: >
   "notification routing", "deploy extension", "test webhook",
   "notification preset", "test notification", "webhook actions",
   or wants to set up, configure, or manage the observability stack for a service or team.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Observability Setup Skill

--- a/skills/cx-olly/SKILL.md
+++ b/skills/cx-olly/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: cx-olly
 description: This skill should be used when the user asks to "chat with AI", "ask Olly", "ask the agent", "send message to AI", "continue a chat", "follow up on chat", "get artifact", "download artifact", "list artifacts", "retrieve generated content", "AI-generated charts", "AI analysis", "conversational observability", "natural language query", or wants to interact with the Coralogix Observability Agent (Olly) using the cx CLI.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Olly Observability Agent Skill

--- a/skills/cx-platform-admin/SKILL.md
+++ b/skills/cx-platform-admin/SKILL.md
@@ -9,7 +9,8 @@ description: >
   "user permissions", "role-based access", "manage scopes", "system roles",
   "API key admin", "team member keys", "group membership",
   or wants to audit, manage, or configure access controls for a Coralogix account.
-version: 0.1.0
+metadata:
+  version: "0.1.0"
 ---
 
 # Platform Admin Skill

--- a/skills/cx-telemetry-querying/SKILL.md
+++ b/skills/cx-telemetry-querying/SKILL.md
@@ -14,7 +14,8 @@ description: |
   "check error rate", "look up a metric", "check memory usage",
   "how do I write a DataPrime query", "DataPrime syntax",
   or wants to answer questions using observability data from logs, metrics, traces, RUM, or APM.
-version: 0.2.0
+metadata:
+  version: "0.2.0"
 ---
 
 # Telemetry Querying Skill


### PR DESCRIPTION
This PR adds upstream Agent Skills spec validation to the skills CI workflow using `skills-ref` / `agentskills validate`.
The spec validator now checks each `skills/**/SKILL.md` for:
- valid `SKILL.md` YAML frontmatter
- closed YAML frontmatter
- frontmatter parses as a YAML mapping
- required `name` and `description` fields
- allowed top-level frontmatter fields only:
  - `name`
  - `description`
  - `license`
  - `allowed-tools`
  - `metadata`
  - `compatibility`
- `name` is a non-empty string
- `name` is max 64 characters
- `name` is lowercase
- `name` contains only alphanumeric characters and hyphens
- `name` does not start or end with a hyphen
- `name` does not contain consecutive hyphens
- `name` matches the parent skill directory
- `description` is a non-empty string
- `description` is max 1024 characters
- optional `compatibility` is a string
- optional `compatibility` is max 500 characters
The existing `scripts/verify-skills.sh` remains responsible for cx-cli-specific checks such as trigger coverage, command references, related skill links, max 400-line `SKILL.md` size, and shared-reference sync.

## Notes
To comply with the upstream Agent Skills spec, skill versions were moved from top-level `version:` into `metadata.version`.
## Validation
- Ran `agentskills validate` for all `skills/**/SKILL.md`
- Ran `bash scripts/verify-skills.sh`
