### PR TITLE
feat(olly): hardcode interaction mode to skill (pro mode)

### DIFF
--- a/skills/cx-olly/SKILL.md
+++ b/skills/cx-olly/SKILL.md
@@ -13,7 +13,7 @@ Use this skill to interact with Coralogix's Observability Agent (Olly) via the `
 
 | Command | Purpose | Key flags |
 |---|---|---|
-| `cx olly ask "message"` | Send a message to the Observability Agent | `--chat-id`, `--mode`, `--model`, `--timeout` |
+| `cx olly ask "message"` | Send a message to the Observability Agent | `--chat-id`, `--model`, `--timeout` |
 | `cx olly artifacts list` | List all generated artifacts | - |
 | `cx olly artifacts get <id>` | Get artifact content by ID | - |
 
@@ -38,17 +38,6 @@ cx olly ask "Tell me more about the error rates" --chat-id <chat-id>
 ```
 
 Use `--chat-id` to continue a conversation and maintain context from previous messages.
-
-### Interaction modes
-
-| Mode | Description |
-|---|---|
-| `fast` | Quick responses, less detailed analysis |
-| `focus` | Balanced mode (default) - good for most queries |
-
-```bash
-cx olly ask "Quick summary of recent errors" --mode fast
-```
 
 ### Model selection
 

--- a/src/commands/olly/api.rs
+++ b/src/commands/olly/api.rs
@@ -201,14 +201,13 @@ impl OllyApi {
         &self,
         chat_id: &str,
         content: &str,
-        interaction_mode: &str,
         model_choice: &str,
         timeout_seconds: u32,
     ) -> Result<Interaction> {
         let path = format!("{CHATS_BASE}/{chat_id}/interactions/");
         let body = json!({
             "content": [InputContentBlock::text(content)],
-            "interaction_mode": interaction_mode,
+            "interaction_mode": "skill",
             "model_choice": model_choice,
             "should_block": true,
             "timeout_seconds": timeout_seconds

--- a/src/commands/olly/mod.rs
+++ b/src/commands/olly/mod.rs
@@ -23,12 +23,10 @@ use crate::spill::{self, maybe_spill, SpillOutcome};
 ///
 /// Creates a new chat if `chat_id` is None, otherwise continues an existing chat.
 /// Uses blocking mode to wait for the response.
-#[allow(clippy::too_many_arguments)]
 pub async fn run_ask(
     targets: &[Arc<ExecutionTarget>],
     message: &str,
     chat_id: Option<&str>,
-    mode: &str,
     model: &str,
     timeout: u32,
     output: OutputFormat,
@@ -52,9 +50,7 @@ pub async fn run_ask(
     };
 
     eprintln!("{}", "Sending message...".dimmed());
-    let interaction = api
-        .send_message(&chat_id, message, mode, model, timeout)
-        .await?;
+    let interaction = api.send_message(&chat_id, message, model, timeout).await?;
 
     // Render based on output format
     match output {

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,7 +525,7 @@ Examples:
 Examples:
   cx olly ask \"What alerts fired today?\"
   cx olly ask \"Show me error logs\" --chat-id <id>
-  cx olly ask \"Analyze this metric\" --mode deep-research
+  cx olly ask \"Analyze this metric\" --model claude-sonnet-4-5
   cx olly artifacts get <artifact-id>")]
     Olly {
         #[command(subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -640,7 +640,7 @@ enum OllyCmd {
 Examples:
   cx olly ask \"What alerts fired today?\"
   cx olly ask \"Show me error logs\" --chat-id <uuid>
-  cx olly ask \"Analyze this\" --mode skill --model claude-sonnet-4-5")]
+  cx olly ask \"Analyze this\" --model claude-sonnet-4-5")]
     Ask {
         /// The message to send to the assistant.
         message: String,
@@ -648,10 +648,6 @@ Examples:
         /// Continue an existing chat (omit to create a new chat).
         #[arg(long)]
         chat_id: Option<String>,
-
-        /// Interaction mode: fast, focus, or skill.
-        #[arg(long, default_value = "focus")]
-        mode: String,
 
         /// Model choice (e.g., gpt-5.2, claude-sonnet-4-5, gpt-5.4, claude-haiku-4-5).
         #[arg(long, default_value = "gpt-5.2")]
@@ -3383,7 +3379,6 @@ async fn main() -> Result<()> {
             OllyCmd::Ask {
                 message,
                 chat_id,
-                mode,
                 model,
                 timeout,
             } => {
@@ -3391,7 +3386,6 @@ async fn main() -> Result<()> {
                     &targets,
                     &message,
                     chat_id.as_deref(),
-                    &mode,
                     &model,
                     timeout,
                     output,

--- a/tests/olly/main.rs
+++ b/tests/olly/main.rs
@@ -54,7 +54,6 @@ async fn ask_creates_chat_and_sends_message() {
         &targets,
         "What alerts fired today?",
         None,
-        "focus",
         "gpt-5.2",
         900,
         OutputFormat::Json,
@@ -93,7 +92,6 @@ async fn ask_continues_existing_chat() {
         &targets,
         "Tell me more",
         Some("existing-chat"),
-        "focus",
         "gpt-5.2",
         900,
         OutputFormat::Json,
@@ -103,7 +101,7 @@ async fn ask_continues_existing_chat() {
 }
 
 #[tokio::test]
-async fn ask_with_different_modes() {
+async fn ask_with_different_models() {
     let server = MockServer::start().await;
 
     Mock::given(method("POST"))
@@ -143,13 +141,12 @@ async fn ask_with_different_modes() {
         &targets,
         "Analyze this complex issue",
         None,
-        "deep-research",
         "advanced",
         900,
         OutputFormat::Json,
     )
     .await
-    .expect("run_ask with deep-research mode should succeed");
+    .expect("run_ask with advanced model should succeed");
 }
 
 #[tokio::test]
@@ -185,7 +182,6 @@ async fn ask_handles_cancelled_response() {
         &targets,
         "Query that gets cancelled",
         None,
-        "focus",
         "gpt-5.2",
         900,
         OutputFormat::Json,
@@ -204,7 +200,6 @@ async fn ask_rejects_multi_profile() {
         &targets,
         "Hello",
         None,
-        "focus",
         "gpt-5.2",
         900,
         OutputFormat::Json,

--- a/tests/olly/main.rs
+++ b/tests/olly/main.rs
@@ -196,15 +196,7 @@ async fn ask_rejects_multi_profile() {
     let target2 = common::test_target("profile2", "http://localhost:2");
     let targets = vec![target1, target2];
 
-    let result = run_ask(
-        &targets,
-        "Hello",
-        None,
-        "gpt-5.2",
-        900,
-        OutputFormat::Json,
-    )
-    .await;
+    let result = run_ask(&targets, "Hello", None, "gpt-5.2", 900, OutputFormat::Json).await;
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();

--- a/tests/olly/main.rs
+++ b/tests/olly/main.rs
@@ -2,7 +2,7 @@
 mod common;
 
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use coralogix_cli::commands::olly::{run_artifacts_get, run_ask};
@@ -120,7 +120,7 @@ async fn ask_with_different_models() {
             "id": "interaction-deep",
             "chat_id": "chat-deep",
             "status": "COMPLETED",
-            "interaction_mode": "DEEP_RESEARCH",
+            "interaction_mode": "SKILL",
             "model_choice": "ADVANCED",
             "responses": [
                 {
@@ -201,6 +201,54 @@ async fn ask_rejects_multi_profile() {
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(err.contains("does not support multi-profile"));
+}
+
+#[tokio::test]
+async fn ask_sends_skill_interaction_mode() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/olly/v2/chats/"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "chat-skill",
+            "title": ""
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/olly/v2/chats/chat-skill/interactions/"))
+        .and(body_partial_json(json!({"interaction_mode": "skill"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "interaction-skill",
+            "chat_id": "chat-skill",
+            "status": "COMPLETED",
+            "responses": [
+                {
+                    "id": "msg-skill",
+                    "role": "assistant",
+                    "content": [{"type": "text", "text": "Response in skill mode"}]
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_ask(
+        &targets,
+        "Test message",
+        None,
+        "gpt-5.2",
+        900,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_ask should send skill interaction_mode");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Remove the `--mode` CLI flag from `cx olly ask` — pro mode (skill-based agent) is now always used
- Hardcode `interaction_mode: "skill"` in the API request body; no longer accepting user input for this field
- Remove the `interaction_mode` parameter from `run_ask()` and `OllyApi::send_message()` throughout the call chain
- Update docs (`SKILL.md`) to remove the modes table and usage examples
- Add `ask_sends_skill_interaction_mode` test using `body_partial_json` to explicitly assert `"skill"` is sent in the request body
- Fix stale `"DEEP_RESEARCH"` in the `ask_with_different_models` mock response

Fixes SAG-6.