### PR TITLE
Fix alerts v5 endpoints

### DIFF
--- a/skills/cx-alerts/SKILL.md
+++ b/skills/cx-alerts/SKILL.md
@@ -19,7 +19,7 @@ Use this skill to list, inspect, create, delete, enable, and disable Coralogix a
 | `cx alerts delete <id>` | Delete an alert | - |
 | `cx alerts enable <id>` | Enable an alert | - |
 | `cx alerts disable <id>` | Disable an alert | - |
-| `cx alerts events` | List alert trigger events | `--alert-id`, `--start`, `--end` |
+| `cx alerts events` | List events; use alert-version scoped endpoint when filtering | `--alert-version-id`, `--start`, `--end` |
 | `cx alerts event-stats` | Get alert event statistics | - |
 | `cx alerts suppression-rules list` | List suppression rules | - |
 | `cx alerts suppression-rules get <id>` | Get a suppression rule | - |

--- a/src/commands/alerts/api.rs
+++ b/src/commands/alerts/api.rs
@@ -38,9 +38,12 @@ impl AlertDef {
                     .and_then(|v| v.as_str())
             })
             .map(|s| {
-                s.strip_prefix("ALERT_DEF_PRIORITY_")
-                    .unwrap_or(s)
-                    .to_string()
+                let stripped = s.strip_prefix("ALERT_DEF_PRIORITY_").unwrap_or(s);
+                if stripped == "P5_OR_UNSPECIFIED" {
+                    "P5".to_string()
+                } else {
+                    stripped.to_string()
+                }
             })
             .unwrap_or_else(|| "-".to_string())
     }
@@ -133,55 +136,17 @@ pub struct CreateAlertResponse {
 }
 
 #[derive(Debug, Deserialize)]
