### PR TITLE
skill: share dashboard link as final step of cx-create-dashboard

### DIFF
--- a/skills/cx-create-dashboard/SKILL.md
+++ b/skills/cx-create-dashboard/SKILL.md
@@ -260,27 +260,13 @@ On failure: show the CLI error verbatim and return to Phase 5. The most common c
 
 The workflow is **not done** until the user has a clickable link to the dashboard. Printing the ID alone forces the user to navigate the Coralogix UI by hand, which defeats the point of automating deployment.
 
-After Phase 7 succeeds, capture the dashboard `id` returned by `cx dashboards create` and the active profile's region, then build the link:
-
-```
-https://<region>.app.coralogix.com/#/dashboards/<id>
-```
-
-Region resolution:
-
-| Profile region | Webapp host |
-|---|---|
-| `us1` / `us2` / `us3` | `us1.app.coralogix.com` / `us2.app.coralogix.com` / `us3.app.coralogix.com` |
-| `eu1` / `eu2` | `eu1.app.coralogix.com` / `eu2.app.coralogix.com` |
-| `ap1` / `ap2` / `ap3` | `ap1.app.coralogix.com` / `ap2.app.coralogix.com` / `ap3.app.coralogix.com` |
-| `stg1` | `stg1.app.coralogix.net` |
-| Custom (`https://api.<host>`) | Replace the leading `api.` with `<host>` (e.g. `api.myenv.coralogix.com` → `myenv.app.coralogix.com`). If the API endpoint doesn't follow the `api.` prefix convention, omit the link and surface only the ID with a note. |
-
-Render the link as a markdown link with the dashboard **name** as the link text — that's what the user clicks. The final user-facing message must include this link (see "Output format for the user" below).
+After Phase 7 succeeds, capture the dashboard `id` returned by `cx dashboards create`, build the URL using the region → webapp host mapping in [`references/deploy.md`](references/deploy.md) § "Share the link", and emit the output template below. Render the dashboard **name** as the link text — that's what the user clicks.
 
 ---
 
 ## Output format for the user
+
+When the webapp host is resolvable (any built-in region, or a `Custom` endpoint that follows the `api.<host>` convention):
 
 ````
 ## Plan
