### PR TITLE
Use OpenAPI 5 management endpoints

### DIFF
--- a/contributing/adding-a-command.md
+++ b/contributing/adding-a-command.md
@@ -220,7 +220,7 @@ pub struct ListResponse {
 
 // ── API client ─────────────────────────────────────────────────────
 
-const BASE_PATH: &str = "/mgmt/openapi/latest/your-domain/v1";
+const BASE_PATH: &str = "/mgmt/openapi/5/your-domain/v1";
 
 pub struct YourDomainApi<'a> {
     client: &'a CxClient,
@@ -582,7 +582,7 @@ async fn list_returns_items_from_mock() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/your-domain/v1"))
+        .and(path("/mgmt/openapi/5/your-domain/v1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({
             "items": [{ "id": "abc-123", "name": "Test" }]
         })))

--- a/src/commands/e2m/api.rs
+++ b/src/commands/e2m/api.rs
@@ -80,7 +80,7 @@ pub struct E2mLimitsResponse {
 
 // --- API ---
 
-const E2M_BASE: &str = "/mgmt/openapi/latest/events2metrics/events2metrics/v2";
+const E2M_BASE: &str = "/mgmt/openapi/5/events2metrics/events2metrics/v2";
 
 pub struct E2mApi<'a> {
     client: &'a CxClient,

--- a/src/commands/integrations/api.rs
+++ b/src/commands/integrations/api.rs
@@ -52,7 +52,7 @@ pub struct DeleteIntegrationResponse {}
 
 // --- API ---
 
-const INTEGRATIONS_BASE: &str = "/mgmt/openapi/latest/integrations/integrations/v1";
+const INTEGRATIONS_BASE: &str = "/mgmt/openapi/5/integrations/integrations/v1";
 
 pub struct IntegrationsApi<'a> {
     client: &'a CxClient,

--- a/src/commands/notification_testing/api.rs
+++ b/src/commands/notification_testing/api.rs
@@ -16,7 +16,7 @@ pub struct TestResultResponse {
 
 // --- API ---
 
-const NOTIFICATION_TEST_BASE: &str = "/mgmt/openapi/latest/notifications/notification-center/v1";
+const NOTIFICATION_TEST_BASE: &str = "/mgmt/openapi/5/notifications/notification-center/v1";
 
 pub struct NotificationTestingApi<'a> {
     client: &'a CxClient,

--- a/src/commands/retentions/api.rs
+++ b/src/commands/retentions/api.rs
@@ -43,7 +43,7 @@ pub struct RetentionStatusResponse {
 
 // --- API ---
 
-const RETENTIONS_BASE: &str = "/mgmt/openapi/latest/dataengine/retention-tags/v1";
+const RETENTIONS_BASE: &str = "/mgmt/openapi/5/dataengine/retention-tags/v1";
 
 pub struct RetentionsApi<'a> {
     client: &'a CxClient,

--- a/src/commands/routers/api.rs
+++ b/src/commands/routers/api.rs
@@ -61,7 +61,7 @@ pub struct DeleteRouterResponse {}
 
 // --- API ---
 
-const ROUTERS_BASE: &str = "/mgmt/openapi/latest/notifications/notification-center/v1/routers";
+const ROUTERS_BASE: &str = "/mgmt/openapi/5/notifications/notification-center/v1/routers";
 
 pub struct RoutersApi<'a> {
     client: &'a CxClient,

--- a/tests/e2m/main.rs
+++ b/tests/e2m/main.rs
@@ -32,9 +32,7 @@ async fn list_e2m_returns_items_from_mock() {
     });
 
     Mock::given(method("GET"))
-        .and(path(
-            "/mgmt/openapi/5/events2metrics/events2metrics/v2",
-        ))
+        .and(path("/mgmt/openapi/5/events2metrics/events2metrics/v2"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)

--- a/tests/e2m/main.rs
+++ b/tests/e2m/main.rs
@@ -33,7 +33,7 @@ async fn list_e2m_returns_items_from_mock() {
 
     Mock::given(method("GET"))
         .and(path(
-            "/mgmt/openapi/latest/events2metrics/events2metrics/v2",
+            "/mgmt/openapi/5/events2metrics/events2metrics/v2",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
@@ -62,7 +62,7 @@ async fn get_e2m_by_id() {
 
     Mock::given(method("GET"))
         .and(path(
-            "/mgmt/openapi/latest/events2metrics/events2metrics/v2/e2m-001",
+            "/mgmt/openapi/5/events2metrics/events2metrics/v2/e2m-001",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)

--- a/tests/integrations/main.rs
+++ b/tests/integrations/main.rs
@@ -19,7 +19,7 @@ async fn list_integrations_from_mock() {
     });
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/integrations/integrations/v1"))
+        .and(path("/mgmt/openapi/5/integrations/integrations/v1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -36,7 +36,7 @@ async fn list_integrations_empty() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/integrations/integrations/v1"))
+        .and(path("/mgmt/openapi/5/integrations/integrations/v1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "deployments": [] })))
         .expect(1)
         .mount(&server)

--- a/tests/notification_testing/main.rs
+++ b/tests/notification_testing/main.rs
@@ -14,7 +14,7 @@ async fn test_connector_from_mock() {
 
     Mock::given(method("POST"))
         .and(path(
-            "/mgmt/openapi/latest/notifications/notification-center/v1/connectors/tests/config",
+            "/mgmt/openapi/5/notifications/notification-center/v1/connectors/tests/config",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
         .expect(1)

--- a/tests/retentions/main.rs
+++ b/tests/retentions/main.rs
@@ -19,7 +19,7 @@ async fn retentions_list_from_mock() {
     });
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/latest/dataengine/retention-tags/v1"))
+        .and(path("/mgmt/openapi/5/dataengine/retention-tags/v1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -39,7 +39,7 @@ async fn retentions_status_from_mock() {
 
     Mock::given(method("GET"))
         .and(path(
-            "/mgmt/openapi/latest/dataengine/retention-tags/v1/enabled",
+            "/mgmt/openapi/5/dataengine/retention-tags/v1/enabled",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"enabled": true})))
         .expect(1)

--- a/tests/retentions/main.rs
+++ b/tests/retentions/main.rs
@@ -38,9 +38,7 @@ async fn retentions_status_from_mock() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path(
-            "/mgmt/openapi/5/dataengine/retention-tags/v1/enabled",
-        ))
+        .and(path("/mgmt/openapi/5/dataengine/retention-tags/v1/enabled"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"enabled": true})))
         .expect(1)
         .mount(&server)

--- a/tests/routers/main.rs
+++ b/tests/routers/main.rs
@@ -20,7 +20,7 @@ async fn list_routers_from_mock() {
 
     Mock::given(method("GET"))
         .and(path(
-            "/mgmt/openapi/latest/notifications/notification-center/v1/routers",
+            "/mgmt/openapi/5/notifications/notification-center/v1/routers",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)


### PR DESCRIPTION
## Summary
- Replace remaining /mgmt/openapi/latest management endpoint paths with /mgmt/openapi/5
- Update matching integration-test mocks
- Update the contributing guide command template examples

## Testing
- cargo test --test routers --test retentions --test e2m --test notification_testing --test integrations
- cargo test
- Manual staging smoke tests with -p stg:
  - cx -p stg e2m list -o json
  - cx -p stg e2m get 06e8c3ad-a1b4-422f-909a-da5a1e36fd42 -o json
  - cx -p stg e2m limits -o json
  - cx -p stg retentions list -o json
  - cx -p stg retentions status -o json
  - cx -p stg integrations list -o json
  - cx -p stg notifications routers list -o json
  - cx -p stg notifications routers get router_default -o json

Note: notifications test endpoints were skipped because they currently do not work in the backend.