### PR TITLE
fix: surface server error messages for 401, 403, and 429 responses

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -128,10 +128,7 @@ impl CxClient {
             .and_then(|v| v.to_str().ok())
             .map(String::from);
         let body = resp.text().await.unwrap_or_default();
-        let detail = serde_json::from_str::<Value>(&body)
-            .ok()
-            .and_then(|v| v["message"].as_str().map(String::from))
-            .filter(|s| !s.is_empty());
+        let detail = extract_error_detail(&body);
 
         match status {
             StatusCode::UNAUTHORIZED => Err(CxError::Auth(match detail {
@@ -156,5 +153,83 @@ impl CxClient {
                 message: detail.unwrap_or(body),
             }),
         }
+    }
+}
+
+/// Extract a human-readable error detail from a response body.
+///
+/// Tries common JSON error shapes in order:
+/// 1. `{"message": "..."}`
+/// 2. `{"error": "..."}` (string)
+/// 3. `{"error": {"message": "..."}}`
+/// 4. `{"detail": "..."}`
+///
+/// Returns `None` when the body is not JSON, none of the fields are present,
+/// or every candidate is an empty string.
+fn extract_error_detail(body: &str) -> Option<String> {
+    let v: Value = serde_json::from_str(body).ok()?;
+    let non_empty = |val: &Value| val.as_str().filter(|s| !s.is_empty()).map(String::from);
+    non_empty(&v["message"])
+        .or_else(|| non_empty(&v["error"]))
+        .or_else(|| non_empty(&v["error"]["message"]))
+        .or_else(|| non_empty(&v["detail"]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::extract_error_detail;
+
+    #[test]
+    fn prefers_top_level_message() {
+        let body = r#"{"message":"primary","error":"secondary","detail":"tertiary"}"#;
+        assert_eq!(extract_error_detail(body).as_deref(), Some("primary"));
+    }
+
+    #[test]
+    fn falls_back_to_error_string() {
+        let body = r#"{"error":"Token expired"}"#;
+        assert_eq!(extract_error_detail(body).as_deref(), Some("Token expired"));
+    }
+
+    #[test]
+    fn falls_back_to_nested_error_message() {
+        let body = r#"{"error":{"message":"User lacks role"}}"#;
+        assert_eq!(
+            extract_error_detail(body).as_deref(),
+            Some("User lacks role")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_detail() {
+        let body = r#"{"detail":"resource not found"}"#;
+        assert_eq!(
+            extract_error_detail(body).as_deref(),
+            Some("resource not found")
+        );
+    }
+
+    #[test]
+    fn empty_strings_are_skipped() {
+        let body = r#"{"message":"","error":"actual"}"#;
+        assert_eq!(extract_error_detail(body).as_deref(), Some("actual"));
+    }
+
+    #[test]
+    fn returns_none_for_non_json() {
+        assert_eq!(extract_error_detail("plain text"), None);
+        assert_eq!(extract_error_detail(""), None);
+    }
+
+    #[test]
+    fn returns_none_when_no_recognized_fields() {
+        let body = r#"{"code":42,"trace_id":"abc"}"#;
+        assert_eq!(extract_error_detail(body), None);
+    }
+
+    #[test]
+    fn returns_none_when_error_object_has_no_message() {
+        let body = r#"{"error":{"code":"E_BAD"}}"#;
+        assert_eq!(extract_error_detail(body), None);
     }
 }

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -130,24 +130,25 @@ impl CxClient {
         let body = resp.text().await.unwrap_or_default();
         let detail = serde_json::from_str::<Value>(&body)
             .ok()
-            .and_then(|v| v["message"].as_str().map(String::from));
+            .and_then(|v| v["message"].as_str().map(String::from))
+            .filter(|s| !s.is_empty());
 
         match status {
-            StatusCode::UNAUTHORIZED => Err(CxError::Auth(
-                "Invalid or expired API key. Run `cx profiles add` to update credentials."
-                    .into(),
-            )),
+            StatusCode::UNAUTHORIZED => Err(CxError::Auth(match detail {
+                Some(d) => format!("{d}. Run `cx profiles add` to update credentials."),
+                None => "Invalid or expired API key. Run `cx profiles add` to update credentials.".into(),
+            })),
             StatusCode::FORBIDDEN => Err(CxError::Auth(match detail {
-                Some(d) => format!("Permission denied: {d}. Check your API key's scopes."),
+                Some(d) => format!("{d}. Check your API key's scopes."),
                 None => "Permission denied: your API key does not have the required scope for this operation.".into(),
             })),
             StatusCode::TOO_MANY_REQUESTS => Err(CxError::Api {
                 status: code,
-                message: match retry_after {
-                    Some(secs) => {
-                        format!("Rate limited by the API. Retry after {secs} seconds.")
-                    }
-                    None => "Rate limited by the API. Wait and retry.".into(),
+                message: match (detail, retry_after) {
+                    (Some(d), Some(secs)) => format!("{d}. Retry after {secs} seconds."),
+                    (Some(d), None) => d,
+                    (None, Some(secs)) => format!("Rate limited by the API. Retry after {secs} seconds."),
+                    (None, None) => "Rate limited by the API. Wait and retry.".into(),
                 },
             }),
             _ => Err(CxError::Api {

--- a/tests/api_client/main.rs
+++ b/tests/api_client/main.rs
@@ -205,6 +205,28 @@ async fn error_404_catch_all() {
 }
 
 #[tokio::test]
+async fn error_401_with_nested_error_message() {
+    init_tls();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(401)
+                .set_body_json(json!({"error": {"message": "Bearer prefix missing"}})),
+        )
+        .mount(&server)
+        .await;
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Bearer prefix missing"),
+        "expected nested server message, got: {msg}"
+    );
+    assert!(msg.contains("cx profiles add"), "expected hint, got: {msg}");
+}
+
+#[tokio::test]
 async fn error_500_with_raw_body() {
     init_tls();
     let server = MockServer::start().await;

--- a/tests/api_client/main.rs
+++ b/tests/api_client/main.rs
@@ -48,8 +48,12 @@ async fn error_403_with_message() {
     let err = client.get::<Value>("/test", &[]).await.unwrap_err();
     let msg = err.to_string();
     assert!(
-        msg.contains("Permission denied: missing dashboards:write scope"),
+        msg.contains("missing dashboards:write scope"),
         "expected server message in error, got: {msg}"
+    );
+    assert!(
+        msg.contains("Check your API key's scopes"),
+        "expected scope hint in error, got: {msg}"
     );
 }
 
@@ -132,6 +136,71 @@ async fn error_500_with_json_message() {
     assert!(
         msg.contains("internal error"),
         "expected server message in error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_401_with_server_message() {
+    init_tls();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({"message": "Token expired"})))
+        .mount(&server)
+        .await;
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Token expired"),
+        "expected server message, got: {msg}"
+    );
+    assert!(msg.contains("cx profiles add"), "expected hint, got: {msg}");
+}
+
+#[tokio::test]
+async fn error_429_with_message_and_retry_after() {
+    init_tls();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(429)
+                .append_header("Retry-After", "30")
+                .set_body_json(json!({"message": "Per-team quota exhausted"})),
+        )
+        .mount(&server)
+        .await;
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("Per-team quota exhausted"),
+        "expected server message, got: {msg}"
+    );
+    assert!(
+        msg.contains("Retry after 30 seconds"),
+        "expected retry hint, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_404_catch_all() {
+    init_tls();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(404).set_body_json(json!({"message": "resource not found"})),
+        )
+        .mount(&server)
+        .await;
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("resource not found"),
+        "expected server message, got: {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary

`CxClient::checked_text` was discarding server-provided error detail for 401 and 429 and forcing a `"Permission denied: ..."` prefix on 403. This PR:

- **Surfaces server messages for 401, 403, and 429** — the server's detail is shown first; the existing actionable hints (`cx profiles add`, `Check your API key's scopes`, `Retry after N seconds`) are appended as a suffix.
- **Broadens detail extraction to handle common error-body shapes**, not just `{"message": "..."}`. A new helper `extract_error_detail` tries fields in order:
  1. `{"message": "..."}` *(existing)*
  2. `{"error": "..."}` — plain string, common in many REST APIs
  3. `{"error": {"message": "..."}}` — OpenAI / Stripe / AWS-style
  4. `{"detail": "..."}` — FastAPI / DRF default
- Falls back to the existing hardcoded text when no parseable message is found, so behavior in the "no body" case is unchanged.
- `CxError` variant routing is preserved: 401/403 still produce `CxError::Auth(_)`, 429 still produces `CxError::Api { status: 429, .. }`.

### Example before/after

| Status | Server body | Before | After |
|---|---|---|---|
| 401 | `{"message":"Token expired"}` | `Invalid or expired API key. Run cx profiles add to update credentials.` | `Token expired. Run cx profiles add to update credentials.` |
| 401 | `{"error":{"message":"Bearer prefix missing"}}` | `Invalid or expired API key. Run cx profiles add to update credentials.` | `Bearer prefix missing. Run cx profiles add to update credentials.` |
| 403 | `{"message":"missing dashboards:write scope"}` | `Permission denied: missing dashboards:write scope. Check your API key's scopes.` | `missing dashboards:write scope. Check your API key's scopes.` |
| 429 | `{"message":"Per-team quota exhausted"}` + `Retry-After: 30` | `Rate limited by the API. Retry after 30 seconds.` | `Per-team quota exhausted. Retry after 30 seconds.` |

## Test plan

- [x] `cargo fmt` clean
- [x] `cargo clippy` zero warnings
- [x] `cargo test` — full suite passes, no regressions
- [x] 8 new unit tests for `extract_error_detail` covering precedence order, empty-string skipping, non-JSON bodies, and missing fields
- [x] 4 new integration tests in `tests/api_client/main.rs`: `error_401_with_server_message`, `error_401_with_nested_error_message`, `error_429_with_message_and_retry_after`, `error_404_catch_all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)