-pub struct SetActiveResponse {}
-
-#[derive(Debug, Deserialize)]
 pub struct DeleteAlertResponse {}
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct AlertEvent {
-    #[serde(default, deserialize_with = "string_or_number")]
-    pub id: Option<String>,
-    #[serde(default, deserialize_with = "string_or_number")]
-    pub alert_def_id: Option<String>,
-    pub alert_name: Option<String>,
-    pub severity: Option<String>,
-    pub status: Option<String>,
-    pub triggered_at: Option<String>,
-    pub resolved_at: Option<String>,
-}
-
-impl AlertEvent {
-    pub fn display_severity(&self) -> String {
-        self.severity
-            .as_deref()
-            .map(|s| {
-                s.strip_prefix("ALERT_EVENT_SEVERITY_")
-                    .or_else(|| s.strip_prefix("ALERT_DEF_PRIORITY_"))
-                    .unwrap_or(s)
-                    .to_string()
-            })
-            .unwrap_or_else(|| "-".to_string())
-    }
-
-    pub fn display_status(&self) -> String {
-        self.status
-            .as_deref()
-            .map(|s| {
-                s.strip_prefix("ALERT_EVENT_STATUS_")
-                    .unwrap_or(s)
-                    .to_string()
-            })
-            .unwrap_or_else(|| "-".to_string())
-    }
-}
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ListAlertEventsResponse {
+pub struct EventsResponse {
     #[serde(default)]
-    pub alert_events: Vec<AlertEvent>,
+    pub events: Vec<Value>,
+    #[serde(default, alias = "alertEvents")]
+    pub alert_events: Vec<Value>,
+    #[serde(default)]
+    pub pagination: Option<Value>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -193,7 +158,8 @@ pub struct GetAlertEventStatsResponse {
 
 // --- API ---
 
-const ALERTS_BASE: &str = "/mgmt/openapi/latest/alerts/alerts-general/v3";
+const ALERTS_BASE: &str = "/mgmt/openapi/5/alerts/alerts/v3";
+const EVENTS_BASE: &str = "/mgmt/openapi/5/alerts/events/v3";
 
 pub struct AlertsApi<'a> {
     client: &'a CxClient,
@@ -217,7 +183,7 @@ impl<'a> AlertsApi<'a> {
 
     /// Get a single alert definition by alert version ID.
     pub async fn get_by_version_id(&self, version_id: &str) -> Result<Value> {
-        let path = format!("{ALERTS_BASE}/alert-version-id/{version_id}");
+        let path = format!("{ALERTS_BASE}/version-ids/{version_id}");
         self.client.get(&path, &[]).await
     }
 
@@ -226,21 +192,24 @@ impl<'a> AlertsApi<'a> {
         self.client.post(ALERTS_BASE, body).await
     }
 
+    /// Replace an alert definition from a JSON body.
+    pub async fn replace(&self, body: &Value) -> Result<CreateAlertResponse> {
+        self.client.put(ALERTS_BASE, body).await
+    }
+
     /// Delete an alert definition.
     pub async fn delete(&self, id: &str) -> Result<DeleteAlertResponse> {
         let path = format!("{ALERTS_BASE}/{id}");
         self.client.delete(&path).await
     }
 
-    /// Enable or disable an alert definition.
-    pub async fn set_active(&self, id: &str, active: bool) -> Result<SetActiveResponse> {
-        let path = format!("{ALERTS_BASE}/{id}:setActive");
-        let val = if active { "true" } else { "false" };
-        self.client.post_empty(&path, &[("active", val)]).await
+    /// List general events.
+    pub async fn list_events(&self, params: &[(&str, &str)]) -> Result<EventsResponse> {
+        self.client.get(EVENTS_BASE, params).await
     }
 
-    /// List alert events.
-    pub async fn list_events(&self, params: &[(&str, &str)]) -> Result<ListAlertEventsResponse> {
+    /// List events scoped to one or more alert version IDs.
+    pub async fn list_alert_events(&self, params: &[(&str, &str)]) -> Result<EventsResponse> {
         let path = format!("{ALERTS_BASE}/all/events");
         self.client.get(&path, params).await
     }
@@ -250,6 +219,41 @@ impl<'a> AlertsApi<'a> {
         self.client
             .get("/mgmt/openapi/5/v3/alert-event-stats", &[])
             .await
+    }
+}
+
+pub(crate) fn normalize_alert_payload(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            if let Some(priority) = map.get("priority").and_then(Value::as_str) {
+                if let Some(normalized) = normalize_priority(priority) {
+                    map.insert(
+                        "priority".to_string(),
+                        Value::String(normalized.to_string()),
+                    );
+                }
+            }
+            for child in map.values_mut() {
+                normalize_alert_payload(child);
+            }
+        }
+        Value::Array(values) => {
+            for child in values {
+                normalize_alert_payload(child);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn normalize_priority(priority: &str) -> Option<&'static str> {
+    match priority {
+        "P1" => Some("ALERT_DEF_PRIORITY_P1"),
+        "P2" => Some("ALERT_DEF_PRIORITY_P2"),
+        "P3" => Some("ALERT_DEF_PRIORITY_P3"),
+        "P4" => Some("ALERT_DEF_PRIORITY_P4"),
+        "P5" | "ALERT_DEF_PRIORITY_P5" => Some("ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED"),
+        _ => None,
     }
 }
 
@@ -318,6 +322,51 @@ mod tests {
     }
 
     #[test]
+    fn display_priority_maps_p5_unspecified_to_p5() {
+        let alert = AlertDef {
+            id: None,
+            name: None,
+            description: None,
+            enabled: None,
+            priority: Some("ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED".to_string()),
+            alert_type: None,
+            status: None,
+            created_time: None,
+            updated_time: None,
+            last_triggered_time: None,
+            alert_def_properties: None,
+        };
+        assert_eq!(alert.display_priority(), "P5");
+    }
+
+    #[test]
+    fn normalize_alert_payload_rewrites_p5_priorities() {
+        let mut payload = json!({
+            "alertDefProperties": {
+                "priority": "P5",
+                "rules": [
+                    {
+                        "override": {
+                            "priority": "ALERT_DEF_PRIORITY_P5"
+                        }
+                    }
+                ]
+            }
+        });
+
+        normalize_alert_payload(&mut payload);
+
+        assert_eq!(
+            payload["alertDefProperties"]["priority"],
+            "ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED"
+        );
+        assert_eq!(
+            payload["alertDefProperties"]["rules"][0]["override"]["priority"],
+            "ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED"
+        );
+    }
+
+    #[test]
     fn display_type_strips_prefix_and_titlecases() {
         let alert = AlertDef {
             id: None,
@@ -368,7 +417,7 @@ mod tests {
             last_triggered_time: None,
             alert_def_properties: Some(json!({
                 "name": "From Properties",
-                "priority": "ALERT_DEF_PRIORITY_P5",
+                "priority": "ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED",
                 "type": "ALERT_DEF_TYPE_LOGS_IMMEDIATE",
                 "enabled": true
             })),
@@ -439,12 +488,6 @@ mod tests {
         let def = resp.alert_def.unwrap();
         assert_eq!(def.id.as_deref(), Some("new-id"));
         assert_eq!(def.name.as_deref(), Some("Created Alert"));
-    }
-
-    #[test]
-    fn deserialize_set_active_response() {
-        let json = json!({});
-        let _resp: SetActiveResponse = serde_json::from_value(json).unwrap();
     }
 
     #[test]

--- a/src/commands/alerts/mod.rs
+++ b/src/commands/alerts/mod.rs
@@ -60,6 +60,18 @@ fn event_to_json(event: &Value, include_profile: bool, profile: &str) -> Value {
     v
 }
 
+fn next_page_token(pagination: Option<&Value>) -> Option<String> {
+    pagination
+        .and_then(|p| {
+            p.get("nextPageToken")
+                .or_else(|| p.get("next_page_token"))
+                .or_else(|| p.get("next_page"))
+        })
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+        .map(ToString::to_string)
+}
+
 // ── Subcommand runners ────────────────────────────────────────────────────────
 
 pub async fn run_list(
@@ -443,30 +455,51 @@ pub async fn run_events(
         let end = end_owned.clone();
         async move {
             let api = AlertsApi::new(&t.client);
-            let mut params: Vec<(&str, String)> = Vec::new();
-            if alert_version_ids.is_empty() {
-                params.push((
-                    "filter.timestamp.from",
-                    crate::time::parse_timestamp(&start)?,
-                ));
-                params.push(("filter.timestamp.to", crate::time::parse_timestamp(&end)?));
-                params.push(("pagination.page_size", "100".to_string()));
-                let params_ref: Vec<(&str, &str)> =
-                    params.iter().map(|(k, v)| (*k, v.as_str())).collect();
-                Ok(api.list_events(&params_ref).await?)
-            } else {
-                for id in &alert_version_ids {
-                    params.push(("alert_ids", id.clone()));
+            let start = crate::time::parse_timestamp(&start)?;
+            let end = crate::time::parse_timestamp(&end)?;
+            let mut all_events = Vec::new();
+            let mut page_token: Option<String> = None;
+
+            loop {
+                let mut params: Vec<(&str, String)> = Vec::new();
+                if alert_version_ids.is_empty() {
+                    params.push(("filter.timestamp.from", start.clone()));
+                    params.push(("filter.timestamp.to", end.clone()));
+                    params.push(("pagination.page_size", "100".to_string()));
+                } else {
+                    for id in &alert_version_ids {
+                        params.push(("alert_ids", id.clone()));
+                    }
+                    params.push(("timestamp_range.from", start.clone()));
+                    params.push(("timestamp_range.to", end.clone()));
                 }
-                params.push((
-                    "timestamp_range.from",
-                    crate::time::parse_timestamp(&start)?,
-                ));
-                params.push(("timestamp_range.to", crate::time::parse_timestamp(&end)?));
+                if let Some(token) = &page_token {
+                    params.push(("pagination.page_token", token.clone()));
+                }
+
                 let params_ref: Vec<(&str, &str)> =
                     params.iter().map(|(k, v)| (*k, v.as_str())).collect();
-                Ok(api.list_alert_events(&params_ref).await?)
+
+                let resp = if alert_version_ids.is_empty() {
+                    api.list_events(&params_ref).await?
+                } else {
+                    api.list_alert_events(&params_ref).await?
+                };
+                let next = next_page_token(resp.pagination.as_ref());
+                all_events.extend(if resp.events.is_empty() {
+                    resp.alert_events
+                } else {
+                    resp.events
+                });
+
+                match next {
+                    Some(next) if page_token.as_deref() != Some(next.as_str()) => {
+                        page_token = Some(next);
+                    }
+                    _ => break,
+                }
             }
+            Ok(all_events)
         }
     })
     .await;
@@ -475,12 +508,7 @@ pub async fn run_events(
     let mut all_items: Vec<(String, Value)> = Vec::new();
     for (profile, result) in per_profile {
         match result {
-            Ok(resp) => {
-                let events = if resp.events.is_empty() {
-                    resp.alert_events
-                } else {
-                    resp.events
-                };
+            Ok(events) => {
                 for event in events {
                     all_json.push(event_to_json(&event, include_profile, &profile));
                     all_items.push((profile.clone(), event));

--- a/src/commands/alerts/mod.rs
+++ b/src/commands/alerts/mod.rs
@@ -11,7 +11,7 @@ use crate::config::OutputFormat;
 use crate::error::CxError;
 use crate::execution::{fan_out, ExecutionTarget};
 use crate::render;
-use api::{AlertDef, AlertEvent, AlertsApi};
+use api::{normalize_alert_payload, AlertDef, AlertsApi};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -28,6 +28,30 @@ fn alert_to_json(alert: &AlertDef, include_profile: bool, profile: &str) -> Valu
         "updated_time": alert.updated_time,
         "last_triggered_time": alert.last_triggered_time,
     });
+    if include_profile {
+        if let Value::Object(ref mut m) = v {
+            m.insert("profile".to_string(), Value::String(profile.to_string()));
+        }
+    }
+    v
+}
+
+fn event_field(event: &Value, keys: &[&str]) -> String {
+    for key in keys {
+        if let Some(value) = event.get(*key) {
+            if let Some(s) = value.as_str() {
+                return s.to_string();
+            }
+            if value.is_number() || value.is_boolean() {
+                return value.to_string();
+            }
+        }
+    }
+    String::new()
+}
+
+fn event_to_json(event: &Value, include_profile: bool, profile: &str) -> Value {
+    let mut v = event.clone();
     if include_profile {
         if let Value::Object(ref mut m) = v {
             m.insert("profile".to_string(), Value::String(profile.to_string()));
@@ -220,12 +244,13 @@ pub async fn run_create(
         std::fs::read_to_string(from_file)?
     };
 
-    let body: Value = serde_json::from_str(&raw)?;
+    let mut body: Value = serde_json::from_str(&raw)?;
 
     // Validate that alertDefProperties exists
     if body.get("alertDefProperties").is_none() {
         bail!("JSON must contain an 'alertDefProperties' key. See `cx alerts create --help`.");
     }
+    normalize_alert_payload(&mut body);
 
     eprintln!("{}", "Creating alert...".dimmed());
 
@@ -311,6 +336,33 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
     Ok(())
 }
 
+fn replace_body_with_enabled(
+    mut alert_response: Value,
+    alert_id: &str,
+    active: bool,
+) -> Result<Value> {
+    let alert_def = alert_response
+        .get_mut("alertDef")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| anyhow::anyhow!("Alert response did not contain 'alertDef'."))?;
+
+    let mut properties = alert_def
+        .remove("alertDefProperties")
+        .ok_or_else(|| anyhow::anyhow!("Alert response did not contain 'alertDefProperties'."))?;
+
+    let props = properties
+        .as_object_mut()
+        .ok_or_else(|| anyhow::anyhow!("'alertDefProperties' was not a JSON object."))?;
+    props.insert("enabled".to_string(), Value::Bool(active));
+
+    let mut body = json!({
+        "id": alert_id,
+        "alertDefProperties": properties,
+    });
+    normalize_alert_payload(&mut body);
+    Ok(body)
+}
+
 pub async fn run_enable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Result<()> {
     eprintln!("{}", format!("Enabling alert {alert_id}...").dimmed());
 
@@ -320,7 +372,9 @@ pub async fn run_enable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
         let id = id.clone();
         async move {
             let api = AlertsApi::new(&t.client);
-            api.set_active(&id, true).await?;
+            let alert = api.get(&id).await?;
+            let body = replace_body_with_enabled(alert, &id, true)?;
+            api.replace(&body).await?;
             Ok(())
         }
     })
@@ -348,7 +402,9 @@ pub async fn run_disable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Re
         let id = id.clone();
         async move {
             let api = AlertsApi::new(&t.client);
-            api.set_active(&id, false).await?;
+            let alert = api.get(&id).await?;
+            let body = replace_body_with_enabled(alert, &id, false)?;
+            api.replace(&body).await?;
             Ok(())
         }
     })
@@ -369,7 +425,7 @@ pub async fn run_disable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Re
 
 pub async fn run_events(
     targets: &[Arc<ExecutionTarget>],
-    alert_id: Option<&str>,
+    alert_version_ids: &[String],
     start: Option<&str>,
     end: Option<&str>,
     output: OutputFormat,
@@ -377,54 +433,56 @@ pub async fn run_events(
     eprintln!("{}", "Fetching alert events...".dimmed());
 
     let include_profile = targets.len() > 1;
-    let alert_id_owned = alert_id.map(|s| s.to_string());
-    let start_owned = start.map(|s| s.to_string());
-    let end_owned = end.map(|s| s.to_string());
+    let alert_version_ids = alert_version_ids.to_vec();
+    let start_owned = start.unwrap_or("now-24h").to_string();
+    let end_owned = end.unwrap_or("now").to_string();
 
     let per_profile = fan_out(targets, |t| {
-        let alert_id = alert_id_owned.clone();
+        let alert_version_ids = alert_version_ids.clone();
         let start = start_owned.clone();
         let end = end_owned.clone();
         async move {
             let api = AlertsApi::new(&t.client);
             let mut params: Vec<(&str, String)> = Vec::new();
-            if let Some(ref id) = alert_id {
-                params.push(("alert_id", id.clone()));
+            if alert_version_ids.is_empty() {
+                params.push((
+                    "filter.timestamp.from",
+                    crate::time::parse_timestamp(&start)?,
+                ));
+                params.push(("filter.timestamp.to", crate::time::parse_timestamp(&end)?));
+                params.push(("pagination.page_size", "100".to_string()));
+                let params_ref: Vec<(&str, &str)> =
+                    params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+                Ok(api.list_events(&params_ref).await?)
+            } else {
+                for id in &alert_version_ids {
+                    params.push(("alert_ids", id.clone()));
+                }
+                params.push((
+                    "timestamp_range.from",
+                    crate::time::parse_timestamp(&start)?,
+                ));
+                params.push(("timestamp_range.to", crate::time::parse_timestamp(&end)?));
+                let params_ref: Vec<(&str, &str)> =
+                    params.iter().map(|(k, v)| (*k, v.as_str())).collect();
+                Ok(api.list_alert_events(&params_ref).await?)
             }
-            if let Some(ref s) = start {
-                params.push(("start", s.clone()));
-            }
-            if let Some(ref e) = end {
-                params.push(("end", e.clone()));
-            }
-            let params_ref: Vec<(&str, &str)> =
-                params.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            Ok(api.list_events(&params_ref).await?)
         }
     })
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
-    let mut all_items: Vec<(String, AlertEvent)> = Vec::new();
+    let mut all_items: Vec<(String, Value)> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
-                for event in resp.alert_events {
-                    let mut v = json!({
-                        "id": event.id,
-                        "alert_def_id": event.alert_def_id,
-                        "alert_name": event.alert_name,
-                        "severity": event.display_severity(),
-                        "status": event.display_status(),
-                        "triggered_at": event.triggered_at,
-                        "resolved_at": event.resolved_at,
-                    });
-                    if include_profile {
-                        if let Value::Object(ref mut m) = v {
-                            m.insert("profile".to_string(), Value::String(profile.clone()));
-                        }
-                    }
-                    all_json.push(v);
+                let events = if resp.events.is_empty() {
+                    resp.alert_events
+                } else {
+                    resp.events
+                };
+                for event in events {
+                    all_json.push(event_to_json(&event, include_profile, &profile));
                     all_items.push((profile.clone(), event));
                 }
             }
@@ -446,24 +504,24 @@ pub async fn run_events(
             }
             let rows: Vec<Vec<String>> = all_items
                 .iter()
-                .map(|(profile, evt)| {
+                .map(|(profile, event)| {
                     vec![
                         profile.clone(),
-                        evt.id.clone().unwrap_or_default(),
-                        evt.alert_name.clone().unwrap_or_default(),
-                        evt.display_severity(),
-                        evt.display_status(),
-                        evt.triggered_at.clone().unwrap_or_default(),
+                        event_field(event, &["cxEventKey", "id", "eventId"]),
+                        event_field(event, &["cxEventType", "type", "status"]),
+                        event_field(event, &["cxEventPayloadType", "alertName", "alert_name"]),
+                        event_field(event, &["cxEventTimestamp", "triggeredAt", "triggered_at"]),
+                        event_field(event, &["cxEventDedupKey", "dedupKey"]),
                     ]
                 })
                 .collect();
             render::render_table(
                 &[
-                    "Event ID",
-                    "Alert Name",
-                    "Severity",
-                    "Status",
-                    "Triggered At",
+                    "Event Key",
+                    "Type",
+                    "Payload Type",
+                    "Timestamp",
+                    "Dedup Key",
                 ],
                 rows,
                 include_profile,

--- a/src/main.rs
+++ b/src/main.rs
@@ -913,12 +913,12 @@ Examples:
     #[command(after_help = "\
 Examples:
   cx alerts events
-  cx alerts events --alert-id <id>
-  cx alerts events --start now-24h")]
+  cx alerts events --alert-version-id <version-id>
+  cx alerts events --alert-version-id <version-id> --start now-24h")]
     Events {
-        /// Filter by alert definition ID.
+        /// Filter by alert version ID. Repeat to include multiple alert versions.
         #[arg(long)]
-        alert_id: Option<String>,
+        alert_version_id: Vec<String>,
 
         /// Start time filter (ISO 8601 or relative).
         #[arg(long)]
@@ -2501,13 +2501,13 @@ async fn main() -> Result<()> {
                 commands::alerts::run_disable(&targets, &alert_id).await?;
             }
             AlertsCmd::Events {
-                alert_id,
+                alert_version_id,
                 start,
                 end,
             } => {
                 commands::alerts::run_events(
                     &targets,
-                    alert_id.as_deref(),
+                    &alert_version_id,
                     start.as_deref(),
                     end.as_deref(),
                     output,

--- a/tests/alerts/main.rs
+++ b/tests/alerts/main.rs
@@ -2,7 +2,7 @@
 mod common;
 
 use serde_json::json;
-use wiremock::matchers::{body_json, method, path, query_param};
+use wiremock::matchers::{body_json, method, path, query_param, query_param_is_missing};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use coralogix_cli::commands::alerts::{
@@ -273,6 +273,46 @@ async fn events_without_alert_version_ids_uses_general_events_endpoint() {
 }
 
 #[tokio::test]
+async fn events_without_alert_version_ids_paginates_general_events_endpoint() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/events/v3"))
+        .and(query_param_is_missing("pagination.page_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": [
+                { "cxEventKey": "event-1" }
+            ],
+            "pagination": {
+                "nextPageToken": "page-2"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/events/v3"))
+        .and(query_param("pagination.page_token", "page-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": [
+                { "cxEventKey": "event-2" }
+            ],
+            "pagination": {}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_events(&targets, &[], None, None, OutputFormat::Json)
+        .await
+        .expect("run_events should paginate general events endpoint");
+}
+
+#[tokio::test]
 async fn events_with_alert_version_ids_uses_scoped_endpoint() {
     let server = MockServer::start().await;
 
@@ -293,4 +333,47 @@ async fn events_with_alert_version_ids_uses_scoped_endpoint() {
     run_events(&targets, &ids, None, None, OutputFormat::Json)
         .await
         .expect("run_events should use scoped alert events endpoint");
+}
+
+#[tokio::test]
+async fn events_with_alert_version_ids_paginates_scoped_endpoint() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/all/events"))
+        .and(query_param("alert_ids", "version-001"))
+        .and(query_param_is_missing("pagination.page_token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "alertEvents": [
+                { "cxEventKey": "event-1" }
+            ],
+            "pagination": {
+                "nextPageToken": "page-2"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/all/events"))
+        .and(query_param("alert_ids", "version-001"))
+        .and(query_param("pagination.page_token", "page-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "alertEvents": [
+                { "cxEventKey": "event-2" }
+            ],
+            "pagination": {}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+    let ids = vec!["version-001".to_string()];
+
+    run_events(&targets, &ids, None, None, OutputFormat::Json)
+        .await
+        .expect("run_events should paginate scoped alert events endpoint");
 }

--- a/tests/alerts/main.rs
+++ b/tests/alerts/main.rs
@@ -2,10 +2,12 @@
 mod common;
 
 use serde_json::json;
-use wiremock::matchers::{method, path, query_param};
+use wiremock::matchers::{body_json, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use coralogix_cli::commands::alerts::{run_delete, run_disable, run_enable, run_get, run_list};
+use coralogix_cli::commands::alerts::{
+    run_delete, run_disable, run_enable, run_events, run_get, run_list,
+};
 use coralogix_cli::config::OutputFormat;
 
 #[tokio::test]
@@ -35,7 +37,7 @@ async fn list_alerts_returns_items_from_mock() {
     });
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -61,7 +63,7 @@ async fn list_alerts_with_name_filter() {
     });
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -92,9 +94,7 @@ async fn get_alert_by_id() {
     });
 
     Mock::given(method("GET"))
-        .and(path(
-            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-001",
-        ))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/alert-001"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -114,9 +114,7 @@ async fn get_alert_falls_back_to_version_id_on_404() {
 
     // Primary endpoint returns 404
     Mock::given(method("GET"))
-        .and(path(
-            "/mgmt/openapi/latest/alerts/alerts-general/v3/ver-123",
-        ))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/ver-123"))
         .respond_with(ResponseTemplate::new(404).set_body_json(json!({"message": "not found"})))
         .expect(1)
         .mount(&server)
@@ -130,9 +128,7 @@ async fn get_alert_falls_back_to_version_id_on_404() {
         }
     });
     Mock::given(method("GET"))
-        .and(path(
-            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-version-id/ver-123",
-        ))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/version-ids/ver-123"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -150,11 +146,32 @@ async fn get_alert_falls_back_to_version_id_on_404() {
 async fn enable_alert() {
     let server = MockServer::start().await;
 
-    Mock::given(method("POST"))
-        .and(path(
-            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-001:setActive",
-        ))
-        .and(query_param("active", "true"))
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/alert-001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "alertDef": {
+                "id": "alert-001",
+                "alertDefProperties": {
+                    "name": "Test",
+                    "enabled": false,
+                    "priority": "ALERT_DEF_PRIORITY_P5"
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
+        .and(body_json(json!({
+            "id": "alert-001",
+            "alertDefProperties": {
+                "name": "Test",
+                "enabled": true,
+                "priority": "ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED"
+            }
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .expect(1)
         .mount(&server)
@@ -173,9 +190,7 @@ async fn delete_alert() {
     let server = MockServer::start().await;
 
     Mock::given(method("DELETE"))
-        .and(path(
-            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-001",
-        ))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/alert-001"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .expect(1)
         .mount(&server)
@@ -193,11 +208,30 @@ async fn delete_alert() {
 async fn disable_alert() {
     let server = MockServer::start().await;
 
-    Mock::given(method("POST"))
-        .and(path(
-            "/mgmt/openapi/latest/alerts/alerts-general/v3/alert-001:setActive",
-        ))
-        .and(query_param("active", "false"))
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/alert-001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "alertDef": {
+                "id": "alert-001",
+                "alertDefProperties": {
+                    "name": "Test",
+                    "enabled": true
+                }
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
+        .and(body_json(json!({
+            "id": "alert-001",
+            "alertDefProperties": {
+                "name": "Test",
+                "enabled": false
+            }
+        })))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .expect(1)
         .mount(&server)
@@ -209,4 +243,54 @@ async fn disable_alert() {
     run_disable(&targets, "alert-001")
         .await
         .expect("run_disable should succeed");
+}
+
+#[tokio::test]
+async fn events_without_alert_version_ids_uses_general_events_endpoint() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/events/v3"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": [
+                {
+                    "cxEventKey": "event-1",
+                    "cxEventType": "test",
+                    "cxEventTimestamp": "1714857600"
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_events(&targets, &[], None, None, OutputFormat::Json)
+        .await
+        .expect("run_events should use general events endpoint");
+}
+
+#[tokio::test]
+async fn events_with_alert_version_ids_uses_scoped_endpoint() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3/all/events"))
+        .and(query_param("alert_ids", "version-001"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "events": []
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+    let ids = vec!["version-001".to_string()];
+
+    run_events(&targets, &ids, None, None, OutputFormat::Json)
+        .await
+        .expect("run_events should use scoped alert events endpoint");
 }

--- a/tests/profile_override/main.rs
+++ b/tests/profile_override/main.rs
@@ -53,7 +53,7 @@ async fn explicit_profile_uses_profile_key_not_env_var() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .and(header("Authorization", "Bearer profile-key-aaa"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "alertDefs": []
@@ -78,7 +78,7 @@ async fn no_explicit_profile_uses_env_var_key() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .and(header("Authorization", "Bearer env-key-bbb"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "alertDefs": []
@@ -103,7 +103,7 @@ async fn explicit_api_key_flag_overrides_profile_key() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .and(header("Authorization", "Bearer explicit-flag-key"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "alertDefs": []
@@ -136,7 +136,7 @@ async fn explicit_profile_uses_profile_region_not_env_var() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "alertDefs": []
         })))
@@ -164,7 +164,7 @@ async fn multi_profile_with_env_api_key_does_not_bail() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "alertDefs": []
         })))
@@ -202,7 +202,7 @@ async fn multi_profile_with_env_region_does_not_bail() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/alerts/alerts-general/v3"))
+        .and(path("/mgmt/openapi/5/alerts/alerts/v3"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "alertDefs": []
         })))


### PR DESCRIPTION
## Summary
- move alerts command paths to the v5 alert definitions/events APIs
- normalize P5 priorities to the accepted ALERT_DEF_PRIORITY_P5_OR_UNSPECIFIED wire value while rendering them as P5
- replace enable/disable setActive calls with v5 get-modify-replace
- split alerts events behavior between general events and alert-version-scoped events

## Validation
- cargo test
- staging smoke test with temporary alert aaa8aef1-6b44-42f9-ab0c-0fbefece8ab4, deleted and verified gone
- verified scoped alert version ID 26f1d427-bea1-4af7-8709-a810e5d3b35b returned [] for events as expected