@@ -301,11 +287,24 @@ Open it: [<Name>](https://<region>.app.coralogix.com/#/dashboards/<id>)
 Adjust filter values (e.g. `account_id`) after opening it.
 ````
 
-If the region is custom and the webapp host couldn't be derived, replace the link line with:
+When the webapp host **cannot** be derived (custom endpoint that doesn't match `api.<host>`), omit the link entirely — do not invent a URL. Use this template instead:
 
-```
+````
+## Plan
+<the approved Phase 3 plan>
+
+## Verification
+- PromQL queries verified: <N>/<N>
+- DataPrime queries verified: <N>/<N>
+
+## Deployed
 - Dashboard: **<Name>** (open via the Coralogix UI; ID `<id>`)
-```
+- ID: `<id>`
+- Folder: `<folder name or "root">`
+- Profile: `<cx profile>`
+
+Adjust filter values (e.g. `account_id`) after opening it.
+````
 
 ---
 

--- a/skills/cx-create-dashboard/SKILL.md
+++ b/skills/cx-create-dashboard/SKILL.md
@@ -72,9 +72,10 @@ Dashboard Progress:
 - [ ] Phase 5: Live-verify every query through the cx CLI
 - [ ] Phase 6: Self-verify structure against the checklist
 - [ ] Phase 7: Deploy via `cx dashboards create`
+- [ ] Phase 8: Share the dashboard link with the user
 ```
 
-Proceed in order. Don't jump to Phase 4 before the user approves the Phase 3 plan, and don't run Phase 7 before Phases 5 and 6 both pass.
+Proceed in order. Don't jump to Phase 4 before the user approves the Phase 3 plan, and don't run Phase 7 before Phases 5 and 6 both pass. Phase 8 is mandatory — the workflow is not done until the user has a clickable link.
 
 ---
 
@@ -255,6 +256,30 @@ On failure: show the CLI error verbatim and return to Phase 5. The most common c
 
 ---
 
+## Phase 8: Share the dashboard link
+
+The workflow is **not done** until the user has a clickable link to the dashboard. Printing the ID alone forces the user to navigate the Coralogix UI by hand, which defeats the point of automating deployment.
+
+After Phase 7 succeeds, capture the dashboard `id` returned by `cx dashboards create` and the active profile's region, then build the link:
+
+```
+https://<region>.app.coralogix.com/#/dashboards/<id>
+```
+
+Region resolution:
+
+| Profile region | Webapp host |
+|---|---|
+| `us1` / `us2` / `us3` | `us1.app.coralogix.com` / `us2.app.coralogix.com` / `us3.app.coralogix.com` |
+| `eu1` / `eu2` | `eu1.app.coralogix.com` / `eu2.app.coralogix.com` |
+| `ap1` / `ap2` / `ap3` | `ap1.app.coralogix.com` / `ap2.app.coralogix.com` / `ap3.app.coralogix.com` |
+| `stg1` | `stg1.app.coralogix.net` |
+| Custom (`https://api.<host>`) | Replace the leading `api.` with `<host>` (e.g. `api.myenv.coralogix.com` → `myenv.app.coralogix.com`). If the API endpoint doesn't follow the `api.` prefix convention, omit the link and surface only the ID with a note. |
+
+Render the link as a markdown link with the dashboard **name** as the link text — that's what the user clicks. The final user-facing message must include this link (see "Output format for the user" below).
+
+---
+
 ## Output format for the user
 
 ````
@@ -266,13 +291,21 @@ On failure: show the CLI error verbatim and return to Phase 5. The most common c
 - DataPrime queries verified: <N>/<N>
 
 ## Deployed
-- Dashboard: **<Name>**
+- Dashboard: **[<Name>](https://<region>.app.coralogix.com/#/dashboards/<id>)**
 - ID: `<id>`
 - Folder: `<folder name or "root">`
 - Profile: `<cx profile>`
 
-The dashboard is live in Coralogix. Adjust filter values (e.g. `account_id`) after opening it.
+Open it: [<Name>](https://<region>.app.coralogix.com/#/dashboards/<id>)
+
+Adjust filter values (e.g. `account_id`) after opening it.
 ````
+
+If the region is custom and the webapp host couldn't be derived, replace the link line with:
+
+```
+- Dashboard: **<Name>** (open via the Coralogix UI; ID `<id>`)
+```
 
 ---
 

--- a/skills/cx-create-dashboard/references/deploy.md
+++ b/skills/cx-create-dashboard/references/deploy.md
@@ -76,7 +76,7 @@ Region → webapp host mapping:
 | `stg1` | `stg1.app.coralogix.net` |
 | Custom (`https://api.<host>`) | Strip the leading `api.` and use `<host>` (e.g. `api.myenv.coralogix.com` → `myenv.app.coralogix.com`). |
 
-If the custom endpoint doesn't follow the `api.` prefix convention, skip the link and tell the user the dashboard ID and name so they can open it from the Coralogix UI directly.
+If the custom endpoint doesn't follow the `api.` prefix convention, **omit the link entirely** — do not invent a URL. Use the second ("webapp host cannot be derived") template in `SKILL.md` § "Output format for the user", which drops the markdown link from the `Deployed` line *and* drops the standalone `Open it:` line so the user is never shown a broken URL.
 
 Render the link as a markdown link using the dashboard **name** as the link text, e.g.:
 
@@ -84,7 +84,7 @@ Render the link as a markdown link using the dashboard **name** as the link text
 Dashboard: **[Order Service - Health](https://eu2.app.coralogix.com/#/dashboards/abc123def456)**
 ```
 
-Then emit the summary defined in the main `SKILL.md` "Output format for the user" section, which includes the link both in the "Deployed" line and as a standalone "Open it:" line so the user can click it without scrolling.
+Then emit the summary defined in the main `SKILL.md` § "Output format for the user".
 
 ---
 

--- a/skills/cx-create-dashboard/references/deploy.md
+++ b/skills/cx-create-dashboard/references/deploy.md
@@ -52,10 +52,42 @@ The CLI generates the `requestId` envelope automatically and prints the created 
 
 On failure: show the CLI error verbatim, return to Phase 5 (most common cause: a query that parses locally but the live API rejects), fix, and redeploy.
 
-On success: emit the summary defined in the main `SKILL.md` "Output format for the user" section.
+On success: continue to step 4 below — the workflow is **not finished** until the user has the link.
 
 ---
 
-## 4. Idempotency note
+## 4. Share the link (final step — mandatory)
+
+Don't stop at "dashboard created". The very last action is to give the user a clickable link to the dashboard.
+
+Build the URL from the active profile's region and the dashboard `id` returned by `cx dashboards create`:
+
+```
+https://<region>.app.coralogix.com/#/dashboards/<id>
+```
+
+Region → webapp host mapping:
+
+| Region | Webapp host |
+|---|---|
+| `us1` / `us2` / `us3` | `us1.app.coralogix.com` / `us2.app.coralogix.com` / `us3.app.coralogix.com` |
+| `eu1` / `eu2` | `eu1.app.coralogix.com` / `eu2.app.coralogix.com` |
+| `ap1` / `ap2` / `ap3` | `ap1.app.coralogix.com` / `ap2.app.coralogix.com` / `ap3.app.coralogix.com` |
+| `stg1` | `stg1.app.coralogix.net` |
+| Custom (`https://api.<host>`) | Strip the leading `api.` and use `<host>` (e.g. `api.myenv.coralogix.com` → `myenv.app.coralogix.com`). |
+
+If the custom endpoint doesn't follow the `api.` prefix convention, skip the link and tell the user the dashboard ID and name so they can open it from the Coralogix UI directly.
+
+Render the link as a markdown link using the dashboard **name** as the link text, e.g.:
+
+```
+Dashboard: **[Order Service - Health](https://eu2.app.coralogix.com/#/dashboards/abc123def456)**
+```
+
+Then emit the summary defined in the main `SKILL.md` "Output format for the user" section, which includes the link both in the "Deployed" line and as a standalone "Open it:" line so the user can click it without scrolling.
+
+---
+
+## 5. Idempotency note
 
 Each run generates a fresh top-level `id` (21-char nanoid), so re-running this skill creates a *new* dashboard rather than overwriting an existing one. If the user wants to replace an existing dashboard, point them at the Coralogix API's "replace dashboard" endpoint - that's outside this skill's current scope.


### PR DESCRIPTION
## Summary

- Adds a mandatory **Phase 8: Share the dashboard link** to the `cx-create-dashboard` skill so the workflow ends by giving the user a clickable URL to the new dashboard, not just an ID.
- Updates the "Output format for the user" template to render the dashboard name as a markdown link to `https://<region>.app.coralogix.com/#/dashboards/<id>`, plus a standalone "Open it:" line.
- Documents region → webapp host mapping for `us*` / `eu*` / `ap*` / `stg1` and a `Custom` region fallback (strip leading `api.`, otherwise omit the link and surface only the ID).
- Mirrors the same guidance in `references/deploy.md` as a new "Step 4. Share the link (final step — mandatory)".

Closes [KNO-384](https://linear.app/coralogix/issue/KNO-384/cx-create-dashboard-skill-share-dashboard-link-as-final-step).

## Test plan

- [ ] Skill-only change; no Rust touched, so `cargo` checks aren't required.
- [ ] Eyeball the rendered markdown for `SKILL.md` and `references/deploy.md`.


Made with [Cursor](https://cursor.com)