### PR TITLE
Fix dashboard gauge bounds validation

### DIFF
--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/skills/cx-dashboards/SKILL.md
+++ b/skills/cx-dashboards/SKILL.md
@@ -239,6 +239,7 @@ Run this checklist against the final JSON. Fix and re-check if any item fails be
 - [ ] Each section has `id.value`, `rows`, and `options.custom`.
 - [ ] Each row has `id.value`, `appearance.height`, and `widgets`.
 - [ ] Each widget has a unique `id.value` and a `definition` with exactly one of `gauge` / `pieChart` / `lineChart` / `dataTable`.
+- [ ] Every gauge has numeric `min` and `max`, and `min < max`.
 - [ ] Success-rate gauges use `thresholdType: "THRESHOLD_TYPE_ABSOLUTE"` with green at high values; error/DLQ gauges use red at high values.
 - [ ] "Total" / "stat" widgets are encoded as `gauge`, not as a stat type.
 - [ ] Top-level `filters` includes each slicing dimension from Phase 2.

--- a/skills/cx-dashboards/references/widget-templates.md
+++ b/skills/cx-dashboards/references/widget-templates.md
@@ -51,6 +51,8 @@ A row always looks like:
 
 Use for headline numbers: counts, percentages, success rates.
 
+Gauge `min` and `max` must be numeric and `min < max`. This API constraint applies even when `thresholdType` is `THRESHOLD_TYPE_ABSOLUTE`; use a real range such as `0..100` for percentages, a known capacity/limit when available, or a max above the highest threshold.
+
 ```json
 {
   "id": {"value": "<uuid>"},


### PR DESCRIPTION
## Summary
- Add a Phase 6 cx-dashboards self-check for numeric gauge min/max bounds with min < max
- Document that absolute-threshold gauges still need a valid API range
- Link project-local Codex skills to the existing Claude skills directory

## Test
- scripts/verify-skills.sh