### PR TITLE
Improve create-pr skill with structured 8-section PR template

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -38,31 +38,127 @@ If the branch isn't pushed or is ahead of the remote, ask the user before pushin
 
 ### 4. Analyze changes
 
-Get the full picture of what the PR will contain - look at ALL commits on the branch, not just the latest one:
+Most of the code in this repo is LLM-generated, so reviewers lean on the PR description more than the diff. Your job here is to gather enough material to fill **every** section of the template in step 5 — not just enumerate what changed.
+
+Look at ALL commits on the branch, not just the latest one:
 ```bash
-git log --oneline <base-branch>..HEAD
+git log <base-branch>..HEAD                 # full messages, not just --oneline
 git diff <base-branch>...HEAD
+git rev-parse --abbrev-ref HEAD             # branch name often carries a ticket ID
 ```
 
-If the diff is very large, also read the individual commit messages for context since they often explain intent better than raw diffs.
+While reading, deliberately collect:
+- **Why** the change exists (commit messages, branch name, linked tickets)
+- **How** it works at a high level (which modules/layers, data/control flow)
+- **Non-obvious decisions** (anything a reviewer might question)
+- **Behavioral / interface / schema changes** (what's different about the system after merge)
+- **What was actually tested** (look for test files added, but verify with the user / run history)
+- **Risks** (breaking changes, migrations, blast radius)
+
+If you don't have material for a section, don't invent it — that section becomes `N/A — <one-line reason>` in step 5.
 
 ### 5. Create the PR
 
-Generate a concise title (<70 chars) and a short summary body. The title should describe the change at a high level. The body should have a few bullet points explaining what changed and why.
+Generate a concise title (<70 chars) describing the change at a high level.
 
-Use this format:
+The body **must follow the template below exactly**. All 8 section headers must appear in order. If a section truly doesn't apply, write `N/A — <one-line reason>` under that header — never omit a header, never leave a section empty.
+
+Template (fill in under each header):
+
+````
+## Context
+Why this change exists. What problem it solves or capability it adds.
+Reference the trigger (bug, feature request, incident, refactor goal).
+One short paragraph — not a changelog.
+
+## Linked Issues
+Linear tickets, GitHub issues, incident IDs, or prior PRs this builds on.
+`N/A — <reason>` if none.
+
+## Design
+The high-level shape of the implementation. How the pieces fit together,
+which modules/layers are touched and in what role, and the data/control
+flow for the main path. Aim for what a reviewer would draw on a
+whiteboard. Avoid restating the diff line-by-line.
+
+## Key Decisions
+Non-obvious choices and the trade-offs behind them. Alternatives
+considered and why they were rejected. Anything a reviewer might
+otherwise flag as "why did you do it this way?" — answer it here
+pre-emptively. `N/A — <reason>` only for trivial/mechanical changes.
+
+## Changes
+Logical/semantic changes — not a file-by-file inventory. Focus on:
+- Interface changes (new/changed/removed commands, flags, public APIs)
+- Schema changes (config, data model, API request/response shapes)
+- Behavioral changes (what `cx` does differently now)
+Skip mechanical detail (which files moved, which libs bumped) unless
+it materially affects reviewers. Rollout concerns (migrations,
+breaking-change handling) belong in Risks & Rollout, not here.
+Bullet list.
+
+## Testing
+How the change was verified. List the exact commands run (unit,
+integration, e2e, manual `cx` invocations). If a layer was skipped,
+say why. Aspirational tests don't count — only what was actually
+executed.
+
+## Risks & Rollout
+Backwards compatibility, breaking changes, migrations, feature flags,
+performance impact, blast radius if this goes wrong. How to roll back.
+`N/A — <reason>` for low-risk changes (e.g. pure docs, isolated
+refactor).
+
+## Out of Scope / Follow-ups
+What this PR deliberately does *not* do, and any follow-up work that
+should land separately. `N/A — <reason>` if the PR is fully
+self-contained.
+````
+
+Invoke with:
 ```bash
 gh pr create --title "the title" --body "$(cat <<'EOF'
-## Summary
-- First change
-- Second change
+## Context
+...
 
+## Linked Issues
+...
+
+## Design
+...
+
+## Key Decisions
+...
+
+## Changes
+- ...
+
+## Testing
+- ...
+
+## Risks & Rollout
+...
+
+## Out of Scope / Follow-ups
+...
 EOF
 )"
 ```
 
 If the base branch is not the default, pass `--base <branch>`.
 
-### 6. Report back
+### 6. Pre-submit checklist
+
+Before running `gh pr create`, verify the body you assembled:
+
+- [ ] All 8 section headers are present, in order: Context, Linked Issues, Design, Key Decisions, Changes, Testing, Risks & Rollout, Out of Scope / Follow-ups
+- [ ] No section is empty — each has either real content or `N/A — <reason>`
+- [ ] Testing lists commands that were **actually run** for this branch, not generic suggestions
+- [ ] Changes describes logical/semantic differences, not a file inventory
+- [ ] Design says how the change works at a level above the diff
+
+If anything fails, fix the body before submitting.
+
+### 7. Report back
 
 Print the PR URL so the user can click through to it.


### PR DESCRIPTION
## Context
The `/create-pr` skill previously produced minimal `## Summary` + bullet-list bodies. Most code in this repo is LLM-generated, so reviewers rely on the PR description more than the diff to understand intent, design, and risk. The loose template made it easy for agents to produce shallow descriptions that didn't surface the information reviewers actually need. This change reshapes the skill so the agent gathers the right material and emits a consistent, reviewable body for every PR.

## Linked Issues
AIAPP-1764 — improve create-pr skill in CLI (branch: `yonatanbeker/aiapp-1764-improve-create-pr-skill-in-cli`).

## Design
Pure skill-prompt edit in `.claude/skills/create-pr/SKILL.md`; no Rust code, no runtime behavior changes. The skill is read by Claude Code when the user runs `/create-pr`. Two phases are tightened:

1. **Step 4 (Analyze changes)** now explicitly tells the agent *what to collect* (why, how, non-obvious decisions, behavioral/interface/schema changes, what was actually tested, risks) so step 5 has material to draw on. It also calls out reading the branch name for ticket IDs and full commit messages (not `--oneline`).
2. **Step 5 (Create the PR)** replaces the freeform `## Summary` body with a fixed 8-section template: Context, Linked Issues, Design, Key Decisions, Changes, Testing, Risks & Rollout, Out of Scope / Follow-ups. Sections that don't apply must be filled with `N/A — <reason>` rather than omitted, so structure is invariant across PRs.

A new step 6 adds a pre-submit checklist (all headers present and in order, no empty sections, Testing reflects actual commands run, Changes is semantic not file-listy, Design sits above the diff). Reporting is renumbered to step 7.

## Key Decisions
- **Mandatory headers with `N/A — <reason>` fallback** instead of optional/omittable sections. Optional sections drift toward being skipped; forcing an explicit `N/A` reason makes the omission a deliberate signal to reviewers and prevents the agent from silently dropping risk/rollout context.
- **Separate `Design` and `Changes` sections.** `Changes` stays semantic (interfaces, schemas, behavior); `Design` covers how the pieces fit together. Collapsing them encourages file-by-file inventories, which the existing `[[feedback_pr_descriptions]]` memory already pushes back against.
- **Pre-submit checklist embedded in the skill** rather than relying on the agent to self-correct. It targets the failure modes observed (missing headers, generic "Testing: ran tests" lines, file inventories under Changes).
- **No template variables / placeholders.** The skill instructs the agent to write `N/A — <reason>` literally; this is cheaper than asking the agent to reason about placeholder substitution.

## Changes
- `/create-pr` now emits an 8-section structured body for every PR (Context, Linked Issues, Design, Key Decisions, Changes, Testing, Risks & Rollout, Out of Scope / Follow-ups), with `N/A — <reason>` required for non-applicable sections.
- Analysis step now requires collecting why / how / decisions / behavior / testing / risks before drafting the body, and reading the branch name for ticket IDs.
- New pre-submit checklist step validates header completeness, non-empty sections, real (not aspirational) testing, semantic Changes, and above-the-diff Design.

## Testing
- This PR itself was created using the updated skill — it is the smoke test for the new template (every section below was authored against the new flow, including this one).
- No Rust code changed, so `cargo fmt` / `cargo clippy` / `cargo test` are not relevant for this PR and were not run.

## Risks & Rollout
Low risk. The skill only runs when a user invokes `/create-pr`, and the change is text-only inside `.claude/skills/`. Worst case: an agent produces a more verbose PR body than before; reviewers can ignore sections that are `N/A`. Rollback is a single-commit revert.

## Out of Scope / Follow-ups
- Not updating the broader `contributing/` docs to reference the new template — can follow up if maintainers want the human-authored PR flow to match.
- Not adding lint/CI enforcement that PRs include the 8 headers; the skill is advisory, not enforced server-side.