### PR TITLE
ci: enable TW doc review (shadow mode, 2-week audit)

### DIFF
--- a/.github/workflows/tw-doc-review-caller.yml
+++ b/.github/workflows/tw-doc-review-caller.yml
@@ -1,0 +1,15 @@
+name: TW doc review
+
+on:
+  pull_request:
+    paths:
+      - "README.md"
+      - "docs/*.md"
+
+jobs:
+  tw-review:
+    uses: coralogix/documentation/.github/workflows/tw-doc-review.yml@master
+    with:
+      doc_paths: "README.md docs/*.md"
+      shadow: true
+    secrets: inherit

--- a/.github/workflows/tw-doc-review-caller.yml
+++ b/.github/workflows/tw-doc-review-caller.yml
@@ -11,8 +11,17 @@ permissions:
 
 jobs:
   tw-review:
-    uses: coralogix/documentation/.github/workflows/tw-doc-review.yml@master
+    # Pinned to a specific commit SHA to prevent supply-chain risk from
+    # upstream changes in coralogix/documentation. To bump, review the diff
+    # at https://github.com/coralogix/documentation/commits/master/.github/workflows/tw-doc-review.yml
+    # then update both the SHA and the trailing date comment.
+    uses: coralogix/documentation/.github/workflows/tw-doc-review.yml@1bd3ba3219547e9461cc0fec2335857e8bde6f0e  # 2026-05-19
+    permissions: {}
     with:
       doc_paths: "README.md docs/*.md"
       shadow: true
-    secrets: inherit
+    # Forward only the one secret the reusable workflow declares
+    # (ANTHROPIC_API_KEY). Avoid `secrets: inherit` so an upstream change
+    # cannot pull additional secrets out of this repo.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/tw-doc-review-caller.yml
+++ b/.github/workflows/tw-doc-review-caller.yml
@@ -6,6 +6,9 @@ on:
       - "README.md"
       - "docs/*.md"
 
+permissions:
+  contents: read
+
 jobs:
   tw-review:
     uses: coralogix/documentation/.github/workflows/tw-doc-review.yml@master


### PR DESCRIPTION
## Summary

Adds an automated Technical Writing review for PRs touching docs in this repo. Mirrors what the TW team does manually with `/review-doc` — sentence-case headings, terminology consistency, broken examples, vendor-doc accuracy, etc. — but proposes the fixes inline at the exact line as one-click "Apply suggestion" buttons.

Companion to [coralogix/documentation#2474](https://github.com/coralogix/documentation/pull/2474).

## What this PR adds

One workflow file: `.github/workflows/tw-doc-review-caller.yml`.

It calls the reusable workflow [`coralogix/documentation/.github/workflows/tw-doc-review.yml@master`](https://github.com/coralogix/documentation/blob/master/.github/workflows/tw-doc-review.yml) — all review logic lives in the docs repo and is maintained by the TW team. Updates to the review criteria don't require a change here.

## What triggers a review in this repo

PRs touching any of these files:

- `README.md`
- `docs/*.md`

PRs that don't touch these files are unaffected.

## What the bot does

- Runs 6 reviewers in parallel — technical accuracy, terminology, structure, testability, red-team verification (against your PR's source code + official upstream docs), and a deterministic lint
- Posts one PR review with a summary + inline suggestions at the exact diff lines
- For each suggestion you click **Apply suggestion** (commits to the PR branch), **Add suggestion to batch** (queue + commit several together), or **Resolve** (dismiss)
- Findings without a clear one-click fix appear as comments without suggestions

## Shadow mode — non-blocking by default

`shadow: true` is set in the workflow. The bot posts comments but **cannot block your merges** during this period. The TW team audits accuracy for ~2 weeks (target: false-positive rate < 20%, false-negative rate < 10%), then proposes flipping to blocking mode in a follow-up PR.

## If the bot misbehaves on your PR

1. **Disagree with a finding?** Click **Resolve** on the comment — it's dismissed for that PR.
2. **Want to opt out a specific file?** Edit the `paths:` block in `tw-doc-review-caller.yml`.
3. **Bot is wrong systematically?** Ping `#docs-interface` on Slack or open an issue in [coralogix/documentation](https://github.com/coralogix/documentation/issues) tagging the TW team.

## Note

This caller workflow installs now, but the bot will start reviewing PRs only after [coralogix/documentation#2474](https://github.com/coralogix/documentation/pull/2474) merges (the reusable workflow it references doesn't exist on docs/master yet). Until then, this is a no-op.

## What to check before merging

- [ ] Workflow file is syntactically valid (GitHub validates on PR open)
- [ ] The watched-files list above looks right for this repo
- [ ] You're OK with shadow-mode review on those files

🤖 Caller workflow generated from [`coralogix/documentation/scripts/tw-ci-setup/`](https://github.com/coralogix/documentation/tree/master/scripts/tw-ci-setup)