### PR TITLE
docs: add read-only mode docs, rename allow_costly_commands to olly_enabled

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -95,6 +95,9 @@ The default install script and release binaries are built for musl on Linux, so 
 | `default_output_format` | `"text"` | Output format when `-o` is not provided (`text`, `json`, `agents`) |
 | `max_dataprime_direct_output_size` | `102400` (100 KiB) | Max byte size for non-aggregated DataPrime results in `agents` mode before spilling to a temp file. Set to `-1` to disable |
 | `temp_dir` | `"/tmp/"` | Directory for spilled result files |
+| `read_only` | `false` | Block all write operations globally (equivalent to always passing `--read-only`) |
+| `allow_risky_commands` | `true` | Allow write operations under risky commands (`iam`, `archive`) |
+| `olly_enabled` | `true` | Enable the Olly AI assistant (`olly ask`) |
 
 Example:
 
@@ -103,6 +106,9 @@ default_profile = "default"
 default_output_format = "text"
 max_dataprime_direct_output_size = 102400
 temp_dir = "/tmp/"
+read_only = false
+allow_risky_commands = true
+olly_enabled = true
 ```
 
 ## Profile files (`~/.cx/profiles/<name>.toml`)
@@ -208,12 +214,36 @@ Environment variables override profile file values:
 | `CX_PROFILE` | `-p` flag / `default_profile` |
 | `CX_API_KEY` | `api_key` in profile (also overrides OAuth - sets the bearer token directly) |
 | `CX_REGION` | `region` in profile |
+| `CX_READ_ONLY` | `read_only` in global config (accepts `1`, `true`, `yes`, `on`) |
 
 **Precedence order:** CLI flags > environment variables > profile file > global config defaults.
 
 > **Note:** `CX_API_KEY` / `--api-key` always win, even for OAuth profiles. This lets scripts and CI systems inject tokens directly without going through the browser login flow.
 
 > **Env-only mode:** when no profile file exists on disk but both `CX_API_KEY` (or `--api-key`) and `CX_REGION` (or `--region`) are supplied, `cx` runs without a profile file. This is convenient for ephemeral environments (CI runners, containers, ad-hoc scripts) where running `cx profiles add` first would be a paper-cut.
+
+## Read-only mode
+
+Read-only mode blocks all write operations (create, update, delete, enable, disable, etc.) while allowing reads (list, get, query, search). This is useful for giving agents or automation safe, query-only access to your Coralogix data.
+
+There are three ways to enable it, listed from narrowest to broadest scope:
+
+| Method | Scope | Example |
+|---|---|---|
+| `--read-only` flag | Single invocation | `cx --read-only alerts list` |
+| `CX_READ_ONLY` env var | Shell session / CI job | `export CX_READ_ONLY=true` |
+| `read_only = true` in `~/.cx/config.toml` | All invocations | See global config table above |
+
+When a write operation is attempted in read-only mode, `cx` exits with an error:
+
+```
+Error: Write operation 'create' is blocked in read-only mode
+(--read-only flag, CX_READ_ONLY env var, or read_only = true in ~/.cx/config.toml).
+```
+
+Local commands (`profiles`, `cleanup`, `completions`) are exempt from read-only enforcement - they manage local configuration and never touch the Coralogix API.
+
+The env var accepts `1`, `true`, `yes`, or `on` (case-insensitive).
 
 ## Shell completion and profiles
 

--- a/src/commands/profiles/mod.rs
+++ b/src/commands/profiles/mod.rs
@@ -241,11 +241,10 @@ pub async fn run_add(profile_name: Option<String>, set_default: bool) -> Result<
                 )
                 .prompt()?;
 
-        global_config.allow_costly_commands =
-            Confirm::new("Allow costly commands? (olly ask — AI assistant queries)")
-                .with_default(true)
-                .with_help_message("When disabled, 'olly ask' is blocked.")
-                .prompt()?;
+        global_config.olly_enabled = Confirm::new("Enable Olly AI assistant? (olly ask)")
+            .with_default(true)
+            .with_help_message("When disabled, 'olly ask' is blocked.")
+            .prompt()?;
 
         global_config.default_profile = name.clone();
         save_config(&global_config)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -171,10 +171,10 @@ pub struct Config {
     #[serde(default = "default_true")]
     pub allow_risky_commands: bool,
 
-    /// Whether to allow costly commands (olly ask).
-    /// When false, these commands are hard-blocked.
+    /// Whether the Olly AI assistant (`olly ask`) is enabled.
+    /// When false, `olly ask` is blocked.
     #[serde(default = "default_true")]
-    pub allow_costly_commands: bool,
+    pub olly_enabled: bool,
 
     /// When true, ALL write operations are blocked globally.
     /// Equivalent to always passing --read-only.
@@ -211,7 +211,7 @@ impl Default for Config {
             max_dataprime_direct_output_size: default_max_dataprime_direct_output_size(),
             temp_dir: default_temp_dir(),
             allow_risky_commands: true,
-            allow_costly_commands: true,
+            olly_enabled: true,
             read_only: false,
             managed_completions: vec![],
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -536,7 +536,7 @@ impl Commands {
         matches!(self, Self::Iam { .. } | Self::DataArchive { .. })
     }
 
-    fn is_costly(&self) -> bool {
+    fn is_olly(&self) -> bool {
         match self {
             Self::Olly { cmd } => matches!(cmd, OllyCmd::Ask { .. }),
             _ => false,
@@ -2161,7 +2161,7 @@ async fn main() -> Result<()> {
     let matches = cmd.get_matches();
     let cli = Cli::from_arg_matches(&matches)?;
 
-    // Load global config early for read-only / risky / costly gating.
+    // Load global config early for read-only / risky / olly gating.
     let global_cfg_early = config::load_config().unwrap_or_default();
 
     let read_only =
@@ -2191,12 +2191,11 @@ async fn main() -> Result<()> {
         }
     }
 
-    // Costly command gating (olly ask).
-    if cli.command.is_costly() && !global_cfg_early.allow_costly_commands {
+    // Olly gating (olly ask).
+    if cli.command.is_olly() && !global_cfg_early.olly_enabled {
         bail!(
-            "This operation may result in additional charges and is currently \
-             disabled in your global configuration.\n\
-             To enable it, set allow_costly_commands = true in ~/.cx/config.toml."
+            "The Olly AI assistant is currently disabled in your global configuration.\n\
+             To enable it, set olly_enabled = true in ~/.cx/config.toml."
         );
     }
 

--- a/tests/risky_costly_gating/main.rs
+++ b/tests/risky_costly_gating/main.rs
@@ -118,12 +118,12 @@ fn risky_enabled_allows_iam_write() {
     );
 }
 
-// ── Costly command gating ────────────────────────────────────────────────────
+// ── Olly gating ─────────────────────────────────────────────────────────────
 
 #[test]
-fn costly_disabled_blocks_olly_ask() {
+fn olly_disabled_blocks_olly_ask() {
     let tmp = temp_home();
-    let output = cx_with_config(&tmp, "allow_costly_commands = false\n")
+    let output = cx_with_config(&tmp, "olly_enabled = false\n")
         .args([
             "olly",
             "ask",
@@ -137,13 +137,13 @@ fn costly_disabled_blocks_olly_ask() {
         .expect("failed to run cx");
     assert!(!output.status.success());
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(stderr.contains("additional charges"), "stderr: {stderr}");
+    assert!(stderr.contains("disabled"), "stderr: {stderr}");
 }
 
 #[test]
-fn costly_disabled_allows_olly_artifacts() {
+fn olly_disabled_allows_olly_artifacts() {
     let tmp = temp_home();
-    let output = cx_with_config(&tmp, "allow_costly_commands = false\n")
+    let output = cx_with_config(&tmp, "olly_enabled = false\n")
         .args([
             "olly",
             "artifacts",
@@ -157,15 +157,15 @@ fn costly_disabled_allows_olly_artifacts() {
         .expect("failed to run cx");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("additional charges"),
+        !stderr.contains("disabled"),
         "artifacts should not be blocked, stderr: {stderr}"
     );
 }
 
 #[test]
-fn costly_enabled_allows_olly_ask() {
+fn olly_enabled_allows_olly_ask() {
     let tmp = temp_home();
-    let output = cx_with_config(&tmp, "allow_costly_commands = true\n")
+    let output = cx_with_config(&tmp, "olly_enabled = true\n")
         .args([
             "olly",
             "ask",
@@ -179,7 +179,7 @@ fn costly_enabled_allows_olly_ask() {
         .expect("failed to run cx");
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("additional charges"),
+        !stderr.contains("disabled"),
         "should not be blocked when enabled, stderr: {stderr}"
     );
 }


### PR DESCRIPTION
## Summary
- Document `--read-only` flag, `CX_READ_ONLY` env var, and `read_only` config option in `docs/configuration.md`
- Add previously undocumented `allow_risky_commands` and `olly_enabled` fields to the global config table and example
- Rename `allow_costly_commands` to `olly_enabled` throughout code, tests, and docs - the old name was overly generic for what it actually gates (`olly ask`)

## Test plan
- [x] `cargo fmt` - clean
- [x] `cargo clippy` - no warnings
- [x] `cargo test` - 590 passed
- [x] `cargo test --test risky_costly_gating` - 10 passed (includes renamed olly gating tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)