### PR TITLE
Fix data usage streaming responses

### DIFF
--- a/skills/cx-cost-optimization/SKILL.md
+++ b/skills/cx-cost-optimization/SKILL.md
@@ -36,6 +36,8 @@ Key flags:
 - All commands support `-o json` for structured output and `-p <profile>` for profile selection
 - `cx usage daily` accepts `--type processed-gbs|units|evaluation-tokens` and `--start`/`--end` time filters
 - `cx usage summary` accepts `--start`/`--end` time filters
+- `cx usage logs-count` and `cx usage spans-count` accept `--start`/`--end` time filters, defaulting to the last 24h, plus `--resolution` (default `1h`), `--subsystem-aggregation`, `--application-aggregation`, and repeated `--param KEY=VALUE` for API filter query params
+- Data usage summary and count endpoints are documented as newline-delimited JSON over `Accept: text/event-stream`; the CLI handles that transport and normalizes count chunks into `.result.logsCount[]` or `.result.spansCount[]`.
 - `cx tco create/update`, `cx retentions update`, `cx archive logs set`, `cx archive metrics create/update/validate` use `--from-file <path>` (or `-` for stdin)
 
 ---
@@ -50,8 +52,8 @@ Follow these steps to diagnose and reduce costs:
 cx usage summary -o json
 cx usage summary --start now-30d -o json
 cx usage daily --type processed-gbs --start now-7d -o json
-cx usage logs-count -o json
-cx usage spans-count -o json
+cx usage logs-count --start now-7d --end now -o json
+cx usage spans-count --start now-7d --end now -o json
 ```
 
 Identify which data types consume the most volume. Use `jq` to sort:
@@ -120,8 +122,8 @@ cx usage summary -o json | jq '[.[] | {name, daily_avg: .avg_daily_gb}] | sort_b
 cx usage daily --type processed-gbs --start now-7d -o json | jq '[.[] | {date, gb: .processed_gbs}]'
 
 # Total logs and spans counts
-cx usage logs-count -o json | jq '.total_count'
-cx usage spans-count -o json | jq '.total_count'
+cx usage logs-count --start now-7d --end now -o json | jq '[.result.logsCount[]?.logsCount | tonumber] | add // 0'
+cx usage spans-count --start now-7d --end now -o json | jq '[.result.spansCount[]? | ((.successSpanCount | tonumber) + (.errorSpanCount | tonumber) + (.lowSuccessSpanCount | tonumber) + (.lowErrorSpanCount | tonumber) + (.mediumSuccessSpanCount | tonumber) + (.mediumErrorSpanCount | tonumber))] | add // 0'
 ```
 
 ### TCO Policy Analysis

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -51,13 +51,6 @@ impl CxClient {
         Ok(serde_json::from_str(&text)?)
     }
 
-    /// GET with optional query params, return the raw response text.
-    pub async fn get_raw(&self, path: &str, params: &[(&str, &str)]) -> Result<String> {
-        let url = format!("{}{path}", self.endpoint);
-        let resp = self.inner.get(&url).query(params).send().await?;
-        self.checked_text(resp).await
-    }
-
     /// GET an endpoint documented as newline-delimited JSON over event-stream.
     pub async fn get_event_stream_raw(
         &self,

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -51,20 +51,19 @@ impl CxClient {
         Ok(serde_json::from_str(&text)?)
     }
 
-    /// GET an endpoint documented as newline-delimited JSON over event-stream.
-    pub async fn get_event_stream_raw(
+    /// GET with optional query params, return the raw response text.
+    pub async fn get_raw(
         &self,
         path: &str,
         params: &[(&str, &str)],
+        headers: &[(&str, &str)],
     ) -> Result<String> {
         let url = format!("{}{path}", self.endpoint);
-        let resp = self
-            .inner
-            .get(&url)
-            .header(header::ACCEPT, "text/event-stream")
-            .query(params)
-            .send()
-            .await?;
+        let mut req = self.inner.get(&url).query(params);
+        for (key, value) in headers {
+            req = req.header(*key, *value);
+        }
+        let resp = req.send().await?;
         self.checked_text(resp).await
     }
 

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -51,6 +51,30 @@ impl CxClient {
         Ok(serde_json::from_str(&text)?)
     }
 
+    /// GET with optional query params, return the raw response text.
+    pub async fn get_raw(&self, path: &str, params: &[(&str, &str)]) -> Result<String> {
+        let url = format!("{}{path}", self.endpoint);
+        let resp = self.inner.get(&url).query(params).send().await?;
+        self.checked_text(resp).await
+    }
+
+    /// GET an endpoint documented as newline-delimited JSON over event-stream.
+    pub async fn get_event_stream_raw(
+        &self,
+        path: &str,
+        params: &[(&str, &str)],
+    ) -> Result<String> {
+        let url = format!("{}{path}", self.endpoint);
+        let resp = self
+            .inner
+            .get(&url)
+            .header(header::ACCEPT, "text/event-stream")
+            .query(params)
+            .send()
+            .await?;
+        self.checked_text(resp).await
+    }
+
     /// POST JSON body, deserialize response into T.
     pub async fn post<T: DeserializeOwned>(&self, path: &str, body: &Value) -> Result<T> {
         let url = format!("{}{path}", self.endpoint);

--- a/src/commands/data_usage/api.rs
+++ b/src/commands/data_usage/api.rs
@@ -88,7 +88,7 @@ impl<'a> DataUsageApi<'a> {
 
 pub fn parse_data_usage_raw_response(raw: &str) -> Result<Value> {
     if let Ok(value) = serde_json::from_str(raw) {
-        return Ok(value);
+        return Ok(normalize_result_array_object(value));
     }
 
     // The Data Usage overview documents `Get data usage`, `logs/count`, and
@@ -113,7 +113,7 @@ pub fn parse_data_usage_raw_response(raw: &str) -> Result<Value> {
 
     Ok(match values.len() {
         0 => Value::Null,
-        1 => values.remove(0),
+        1 => normalize_result_array_object(values.remove(0)),
         _ => merge_result_array_chunks(&values).unwrap_or(Value::Array(values)),
     })
 }
@@ -124,11 +124,7 @@ fn merge_result_array_chunks(values: &[Value]) -> Option<Value> {
         let mut matched = false;
 
         for value in values {
-            let Some(items) = value
-                .get("result")
-                .and_then(|result| result.get(result_key))
-                .and_then(Value::as_array)
-            else {
+            let Some(items) = result_array_items(value, result_key) else {
                 matched = false;
                 break;
             };
@@ -147,6 +143,36 @@ fn merge_result_array_chunks(values: &[Value]) -> Option<Value> {
     }
 
     None
+}
+
+fn normalize_result_array_object(value: Value) -> Value {
+    for result_key in ["logsCount", "spansCount"] {
+        if value
+            .get("result")
+            .and_then(|result| result.get(result_key))
+            .is_some()
+        {
+            return value;
+        }
+
+        if let Some(items) = value.get(result_key).and_then(Value::as_array) {
+            return serde_json::json!({
+                "result": {
+                    result_key: items
+                }
+            });
+        }
+    }
+
+    value
+}
+
+fn result_array_items<'a>(value: &'a Value, result_key: &str) -> Option<&'a Vec<Value>> {
+    value
+        .get("result")
+        .and_then(|result| result.get(result_key))
+        .or_else(|| value.get(result_key))
+        .and_then(Value::as_array)
 }
 
 // --- Tests ---
@@ -209,6 +235,18 @@ mod tests {
     }
 
     #[test]
+    fn parse_data_usage_raw_response_normalizes_single_top_level_logs_count() {
+        let value = parse_data_usage_raw_response(r#"{"logsCount":[]}"#).unwrap();
+        assert_eq!(value, json!({"result": {"logsCount": []}}));
+    }
+
+    #[test]
+    fn parse_data_usage_raw_response_normalizes_single_top_level_spans_count() {
+        let value = parse_data_usage_raw_response(r#"{"spansCount":[]}"#).unwrap();
+        assert_eq!(value, json!({"result": {"spansCount": []}}));
+    }
+
+    #[test]
     fn parse_data_usage_raw_response_accepts_ndjson() {
         let raw = r#"{"timestamp":"2026-05-25T00:00:00Z","count":"1"}
 {"timestamp":"2026-05-25T01:00:00Z","count":"2"}
@@ -227,6 +265,25 @@ mod tests {
     fn parse_data_usage_raw_response_merges_count_chunks() {
         let raw = r#"{"result":{"logsCount":[{"timestamp":"2026-05-25T00:00:00Z","logsCount":"1"}]}}
 {"result":{"logsCount":[{"timestamp":"2026-05-25T01:00:00Z","logsCount":"2"}]}}
+"#;
+        let value = parse_data_usage_raw_response(raw).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "result": {
+                    "logsCount": [
+                        {"timestamp": "2026-05-25T00:00:00Z", "logsCount": "1"},
+                        {"timestamp": "2026-05-25T01:00:00Z", "logsCount": "2"}
+                    ]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn parse_data_usage_raw_response_merges_top_level_count_chunks() {
+        let raw = r#"{"logsCount":[{"timestamp":"2026-05-25T00:00:00Z","logsCount":"1"}]}
+{"logsCount":[{"timestamp":"2026-05-25T01:00:00Z","logsCount":"2"}]}
 "#;
         let value = parse_data_usage_raw_response(raw).unwrap();
         assert_eq!(

--- a/src/commands/data_usage/api.rs
+++ b/src/commands/data_usage/api.rs
@@ -45,6 +45,7 @@ pub struct ExportStatusResponse {
 // --- API ---
 
 const DATA_USAGE_BASE: &str = "/mgmt/openapi/5/dataplans/data-usage/v2";
+const DATA_USAGE_ACCEPT: &str = "text/event-stream";
 
 pub struct DataUsageApi<'a> {
     client: &'a CxClient,
@@ -58,7 +59,7 @@ impl<'a> DataUsageApi<'a> {
     pub async fn get_usage(&self, params: &[(&str, &str)]) -> Result<Value> {
         let raw = self
             .client
-            .get_event_stream_raw(DATA_USAGE_BASE, params)
+            .get_raw(DATA_USAGE_BASE, params, &[("Accept", DATA_USAGE_ACCEPT)])
             .await?;
         parse_data_usage_raw_response(&raw)
     }
@@ -70,13 +71,19 @@ impl<'a> DataUsageApi<'a> {
 
     pub async fn logs_count(&self, params: &[(&str, &str)]) -> Result<Value> {
         let path = format!("{DATA_USAGE_BASE}/logs/count");
-        let raw = self.client.get_event_stream_raw(&path, params).await?;
+        let raw = self
+            .client
+            .get_raw(&path, params, &[("Accept", DATA_USAGE_ACCEPT)])
+            .await?;
         parse_data_usage_raw_response(&raw)
     }
 
     pub async fn spans_count(&self, params: &[(&str, &str)]) -> Result<Value> {
         let path = format!("{DATA_USAGE_BASE}/spans/count");
-        let raw = self.client.get_event_stream_raw(&path, params).await?;
+        let raw = self
+            .client
+            .get_raw(&path, params, &[("Accept", DATA_USAGE_ACCEPT)])
+            .await?;
         parse_data_usage_raw_response(&raw)
     }
 
@@ -87,18 +94,22 @@ impl<'a> DataUsageApi<'a> {
 }
 
 pub fn parse_data_usage_raw_response(raw: &str) -> Result<Value> {
+    // Data Usage overview, logs/count, and spans/count are requested with
+    // `Accept: text/event-stream`, but some responses still arrive as one JSON
+    // object. Parse the single-object form first, then fall back to the
+    // line-delimited event-stream form.
     if let Ok(value) = serde_json::from_str(raw) {
         return Ok(normalize_result_array_object(value));
     }
 
-    // The Data Usage overview documents `Get data usage`, `logs/count`, and
-    // `spans/count` as `Accept: text/event-stream` endpoints that return
-    // newline-delimited JSON. Some responses still arrive as one JSON object,
-    // so parse that first and fall back to the documented line-delimited form.
     let mut values = Vec::new();
     for line in raw.lines() {
         let mut line = line.trim();
-        if line.is_empty() || line.starts_with(':') {
+        if line.is_empty() {
+            continue;
+        }
+        // Server-Sent Events allows colon-prefixed comment/keepalive lines.
+        if line.starts_with(':') {
             continue;
         }
         if let Some(data) = line.strip_prefix("data:") {
@@ -250,6 +261,24 @@ mod tests {
     fn parse_data_usage_raw_response_accepts_ndjson() {
         let raw = r#"{"timestamp":"2026-05-25T00:00:00Z","count":"1"}
 {"timestamp":"2026-05-25T01:00:00Z","count":"2"}
+"#;
+        let value = parse_data_usage_raw_response(raw).unwrap();
+        assert_eq!(
+            value,
+            json!([
+                {"timestamp": "2026-05-25T00:00:00Z", "count": "1"},
+                {"timestamp": "2026-05-25T01:00:00Z", "count": "2"}
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_data_usage_raw_response_accepts_sse_data_lines() {
+        let raw = r#": keepalive
+data: {"timestamp":"2026-05-25T00:00:00Z","count":"1"}
+
+data: {"timestamp":"2026-05-25T01:00:00Z","count":"2"}
+data: [DONE]
 "#;
         let value = parse_data_usage_raw_response(raw).unwrap();
         assert_eq!(

--- a/src/commands/data_usage/api.rs
+++ b/src/commands/data_usage/api.rs
@@ -56,7 +56,11 @@ impl<'a> DataUsageApi<'a> {
     }
 
     pub async fn get_usage(&self, params: &[(&str, &str)]) -> Result<Value> {
-        self.client.get(DATA_USAGE_BASE, params).await
+        let raw = self
+            .client
+            .get_event_stream_raw(DATA_USAGE_BASE, params)
+            .await?;
+        parse_data_usage_raw_response(&raw)
     }
 
     pub async fn daily(&self, data_type: &str, body: &Value) -> Result<Value> {
@@ -64,20 +68,80 @@ impl<'a> DataUsageApi<'a> {
         self.client.post(&path, body).await
     }
 
-    pub async fn logs_count(&self) -> Result<Value> {
+    pub async fn logs_count(&self, params: &[(&str, &str)]) -> Result<Value> {
         let path = format!("{DATA_USAGE_BASE}/logs/count");
-        self.client.get(&path, &[]).await
+        let raw = self.client.get_event_stream_raw(&path, params).await?;
+        parse_data_usage_raw_response(&raw)
     }
 
-    pub async fn spans_count(&self) -> Result<Value> {
+    pub async fn spans_count(&self, params: &[(&str, &str)]) -> Result<Value> {
         let path = format!("{DATA_USAGE_BASE}/spans/count");
-        self.client.get(&path, &[]).await
+        let raw = self.client.get_event_stream_raw(&path, params).await?;
+        parse_data_usage_raw_response(&raw)
     }
 
     pub async fn export_status(&self) -> Result<Value> {
         let path = format!("{DATA_USAGE_BASE}/export-status");
         self.client.get(&path, &[]).await
     }
+}
+
+pub fn parse_data_usage_raw_response(raw: &str) -> Result<Value> {
+    if let Ok(value) = serde_json::from_str(raw) {
+        return Ok(value);
+    }
+
+    // The Data Usage overview documents `Get data usage`, `logs/count`, and
+    // `spans/count` as `Accept: text/event-stream` endpoints that return
+    // newline-delimited JSON. Some responses still arrive as one JSON object,
+    // so parse that first and fall back to the documented line-delimited form.
+    let mut values = Vec::new();
+    for line in raw.lines() {
+        let mut line = line.trim();
+        if line.is_empty() || line.starts_with(':') {
+            continue;
+        }
+        if let Some(data) = line.strip_prefix("data:") {
+            line = data.trim();
+        }
+        if line.is_empty() || line == "[DONE]" {
+            continue;
+        }
+
+        values.push(serde_json::from_str(line)?);
+    }
+
+    Ok(match values.len() {
+        0 => Value::Null,
+        1 => values.remove(0),
+        _ => merge_count_chunks(&values).unwrap_or(Value::Array(values)),
+    })
+}
+
+fn merge_count_chunks(values: &[Value]) -> Option<Value> {
+    for count_key in ["logsCount", "spansCount"] {
+        let mut merged = Vec::new();
+        let mut matched = false;
+
+        for value in values {
+            let items = value
+                .get("result")
+                .and_then(|result| result.get(count_key))
+                .and_then(Value::as_array)?;
+            matched = true;
+            merged.extend(items.iter().cloned());
+        }
+
+        if matched {
+            return Some(serde_json::json!({
+                "result": {
+                    count_key: merged
+                }
+            }));
+        }
+    }
+
+    None
 }
 
 // --- Tests ---
@@ -131,5 +195,45 @@ mod tests {
         let json = json!({ "count": 500000 });
         let resp: SpansCountResponse = serde_json::from_value(json).unwrap();
         assert_eq!(resp.count, json!(500000));
+    }
+
+    #[test]
+    fn parse_data_usage_raw_response_accepts_single_json() {
+        let value = parse_data_usage_raw_response(r#"{"count":1000000}"#).unwrap();
+        assert_eq!(value, json!({"count": 1000000}));
+    }
+
+    #[test]
+    fn parse_data_usage_raw_response_accepts_ndjson() {
+        let raw = r#"{"timestamp":"2026-05-25T00:00:00Z","count":"1"}
+{"timestamp":"2026-05-25T01:00:00Z","count":"2"}
+"#;
+        let value = parse_data_usage_raw_response(raw).unwrap();
+        assert_eq!(
+            value,
+            json!([
+                {"timestamp": "2026-05-25T00:00:00Z", "count": "1"},
+                {"timestamp": "2026-05-25T01:00:00Z", "count": "2"}
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_data_usage_raw_response_merges_count_chunks() {
+        let raw = r#"{"result":{"logsCount":[{"timestamp":"2026-05-25T00:00:00Z","logsCount":"1"}]}}
+{"result":{"logsCount":[{"timestamp":"2026-05-25T01:00:00Z","logsCount":"2"}]}}
+"#;
+        let value = parse_data_usage_raw_response(raw).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "result": {
+                    "logsCount": [
+                        {"timestamp": "2026-05-25T00:00:00Z", "logsCount": "1"},
+                        {"timestamp": "2026-05-25T01:00:00Z", "logsCount": "2"}
+                    ]
+                }
+            })
+        );
     }
 }

--- a/src/commands/data_usage/api.rs
+++ b/src/commands/data_usage/api.rs
@@ -114,20 +114,25 @@ pub fn parse_data_usage_raw_response(raw: &str) -> Result<Value> {
     Ok(match values.len() {
         0 => Value::Null,
         1 => values.remove(0),
-        _ => merge_count_chunks(&values).unwrap_or(Value::Array(values)),
+        _ => merge_result_array_chunks(&values).unwrap_or(Value::Array(values)),
     })
 }
 
-fn merge_count_chunks(values: &[Value]) -> Option<Value> {
-    for count_key in ["logsCount", "spansCount"] {
+fn merge_result_array_chunks(values: &[Value]) -> Option<Value> {
+    for result_key in ["entries", "logsCount", "spansCount"] {
         let mut merged = Vec::new();
         let mut matched = false;
 
         for value in values {
-            let items = value
+            let Some(items) = value
                 .get("result")
-                .and_then(|result| result.get(count_key))
-                .and_then(Value::as_array)?;
+                .and_then(|result| result.get(result_key))
+                .and_then(Value::as_array)
+            else {
+                matched = false;
+                break;
+            };
+
             matched = true;
             merged.extend(items.iter().cloned());
         }
@@ -135,7 +140,7 @@ fn merge_count_chunks(values: &[Value]) -> Option<Value> {
         if matched {
             return Some(serde_json::json!({
                 "result": {
-                    count_key: merged
+                    result_key: merged
                 }
             }));
         }
@@ -231,6 +236,25 @@ mod tests {
                     "logsCount": [
                         {"timestamp": "2026-05-25T00:00:00Z", "logsCount": "1"},
                         {"timestamp": "2026-05-25T01:00:00Z", "logsCount": "2"}
+                    ]
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn parse_data_usage_raw_response_merges_summary_chunks() {
+        let raw = r#"{"result":{"entries":[{"timestamp":"2026-05-25T00:00:00Z","sizeGb":1}]}}
+{"result":{"entries":[{"timestamp":"2026-05-25T01:00:00Z","sizeGb":2}]}}
+"#;
+        let value = parse_data_usage_raw_response(raw).unwrap();
+        assert_eq!(
+            value,
+            json!({
+                "result": {
+                    "entries": [
+                        {"timestamp": "2026-05-25T00:00:00Z", "sizeGb": 1},
+                        {"timestamp": "2026-05-25T01:00:00Z", "sizeGb": 2}
                     ]
                 }
             })

--- a/src/commands/data_usage/mod.rs
+++ b/src/commands/data_usage/mod.rs
@@ -14,6 +14,53 @@ use api::DataUsageApi;
 
 // ── Subcommand runners ────────────────────────────────────────────────────────
 
+fn build_count_query_params(
+    start: Option<&str>,
+    end: Option<&str>,
+    resolution: Option<&str>,
+    subsystem_aggregation: bool,
+    application_aggregation: bool,
+    extra_params: &[String],
+) -> Result<Vec<(String, String)>> {
+    let from = match start.map(crate::time::parse_timestamp).transpose()? {
+        Some(s) => s,
+        None => chrono::Utc::now()
+            .checked_sub_signed(chrono::Duration::hours(24))
+            .unwrap_or_else(chrono::Utc::now)
+            .to_rfc3339(),
+    };
+    let to = match end.map(crate::time::parse_timestamp).transpose()? {
+        Some(s) => s,
+        None => chrono::Utc::now().to_rfc3339(),
+    };
+    let mut params = vec![
+        ("date_range.fromDate".to_string(), from),
+        ("date_range.toDate".to_string(), to),
+    ];
+
+    params.push((
+        "resolution".to_string(),
+        resolution.unwrap_or("1h").to_string(),
+    ));
+    if subsystem_aggregation {
+        params.push(("subsystem_aggregation".to_string(), "true".to_string()));
+    }
+    if application_aggregation {
+        params.push(("application_aggregation".to_string(), "true".to_string()));
+    }
+    for raw in extra_params {
+        let (key, value) = raw
+            .split_once('=')
+            .ok_or_else(|| anyhow::anyhow!("query params must use KEY=VALUE format: {raw}"))?;
+        if key.trim().is_empty() {
+            anyhow::bail!("query param key cannot be empty: {raw}");
+        }
+        params.push((key.to_string(), value.to_string()));
+    }
+
+    Ok(params)
+}
+
 pub async fn run_summary(
     targets: &[Arc<ExecutionTarget>],
     start: Option<&str>,
@@ -161,14 +208,38 @@ pub async fn run_daily(
     Ok(())
 }
 
-pub async fn run_logs_count(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> Result<()> {
+pub async fn run_logs_count(
+    targets: &[Arc<ExecutionTarget>],
+    start: Option<&str>,
+    end: Option<&str>,
+    resolution: Option<&str>,
+    subsystem_aggregation: bool,
+    application_aggregation: bool,
+    extra_params: &[String],
+    output: OutputFormat,
+) -> Result<()> {
     eprintln!("{}", "Fetching logs count...".dimmed());
 
     let include_profile = targets.len() > 1;
+    let params = build_count_query_params(
+        start,
+        end,
+        resolution,
+        subsystem_aggregation,
+        application_aggregation,
+        extra_params,
+    )?;
 
-    let per_profile = fan_out(targets, |t| async move {
-        let api = DataUsageApi::new(&t.client);
-        Ok(api.logs_count().await?)
+    let per_profile = fan_out(targets, |t| {
+        let params = params.clone();
+        async move {
+            let api = DataUsageApi::new(&t.client);
+            let params_ref: Vec<(&str, &str)> = params
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            Ok(api.logs_count(&params_ref).await?)
+        }
     })
     .await;
 
@@ -202,14 +273,38 @@ pub async fn run_logs_count(targets: &[Arc<ExecutionTarget>], output: OutputForm
     Ok(())
 }
 
-pub async fn run_spans_count(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> Result<()> {
+pub async fn run_spans_count(
+    targets: &[Arc<ExecutionTarget>],
+    start: Option<&str>,
+    end: Option<&str>,
+    resolution: Option<&str>,
+    subsystem_aggregation: bool,
+    application_aggregation: bool,
+    extra_params: &[String],
+    output: OutputFormat,
+) -> Result<()> {
     eprintln!("{}", "Fetching spans count...".dimmed());
 
     let include_profile = targets.len() > 1;
+    let params = build_count_query_params(
+        start,
+        end,
+        resolution,
+        subsystem_aggregation,
+        application_aggregation,
+        extra_params,
+    )?;
 
-    let per_profile = fan_out(targets, |t| async move {
-        let api = DataUsageApi::new(&t.client);
-        Ok(api.spans_count().await?)
+    let per_profile = fan_out(targets, |t| {
+        let params = params.clone();
+        async move {
+            let api = DataUsageApi::new(&t.client);
+            let params_ref: Vec<(&str, &str)> = params
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str()))
+                .collect();
+            Ok(api.spans_count(&params_ref).await?)
+        }
     })
     .await;
 

--- a/src/commands/data_usage/mod.rs
+++ b/src/commands/data_usage/mod.rs
@@ -14,22 +14,29 @@ use api::DataUsageApi;
 
 // ── Subcommand runners ────────────────────────────────────────────────────────
 
-fn build_count_query_params(
-    start: Option<&str>,
-    end: Option<&str>,
-    resolution: Option<&str>,
-    subsystem_aggregation: bool,
-    application_aggregation: bool,
-    extra_params: &[String],
-) -> Result<Vec<(String, String)>> {
-    let from = match start.map(crate::time::parse_timestamp).transpose()? {
+pub struct CountCommandOptions<'a> {
+    pub start: Option<&'a str>,
+    pub end: Option<&'a str>,
+    pub resolution: Option<&'a str>,
+    pub subsystem_aggregation: bool,
+    pub application_aggregation: bool,
+    pub extra_params: &'a [String],
+    pub output: OutputFormat,
+}
+
+fn build_count_query_params(options: &CountCommandOptions<'_>) -> Result<Vec<(String, String)>> {
+    let from = match options
+        .start
+        .map(crate::time::parse_timestamp)
+        .transpose()?
+    {
         Some(s) => s,
         None => chrono::Utc::now()
             .checked_sub_signed(chrono::Duration::hours(24))
             .unwrap_or_else(chrono::Utc::now)
             .to_rfc3339(),
     };
-    let to = match end.map(crate::time::parse_timestamp).transpose()? {
+    let to = match options.end.map(crate::time::parse_timestamp).transpose()? {
         Some(s) => s,
         None => chrono::Utc::now().to_rfc3339(),
     };
@@ -40,15 +47,15 @@ fn build_count_query_params(
 
     params.push((
         "resolution".to_string(),
-        resolution.unwrap_or("1h").to_string(),
+        options.resolution.unwrap_or("1h").to_string(),
     ));
-    if subsystem_aggregation {
+    if options.subsystem_aggregation {
         params.push(("subsystem_aggregation".to_string(), "true".to_string()));
     }
-    if application_aggregation {
+    if options.application_aggregation {
         params.push(("application_aggregation".to_string(), "true".to_string()));
     }
-    for raw in extra_params {
+    for raw in options.extra_params {
         let (key, value) = raw
             .split_once('=')
             .ok_or_else(|| anyhow::anyhow!("query params must use KEY=VALUE format: {raw}"))?;
@@ -210,25 +217,12 @@ pub async fn run_daily(
 
 pub async fn run_logs_count(
     targets: &[Arc<ExecutionTarget>],
-    start: Option<&str>,
-    end: Option<&str>,
-    resolution: Option<&str>,
-    subsystem_aggregation: bool,
-    application_aggregation: bool,
-    extra_params: &[String],
-    output: OutputFormat,
+    options: CountCommandOptions<'_>,
 ) -> Result<()> {
     eprintln!("{}", "Fetching logs count...".dimmed());
 
     let include_profile = targets.len() > 1;
-    let params = build_count_query_params(
-        start,
-        end,
-        resolution,
-        subsystem_aggregation,
-        application_aggregation,
-        extra_params,
-    )?;
+    let params = build_count_query_params(&options)?;
 
     let per_profile = fan_out(targets, |t| {
         let params = params.clone();
@@ -256,7 +250,7 @@ pub async fn run_logs_count(
         }
     }
 
-    match output {
+    match options.output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
         OutputFormat::Agents => {
             let toon = toon_encode(&all_results)
@@ -275,25 +269,12 @@ pub async fn run_logs_count(
 
 pub async fn run_spans_count(
     targets: &[Arc<ExecutionTarget>],
-    start: Option<&str>,
-    end: Option<&str>,
-    resolution: Option<&str>,
-    subsystem_aggregation: bool,
-    application_aggregation: bool,
-    extra_params: &[String],
-    output: OutputFormat,
+    options: CountCommandOptions<'_>,
 ) -> Result<()> {
     eprintln!("{}", "Fetching spans count...".dimmed());
 
     let include_profile = targets.len() > 1;
-    let params = build_count_query_params(
-        start,
-        end,
-        resolution,
-        subsystem_aggregation,
-        application_aggregation,
-        extra_params,
-    )?;
+    let params = build_count_query_params(&options)?;
 
     let per_profile = fan_out(targets, |t| {
         let params = params.clone();
@@ -321,7 +302,7 @@ pub async fn run_spans_count(
         }
     }
 
-    match output {
+    match options.output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
         OutputFormat::Agents => {
             let toon = toon_encode(&all_results)

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,7 +316,7 @@ Examples:
   cx usage summary
   cx usage daily --type processed-gbs
   cx usage logs-count
-  cx usage spans-count"
+  cx usage spans-count --start now-24h --end now"
     )]
     DataUsage {
         #[command(subcommand)]
@@ -1219,9 +1219,75 @@ enum DataUsageCmd {
         end: Option<String>,
     },
     /// Show logs count.
-    LogsCount,
+    #[command(after_help = "\
+Examples:
+  cx usage logs-count
+  cx usage logs-count --start now-7d --end now --resolution 6h
+  cx usage logs-count --application-aggregation
+
+Output:
+  JSON output is normalized to one object with rows under result.logsCount.
+  Large backend responses may arrive in multiple JSON chunks; cx merges them.")]
+    LogsCount {
+        /// Start time filter (ISO 8601 or relative, e.g. now-7d). Defaults to 24h ago.
+        #[arg(long)]
+        start: Option<String>,
+
+        /// End time filter (ISO 8601 or relative, e.g. now). Defaults to now.
+        #[arg(long)]
+        end: Option<String>,
+
+        /// Query resolution. Defaults to 1h.
+        #[arg(long)]
+        resolution: Option<String>,
+
+        /// Aggregate by subsystem.
+        #[arg(long)]
+        subsystem_aggregation: bool,
+
+        /// Aggregate by application.
+        #[arg(long)]
+        application_aggregation: bool,
+
+        /// Extra raw query parameter in KEY=VALUE form. Repeat for filters.* fields.
+        #[arg(long = "param")]
+        params: Vec<String>,
+    },
     /// Show spans count.
-    SpansCount,
+    #[command(after_help = "\
+Examples:
+  cx usage spans-count
+  cx usage spans-count --start now-7d --end now --resolution 6h
+  cx usage spans-count --application-aggregation
+
+Output:
+  JSON output is normalized to one object with rows under result.spansCount.
+  Large backend responses may arrive in multiple JSON chunks; cx merges them.")]
+    SpansCount {
+        /// Start time filter (ISO 8601 or relative, e.g. now-7d). Defaults to 24h ago.
+        #[arg(long)]
+        start: Option<String>,
+
+        /// End time filter (ISO 8601 or relative, e.g. now). Defaults to now.
+        #[arg(long)]
+        end: Option<String>,
+
+        /// Query resolution. Defaults to 1h.
+        #[arg(long)]
+        resolution: Option<String>,
+
+        /// Aggregate by subsystem.
+        #[arg(long)]
+        subsystem_aggregation: bool,
+
+        /// Aggregate by application.
+        #[arg(long)]
+        application_aggregation: bool,
+
+        /// Extra raw query parameter in KEY=VALUE form. Repeat for filters.* fields.
+        #[arg(long = "param")]
+        params: Vec<String>,
+    },
     /// Show export status.
     ExportStatus,
 }
@@ -2726,11 +2792,45 @@ async fn main() -> Result<()> {
                 )
                 .await?;
             }
-            DataUsageCmd::LogsCount => {
-                commands::data_usage::run_logs_count(&targets, output).await?;
+            DataUsageCmd::LogsCount {
+                start,
+                end,
+                resolution,
+                subsystem_aggregation,
+                application_aggregation,
+                params,
+            } => {
+                commands::data_usage::run_logs_count(
+                    &targets,
+                    start.as_deref(),
+                    end.as_deref(),
+                    resolution.as_deref(),
+                    subsystem_aggregation,
+                    application_aggregation,
+                    &params,
+                    output,
+                )
+                .await?;
             }
-            DataUsageCmd::SpansCount => {
-                commands::data_usage::run_spans_count(&targets, output).await?;
+            DataUsageCmd::SpansCount {
+                start,
+                end,
+                resolution,
+                subsystem_aggregation,
+                application_aggregation,
+                params,
+            } => {
+                commands::data_usage::run_spans_count(
+                    &targets,
+                    start.as_deref(),
+                    end.as_deref(),
+                    resolution.as_deref(),
+                    subsystem_aggregation,
+                    application_aggregation,
+                    &params,
+                    output,
+                )
+                .await?;
             }
             DataUsageCmd::ExportStatus => {
                 commands::data_usage::run_export_status(&targets, output).await?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2802,13 +2802,15 @@ async fn main() -> Result<()> {
             } => {
                 commands::data_usage::run_logs_count(
                     &targets,
-                    start.as_deref(),
-                    end.as_deref(),
-                    resolution.as_deref(),
-                    subsystem_aggregation,
-                    application_aggregation,
-                    &params,
-                    output,
+                    commands::data_usage::CountCommandOptions {
+                        start: start.as_deref(),
+                        end: end.as_deref(),
+                        resolution: resolution.as_deref(),
+                        subsystem_aggregation,
+                        application_aggregation,
+                        extra_params: &params,
+                        output,
+                    },
                 )
                 .await?;
             }
@@ -2822,13 +2824,15 @@ async fn main() -> Result<()> {
             } => {
                 commands::data_usage::run_spans_count(
                     &targets,
-                    start.as_deref(),
-                    end.as_deref(),
-                    resolution.as_deref(),
-                    subsystem_aggregation,
-                    application_aggregation,
-                    &params,
-                    output,
+                    commands::data_usage::CountCommandOptions {
+                        start: start.as_deref(),
+                        end: end.as_deref(),
+                        resolution: resolution.as_deref(),
+                        subsystem_aggregation,
+                        application_aggregation,
+                        extra_params: &params,
+                        output,
+                    },
                 )
                 .await?;
             }

--- a/tests/data_usage/main.rs
+++ b/tests/data_usage/main.rs
@@ -5,7 +5,7 @@ use serde_json::json;
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use coralogix_cli::commands::data_usage::{run_logs_count, run_summary};
+use coralogix_cli::commands::data_usage::{run_logs_count, run_spans_count, run_summary};
 use coralogix_cli::config::OutputFormat;
 
 #[tokio::test]
@@ -70,4 +70,44 @@ async fn run_logs_count_forwards_time_and_query_params() {
     )
     .await
     .expect("run_logs_count should forward query params");
+}
+
+#[tokio::test]
+async fn run_spans_count_forwards_time_and_query_params() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/dataplans/data-usage/v2/spans/count"))
+        .and(header("Accept", "text/event-stream"))
+        .and(query_param(
+            "date_range.fromDate",
+            "2024-01-01T00:00:00.000Z",
+        ))
+        .and(query_param("date_range.toDate", "2024-01-02T00:00:00.000Z"))
+        .and(query_param("resolution", "6h"))
+        .and(query_param("subsystem_aggregation", "true"))
+        .and(query_param("filters.subsystemName", "worker"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_string("{\"result\":{\"spansCount\":[]}}\n"),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+    let params = vec!["filters.subsystemName=worker".to_string()];
+
+    run_spans_count(
+        &targets,
+        Some("2024-01-01T00:00:00Z"),
+        Some("2024-01-02T00:00:00Z"),
+        Some("6h"),
+        true,
+        false,
+        &params,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_spans_count should forward query params");
 }

--- a/tests/data_usage/main.rs
+++ b/tests/data_usage/main.rs
@@ -2,10 +2,10 @@
 mod common;
 
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use coralogix_cli::commands::data_usage::run_summary;
+use coralogix_cli::commands::data_usage::{run_logs_count, run_summary};
 use coralogix_cli::config::OutputFormat;
 
 #[tokio::test]
@@ -20,6 +20,7 @@ async fn data_usage_summary_from_mock() {
 
     Mock::given(method("GET"))
         .and(path("/mgmt/openapi/5/dataplans/data-usage/v2"))
+        .and(header("Accept", "text/event-stream"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -31,4 +32,42 @@ async fn data_usage_summary_from_mock() {
     run_summary(&targets, None, None, OutputFormat::Json)
         .await
         .expect("run_summary should succeed");
+}
+
+#[tokio::test]
+async fn run_logs_count_forwards_time_and_query_params() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/mgmt/openapi/5/dataplans/data-usage/v2/logs/count"))
+        .and(header("Accept", "text/event-stream"))
+        .and(query_param(
+            "date_range.fromDate",
+            "2024-01-01T00:00:00.000Z",
+        ))
+        .and(query_param("date_range.toDate", "2024-01-02T00:00:00.000Z"))
+        .and(query_param("resolution", "1h"))
+        .and(query_param("application_aggregation", "true"))
+        .and(query_param("filters.applicationName", "api"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("{\"logsCount\":[]}\n"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+    let params = vec!["filters.applicationName=api".to_string()];
+
+    run_logs_count(
+        &targets,
+        Some("2024-01-01T00:00:00Z"),
+        Some("2024-01-02T00:00:00Z"),
+        None,
+        false,
+        true,
+        &params,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_logs_count should forward query params");
 }

--- a/tests/data_usage/main.rs
+++ b/tests/data_usage/main.rs
@@ -5,7 +5,9 @@ use serde_json::json;
 use wiremock::matchers::{header, method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use coralogix_cli::commands::data_usage::{run_logs_count, run_spans_count, run_summary};
+use coralogix_cli::commands::data_usage::{
+    run_logs_count, run_spans_count, run_summary, CountCommandOptions,
+};
 use coralogix_cli::config::OutputFormat;
 
 #[tokio::test]
@@ -60,13 +62,15 @@ async fn run_logs_count_forwards_time_and_query_params() {
 
     run_logs_count(
         &targets,
-        Some("2024-01-01T00:00:00Z"),
-        Some("2024-01-02T00:00:00Z"),
-        None,
-        false,
-        true,
-        &params,
-        OutputFormat::Json,
+        CountCommandOptions {
+            start: Some("2024-01-01T00:00:00Z"),
+            end: Some("2024-01-02T00:00:00Z"),
+            resolution: None,
+            subsystem_aggregation: false,
+            application_aggregation: true,
+            extra_params: &params,
+            output: OutputFormat::Json,
+        },
     )
     .await
     .expect("run_logs_count should forward query params");
@@ -100,13 +104,15 @@ async fn run_spans_count_forwards_time_and_query_params() {
 
     run_spans_count(
         &targets,
-        Some("2024-01-01T00:00:00Z"),
-        Some("2024-01-02T00:00:00Z"),
-        Some("6h"),
-        true,
-        false,
-        &params,
-        OutputFormat::Json,
+        CountCommandOptions {
+            start: Some("2024-01-01T00:00:00Z"),
+            end: Some("2024-01-02T00:00:00Z"),
+            resolution: Some("6h"),
+            subsystem_aggregation: true,
+            application_aggregation: false,
+            extra_params: &params,
+            output: OutputFormat::Json,
+        },
     )
     .await
     .expect("run_spans_count should forward query params");

--- a/tests/e2e/data_usage.rs
+++ b/tests/e2e/data_usage.rs
@@ -28,3 +28,56 @@ fn data_usage_daily() {
         "json",
     ]);
 }
+
+#[test]
+#[ignore]
+fn data_usage_logs_count() {
+    if harness::require_creds("data_usage_logs_count").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&[
+        "usage",
+        "logs-count",
+        "--start",
+        "now-1h",
+        "--end",
+        "now",
+        "-o",
+        "json",
+    ]);
+    assert_count_result(&v, "logsCount");
+}
+
+#[test]
+#[ignore]
+fn data_usage_spans_count() {
+    if harness::require_creds("data_usage_spans_count").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&[
+        "usage",
+        "spans-count",
+        "--start",
+        "now-1h",
+        "--end",
+        "now",
+        "-o",
+        "json",
+    ]);
+    assert_count_result(&v, "spansCount");
+}
+
+fn assert_count_result(v: &serde_json::Value, key: &str) {
+    let rows = v
+        .get("result")
+        .and_then(|result| result.get(key))
+        .and_then(|value| value.as_array())
+        .unwrap_or_else(|| panic!("expected result.{key} array, got: {v}"));
+
+    for (i, row) in rows.iter().enumerate() {
+        assert!(
+            row.get("timestamp").is_some(),
+            "row {i} missing timestamp: {row}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Normalize streamed Data Usage responses for summary, logs count, and spans count into stable JSON result arrays
- Add mocked coverage for text/event-stream headers, time params, resolution, aggregation flags, and raw filter params
- Add credentialed e2e coverage for logs-count and spans-count

## Verification

- `cargo test parse_data_usage_raw_response`
- `cargo test --test data_usage`
- `cargo test --test e2e data_usage`
- `cargo test --test e2e data_usage -- --ignored`
- Manual:
  - `target/debug/cx usage summary -o json`
  - `target/debug/cx usage logs-count --start now-1h --end now -o json`
  - `target/debug/cx usage spans-count --start now-1h --end now -o json`
