### PR TITLE
Fix incidents list filters and pagination

### DIFF
--- a/docs/multi-profile.md
+++ b/docs/multi-profile.md
@@ -18,6 +18,8 @@ cx metrics query 'up' -p us-prod -p eu-prod
 3. Results are merged into a single output, with each row tagged with a `"profile"` key identifying its source.
 4. Errors from individual profiles are printed to stderr but do not fail the entire operation - successful results are still returned. The command exits 0 if at least one profile succeeds.
 
+When a command has a result limit, the limit applies independently to each selected profile. For example, `cx incidents list -p prod -p staging --limit 100` can return up to 100 incidents from `prod` and up to 100 incidents from `staging`.
+
 ## Result tagging
 
 When multiple profiles are used, each result row includes an additional `"profile"` field:

--- a/docs/time-syntax.md
+++ b/docs/time-syntax.md
@@ -1,6 +1,6 @@
 # Time syntax
 
-Commands that accept `--start` and `--end` (`cx logs`, `cx spans`, `cx dataprime query`, `cx metrics query-range`) support the following time expressions. `cx metrics query` uses `--time` for a single instant instead.
+Commands that accept `--start` and `--end` (`cx logs`, `cx spans`, `cx dataprime query`, `cx metrics query-range`, `cx incidents list`) support the following time expressions. `cx metrics query` uses `--time` for a single instant instead.
 
 ## Formats
 
@@ -33,6 +33,7 @@ Compound durations are supported: `1h30m`, `2d12h`.
 | `cx spans` | `now-1h` | `now` |
 | `cx dataprime query` | `now-1h` | `now` |
 | `cx metrics query-range` | `now-1h` | `now` |
+| `cx incidents list` | Not set | Not set |
 | `cx metrics query` | Uses `--time` (defaults to `now`) | N/A |
 
 ## Examples

--- a/skills/cx-incident-management/SKILL.md
+++ b/skills/cx-incident-management/SKILL.md
@@ -32,7 +32,8 @@ Use this skill as the gateway for incident triage, SLO monitoring, and notificat
 | `cx notifications test` | `connector`, `destination`, `preset`, `routing-condition`, `template-render` | Test notification delivery |
 
 Key flags:
-- `cx incidents list` supports `--status` (TRIGGERED, ACKNOWLEDGED, RESOLVED), `--severity` (CRITICAL, WARNING, INFO), `--assignee`
+- `cx incidents list` supports repeatable filters: `--status` (TRIGGERED, ACKNOWLEDGED, RESOLVED), `--severity` (INFO, WARNING, ERROR, CRITICAL), `--state` (TRIGGERED, RESOLVED), `--assignee`, `--application-name`, `--subsystem-name`, `--contextual-label key=value`, `--query`, `--muted`, `--unmuted`, `--created-start/--created-end`, and `--duration-start/--duration-end`
+- `cx incidents list` returns at most 100 incidents by default. Use `--limit <n>` for a bounded result set, `--page-size <n>`/`--page-token <token>` for manual pagination, or `--all` only when you explicitly need every page.
 - All commands support `-o json` for structured output and `-p <profile>` for profile selection
 - `cx slos create/update` use `--from-file <path>` (or `-` for stdin)
 
@@ -46,12 +47,13 @@ Key flags:
 cx incidents list -o json
 cx incidents list --status TRIGGERED -o json
 cx incidents list --severity CRITICAL -o json
+cx incidents list --status TRIGGERED --created-start now-24h --limit 50 -o json
 ```
 
 Get an overview of what's happening. Filter by severity for immediate priorities:
 
 ```bash
-cx incidents list -o json | jq '[.[] | select(.severity == "CRITICAL") | {id, name, status, severity, started_at}]'
+cx incidents list --severity CRITICAL --limit 50 -o json | jq '[.[] | {id, name, state, severity, created_at}]'
 ```
 
 ### Step 2: Get Incident Details

--- a/skills/cx-incident-management/SKILL.md
+++ b/skills/cx-incident-management/SKILL.md
@@ -33,7 +33,7 @@ Use this skill as the gateway for incident triage, SLO monitoring, and notificat
 
 Key flags:
 - `cx incidents list` supports repeatable filters: `--status` (TRIGGERED, ACKNOWLEDGED, RESOLVED), `--severity` (INFO, WARNING, ERROR, CRITICAL), `--state` (TRIGGERED, RESOLVED), `--assignee`, `--application-name`, `--subsystem-name`, `--contextual-label key=value`, `--query`, `--muted`, `--unmuted`, `--created-start/--created-end`, and `--duration-start/--duration-end`
-- `cx incidents list` returns at most 100 incidents by default. Use `--limit <n>` for a bounded result set, `--page-size <n>`/`--page-token <token>` for manual pagination, or `--all` only when you explicitly need every page.
+- `cx incidents list` returns at most 100 incidents per profile by default. Use `--limit <n>` for a bounded per-profile result set, `--page-size <n>`/`--page-token <token>` for manual pagination, or `--all` only when you explicitly need every page.
 - All commands support `-o json` for structured output and `-p <profile>` for profile selection
 - `cx slos create/update` use `--from-file <path>` (or `-` for stdin)
 

--- a/skills/cx-incident-management/SKILL.md
+++ b/skills/cx-incident-management/SKILL.md
@@ -32,7 +32,7 @@ Use this skill as the gateway for incident triage, SLO monitoring, and notificat
 | `cx notifications test` | `connector`, `destination`, `preset`, `routing-condition`, `template-render` | Test notification delivery |
 
 Key flags:
-- `cx incidents list` supports repeatable filters: `--status` (TRIGGERED, ACKNOWLEDGED, RESOLVED), `--severity` (INFO, WARNING, ERROR, CRITICAL), `--state` (TRIGGERED, RESOLVED), `--assignee`, `--application-name`, `--subsystem-name`, `--contextual-label key=value`, `--query`, `--muted`, `--unmuted`, `--created-start/--created-end`, and `--duration-start/--duration-end`
+- `cx incidents list` supports repeatable filters: `--status` (TRIGGERED, ACKNOWLEDGED, RESOLVED), `--severity` (INFO, WARNING, ERROR, CRITICAL), `--state` (TRIGGERED, RESOLVED), `--assignee`, `--application-name`, `--subsystem-name`, `--contextual-label key=value`, `--query`, `--muting muted|unmuted`, `--start/--end`, and `--duration-start/--duration-end`
 - `cx incidents list` returns at most 100 incidents per profile by default. Use `--limit <n>` for a bounded per-profile result set, `--page-size <n>`/`--page-token <token>` for manual pagination, or `--all` only when you explicitly need every page.
 - All commands support `-o json` for structured output and `-p <profile>` for profile selection
 - `cx slos create/update` use `--from-file <path>` (or `-` for stdin)
@@ -47,7 +47,7 @@ Key flags:
 cx incidents list -o json
 cx incidents list --status TRIGGERED -o json
 cx incidents list --severity CRITICAL -o json
-cx incidents list --status TRIGGERED --created-start now-24h --limit 50 -o json
+cx incidents list --status TRIGGERED --start now-24h --limit 50 -o json
 ```
 
 Get an overview of what's happening. Filter by severity for immediate priorities:

--- a/src/commands/incidents/api.rs
+++ b/src/commands/incidents/api.rs
@@ -87,7 +87,27 @@ impl Incident {
 pub struct ListIncidentsResponse {
     #[serde(default)]
     pub incidents: Vec<Incident>,
+    pub pagination: Option<PaginationResponse>,
+    // Older facade responses exposed this at the top level; keep accepting it
+    // so pagination keeps working across API versions.
     pub next_page_token: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PaginationResponse {
+    pub total_size: Option<u32>,
+    pub next_page_token: Option<String>,
+}
+
+impl ListIncidentsResponse {
+    pub fn next_page_token(&self) -> Option<&str> {
+        self.pagination
+            .as_ref()
+            .and_then(|p| p.next_page_token.as_deref())
+            .or(self.next_page_token.as_deref())
+            .filter(|token| !token.is_empty())
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/commands/incidents/mod.rs
+++ b/src/commands/incidents/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -11,6 +11,30 @@ use crate::config::OutputFormat;
 use crate::execution::{fan_out, ExecutionTarget};
 use crate::render;
 use api::{Incident, IncidentsApi};
+
+#[derive(Debug, Clone, Default)]
+pub struct ListIncidentsOptions {
+    pub statuses: Vec<String>,
+    pub severities: Vec<String>,
+    pub states: Vec<String>,
+    pub assignees: Vec<String>,
+    pub application_names: Vec<String>,
+    pub subsystem_names: Vec<String>,
+    pub contextual_labels: Vec<String>,
+    pub search_query: Option<String>,
+    pub search_field: Option<String>,
+    pub search_contextual_label: Option<String>,
+    pub is_muted: Option<bool>,
+    pub created_start: Option<String>,
+    pub created_end: Option<String>,
+    pub duration_start: Option<String>,
+    pub duration_end: Option<String>,
+    pub order_by: Option<String>,
+    pub order_direction: Option<String>,
+    pub page_size: u32,
+    pub page_token: Option<String>,
+    pub limit: Option<usize>,
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -33,57 +57,259 @@ fn incident_to_json(incident: &Incident, include_profile: bool, profile: &str) -
     v
 }
 
+fn normalize_enum(input: &str, prefix: &str) -> String {
+    let normalized = input.trim().replace(['-', ' '], "_").to_ascii_uppercase();
+    if normalized.starts_with(prefix) {
+        normalized
+    } else {
+        format!("{prefix}{normalized}")
+    }
+}
+
+fn normalize_incident_field(input: &str) -> String {
+    let normalized = input.trim().replace(['-', ' '], "_").to_ascii_uppercase();
+    let field = match normalized.as_str() {
+        "CREATED" | "CREATED_AT" | "CREATED_TIME" => "CREATED_TIME",
+        "CLOSED" | "CLOSED_AT" | "CLOSED_TIME" => "CLOSED_TIME",
+        "LAST_UPDATE" | "LAST_STATE_UPDATE" | "LAST_STATE_UPDATE_AT" | "LAST_STATE_UPDATE_TIME" => {
+            "LAST_STATE_UPDATE_TIME"
+        }
+        "APPLICATION" | "APPLICATION_NAME" => "APPLICATION_NAME",
+        "SUBSYSTEM" | "SUBSYSTEM_NAME" => "SUBSYSTEM_NAME",
+        other => other,
+    };
+
+    if field.starts_with("INCIDENTS_FIELDS_") {
+        field.to_string()
+    } else {
+        format!("INCIDENTS_FIELDS_{field}")
+    }
+}
+
+fn normalize_order_direction(input: &str) -> String {
+    normalize_enum(input, "ORDER_BY_DIRECTION_")
+}
+
+fn insert_non_empty_array(filter: &mut Value, key: &str, values: &[String], prefix: Option<&str>) {
+    if values.is_empty() {
+        return;
+    }
+
+    let items: Vec<Value> = values
+        .iter()
+        .map(|v| match prefix {
+            Some(prefix) => Value::String(normalize_enum(v, prefix)),
+            None => Value::String(v.clone()),
+        })
+        .collect();
+    filter[key] = Value::Array(items);
+}
+
+fn insert_time_range(
+    filter: &mut Value,
+    key: &str,
+    start: Option<&str>,
+    end: Option<&str>,
+) -> Result<()> {
+    if start.is_none() && end.is_none() {
+        return Ok(());
+    }
+
+    let mut range = json!({});
+    if let Some(start) = start {
+        range["startTime"] = Value::String(crate::time::parse_timestamp(start)?);
+    }
+    if let Some(end) = end {
+        range["endTime"] = Value::String(crate::time::parse_timestamp(end)?);
+    }
+    filter[key] = range;
+
+    Ok(())
+}
+
+fn insert_contextual_labels(filter: &mut Value, labels: &[String]) -> Result<()> {
+    if labels.is_empty() {
+        return Ok(());
+    }
+
+    let mut map = serde_json::Map::new();
+    for label in labels {
+        let Some((key, value)) = label.split_once('=') else {
+            bail!("Invalid contextual label '{label}'. Use key=value.");
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if key.is_empty() || value.is_empty() {
+            bail!("Invalid contextual label '{label}'. Use key=value.");
+        }
+
+        let entry = map
+            .entry(key.to_string())
+            .or_insert_with(|| json!({ "contextualLabelValues": [] }));
+        entry["contextualLabelValues"]
+            .as_array_mut()
+            .expect("contextual label values initialized as array")
+            .push(Value::String(value.to_string()));
+    }
+
+    filter["contextualLabels"] = Value::Object(map);
+    Ok(())
+}
+
+fn build_list_body(options: &ListIncidentsOptions, page_token: Option<&str>) -> Result<Value> {
+    let mut filter = json!({});
+
+    insert_non_empty_array(
+        &mut filter,
+        "status",
+        &options.statuses,
+        Some("INCIDENT_STATUS_"),
+    );
+    insert_non_empty_array(
+        &mut filter,
+        "severity",
+        &options.severities,
+        Some("INCIDENT_SEVERITY_"),
+    );
+    insert_non_empty_array(
+        &mut filter,
+        "state",
+        &options.states,
+        Some("INCIDENT_STATE_"),
+    );
+    insert_non_empty_array(&mut filter, "assignee", &options.assignees, None);
+    insert_non_empty_array(
+        &mut filter,
+        "applicationName",
+        &options.application_names,
+        None,
+    );
+    insert_non_empty_array(&mut filter, "subsystemName", &options.subsystem_names, None);
+    insert_contextual_labels(&mut filter, &options.contextual_labels)?;
+
+    if let Some(is_muted) = options.is_muted {
+        filter["isMuted"] = Value::Bool(is_muted);
+    }
+
+    if let Some(query) = options.search_query.as_deref() {
+        if options.search_field.is_some() && options.search_contextual_label.is_some() {
+            bail!("Use only one of --query-field or --query-contextual-label with --query.");
+        }
+        if options.search_field.is_none() && options.search_contextual_label.is_none() {
+            bail!("Use --query-field or --query-contextual-label with --query.");
+        }
+
+        let mut search_query = json!({ "query": query });
+        if let Some(field) = options.search_field.as_deref() {
+            search_query["incidentField"] = Value::String(normalize_incident_field(field));
+        }
+        if let Some(label) = options.search_contextual_label.as_deref() {
+            search_query["contextualLabel"] = Value::String(label.to_string());
+        }
+        filter["searchQuery"] = search_query;
+    }
+
+    insert_time_range(
+        &mut filter,
+        "createdAtRange",
+        options.created_start.as_deref(),
+        options.created_end.as_deref(),
+    )?;
+    insert_time_range(
+        &mut filter,
+        "incidentDurationRange",
+        options.duration_start.as_deref(),
+        options.duration_end.as_deref(),
+    )?;
+
+    let mut body = json!({
+        "filter": filter,
+        "pagination": {
+            "pageSize": options.page_size,
+        },
+    });
+
+    if let Some(token) = page_token.or(options.page_token.as_deref()) {
+        body["pagination"]["pageToken"] = Value::String(token.to_string());
+    }
+
+    if let Some(order_by) = options.order_by.as_deref() {
+        body["orderBys"] = json!([
+            {
+                "incidentField": normalize_incident_field(order_by),
+                "direction": normalize_order_direction(
+                    options.order_direction.as_deref().unwrap_or("DESC")
+                ),
+            }
+        ]);
+    }
+
+    Ok(body)
+}
+
 // ── Subcommand runners ────────────────────────────────────────────────────────
 
 pub async fn run_list(
     targets: &[Arc<ExecutionTarget>],
-    status_filter: Option<&str>,
-    severity_filter: Option<&str>,
-    assignee_filter: Option<&str>,
+    options: ListIncidentsOptions,
     output: OutputFormat,
 ) -> Result<()> {
     eprintln!("{}", "Fetching incidents...".dimmed());
 
     let include_profile = targets.len() > 1;
 
-    let status_owned = status_filter.map(|s| s.to_string());
-    let severity_owned = severity_filter.map(|s| s.to_string());
-    let assignee_owned = assignee_filter.map(|s| s.to_string());
-
     let per_profile = fan_out(targets, |t| {
-        let status = status_owned.clone();
-        let severity = severity_owned.clone();
-        let assignee = assignee_owned.clone();
+        let options = options.clone();
         async move {
             let api = IncidentsApi::new(&t.client);
-            let mut filter = json!({});
-            if let Some(s) = status {
-                filter["status"] = Value::String(s);
+            let mut incidents = Vec::new();
+            let mut next_page_token: Option<String> = None;
+
+            loop {
+                let body = build_list_body(&options, next_page_token.as_deref())?;
+                let mut resp = api.list(&body).await?;
+                next_page_token = resp.next_page_token().map(ToString::to_string);
+                incidents.append(&mut resp.incidents);
+
+                if let Some(limit) = options.limit {
+                    if incidents.len() >= limit {
+                        incidents.truncate(limit);
+                        break;
+                    }
+                }
+
+                if next_page_token.is_none() {
+                    break;
+                }
             }
-            if let Some(s) = severity {
-                filter["severity"] = Value::String(s);
-            }
-            if let Some(a) = assignee {
-                filter["assignee"] = Value::String(a);
-            }
-            let body = json!({ "filter": filter });
-            Ok(api.list(&body).await?)
+
+            Ok(incidents)
         }
     })
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Incident)> = Vec::new();
+    let mut success_count = 0usize;
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
-            Ok(resp) => {
-                for incident in resp.incidents {
+            Ok(incidents) => {
+                success_count += 1;
+                for incident in incidents {
                     all_json.push(incident_to_json(&incident, include_profile, &profile));
                     all_items.push((profile.clone(), incident));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+
+    if success_count == 0 && error_count > 0 {
+        bail!("Failed to list incidents for all selected profiles.");
     }
 
     match output {
@@ -520,4 +746,138 @@ pub async fn run_aggregations(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_list_body_uses_repeated_fields_and_full_enum_names() {
+        let body = build_list_body(
+            &ListIncidentsOptions {
+                statuses: vec![
+                    "triggered".to_string(),
+                    "INCIDENT_STATUS_ACKNOWLEDGED".to_string(),
+                ],
+                severities: vec!["critical".to_string()],
+                states: vec!["resolved".to_string()],
+                assignees: vec!["user-1".to_string()],
+                page_size: 25,
+                limit: Some(25),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(
+            body["filter"]["status"],
+            json!(["INCIDENT_STATUS_TRIGGERED", "INCIDENT_STATUS_ACKNOWLEDGED"])
+        );
+        assert_eq!(
+            body["filter"]["severity"],
+            json!(["INCIDENT_SEVERITY_CRITICAL"])
+        );
+        assert_eq!(body["filter"]["state"], json!(["INCIDENT_STATE_RESOLVED"]));
+        assert_eq!(body["filter"]["assignee"], json!(["user-1"]));
+        assert_eq!(body["pagination"]["pageSize"], json!(25));
+    }
+
+    #[test]
+    fn build_list_body_supports_search_labels_ordering_and_page_token() {
+        let body = build_list_body(
+            &ListIncidentsOptions {
+                application_names: vec!["checkout".to_string()],
+                subsystem_names: vec!["api".to_string()],
+                contextual_labels: vec![
+                    "team=payments".to_string(),
+                    "team=platform".to_string(),
+                    "env=prod".to_string(),
+                ],
+                search_query: Some("latency".to_string()),
+                search_field: Some("name".to_string()),
+                is_muted: Some(false),
+                order_by: Some("created_at".to_string()),
+                order_direction: Some("asc".to_string()),
+                page_size: 50,
+                limit: Some(50),
+                ..Default::default()
+            },
+            Some("next-token"),
+        )
+        .unwrap();
+
+        assert_eq!(body["filter"]["applicationName"], json!(["checkout"]));
+        assert_eq!(body["filter"]["subsystemName"], json!(["api"]));
+        assert_eq!(
+            body["filter"]["contextualLabels"]["team"]["contextualLabelValues"],
+            json!(["payments", "platform"])
+        );
+        assert_eq!(
+            body["filter"]["contextualLabels"]["env"]["contextualLabelValues"],
+            json!(["prod"])
+        );
+        assert_eq!(body["filter"]["searchQuery"]["query"], json!("latency"));
+        assert_eq!(
+            body["filter"]["searchQuery"]["incidentField"],
+            json!("INCIDENTS_FIELDS_NAME")
+        );
+        assert_eq!(body["filter"]["isMuted"], json!(false));
+        assert_eq!(body["pagination"]["pageToken"], json!("next-token"));
+        assert_eq!(
+            body["orderBys"],
+            json!([
+                {
+                    "incidentField": "INCIDENTS_FIELDS_CREATED_TIME",
+                    "direction": "ORDER_BY_DIRECTION_ASC"
+                }
+            ])
+        );
+    }
+
+    #[test]
+    fn invalid_contextual_label_errors() {
+        let err = build_list_body(
+            &ListIncidentsOptions {
+                contextual_labels: vec!["team".to_string()],
+                page_size: 100,
+                limit: Some(100),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap_err();
+
+        assert!(err.to_string().contains("Use key=value"));
+    }
+
+    #[test]
+    fn search_query_requires_exactly_one_field_target() {
+        let no_field = build_list_body(
+            &ListIncidentsOptions {
+                search_query: Some("error".to_string()),
+                page_size: 100,
+                limit: Some(100),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap_err();
+        assert!(no_field.to_string().contains("--query-field"));
+
+        let two_fields = build_list_body(
+            &ListIncidentsOptions {
+                search_query: Some("error".to_string()),
+                search_field: Some("name".to_string()),
+                search_contextual_label: Some("service".to_string()),
+                page_size: 100,
+                limit: Some(100),
+                ..Default::default()
+            },
+            None,
+        )
+        .unwrap_err();
+        assert!(two_fields.to_string().contains("Use only one"));
+    }
 }

--- a/src/commands/incidents/mod.rs
+++ b/src/commands/incidents/mod.rs
@@ -34,6 +34,12 @@ pub struct ListIncidentsOptions {
     pub page_size: u32,
     pub page_token: Option<String>,
     pub limit: Option<usize>,
+    pub show_next_page_token: bool,
+}
+
+struct ListIncidentsPage {
+    incidents: Vec<Incident>,
+    next_page_token: Option<String>,
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -283,7 +289,10 @@ pub async fn run_list(
                 }
             }
 
-            Ok(incidents)
+            Ok(ListIncidentsPage {
+                incidents,
+                next_page_token,
+            })
         }
     })
     .await;
@@ -294,9 +303,18 @@ pub async fn run_list(
     let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
-            Ok(incidents) => {
+            Ok(page) => {
                 success_count += 1;
-                for incident in incidents {
+                if options.show_next_page_token {
+                    if let Some(token) = page.next_page_token.as_deref() {
+                        if include_profile {
+                            eprintln!("Next page token for profile '{profile}': {token}");
+                        } else {
+                            eprintln!("Next page token: {token}");
+                        }
+                    }
+                }
+                for incident in page.incidents {
                     all_json.push(incident_to_json(&incident, include_profile, &profile));
                     all_items.push((profile.clone(), incident));
                 }
@@ -798,6 +816,8 @@ mod tests {
                 search_query: Some("latency".to_string()),
                 search_field: Some("name".to_string()),
                 is_muted: Some(false),
+                created_start: Some("2024-01-01T00:00:00Z".to_string()),
+                created_end: Some("2024-01-02T00:00:00Z".to_string()),
                 order_by: Some("created_at".to_string()),
                 order_direction: Some("asc".to_string()),
                 page_size: 50,
@@ -824,6 +844,13 @@ mod tests {
             json!("INCIDENTS_FIELDS_NAME")
         );
         assert_eq!(body["filter"]["isMuted"], json!(false));
+        assert_eq!(
+            body["filter"]["createdAtRange"],
+            json!({
+                "startTime": "2024-01-01T00:00:00.000Z",
+                "endTime": "2024-01-02T00:00:00.000Z"
+            })
+        );
         assert_eq!(body["pagination"]["pageToken"], json!("next-token"));
         assert_eq!(
             body["orderBys"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -1035,7 +1035,7 @@ Examples:
         #[arg(long = "page-token")]
         page_token: Option<String>,
 
-        /// Maximum incidents to return. Use --all to fetch every page.
+        /// Maximum incidents to return per profile. Use --all to fetch every page.
         #[arg(long, default_value_t = 100, conflicts_with = "all", value_parser = clap::value_parser!(u32).range(1..))]
         limit: u32,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Result};
 use clap::parser::ValueSource;
-use clap::{ArgAction, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, ArgMatches, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use clap_complete::aot::Shell;
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
@@ -47,6 +47,20 @@ pub enum SearchByValueDataset {
     Logs,
     Spans,
     All,
+}
+
+#[derive(Debug, Clone, Copy, ValueEnum)]
+enum Muting {
+    Muted,
+    Unmuted,
+}
+
+fn incidents_list_arg_from_cli(matches: &ArgMatches, arg: &str) -> bool {
+    matches
+        .subcommand_matches("incidents")
+        .and_then(|m| m.subcommand_matches("list"))
+        .and_then(|m| m.value_source(arg))
+        == Some(ValueSource::CommandLine)
 }
 
 /// Coralogix CLI - the observability backbone for AI agents and engineering teams.
@@ -954,7 +968,7 @@ Examples:
   cx incidents list
   cx incidents list --severity CRITICAL
   cx incidents list --status TRIGGERED
-  cx incidents list --created-start now-24h --order-by created_at --limit 50")]
+  cx incidents list --start now-24h --order-by created_at --limit 50")]
     List {
         /// Filter by status. Repeatable. Values: TRIGGERED, ACKNOWLEDGED, RESOLVED.
         #[arg(long)]
@@ -996,21 +1010,17 @@ Examples:
         #[arg(long = "query-contextual-label")]
         search_contextual_label: Option<String>,
 
-        /// Return only muted incidents.
-        #[arg(long, action = ArgAction::SetTrue, conflicts_with = "unmuted")]
-        muted: bool,
-
-        /// Return only unmuted incidents.
-        #[arg(long, action = ArgAction::SetTrue)]
-        unmuted: bool,
+        /// Filter by muting state.
+        #[arg(long, value_enum)]
+        muting: Option<Muting>,
 
         /// Created-at range start (ISO 8601 or relative, e.g. now-24h).
-        #[arg(long = "created-start")]
-        created_start: Option<String>,
+        #[arg(long = "start")]
+        start: Option<String>,
 
         /// Created-at range end (ISO 8601 or relative, e.g. now).
-        #[arg(long = "created-end")]
-        created_end: Option<String>,
+        #[arg(long = "end")]
+        end: Option<String>,
 
         /// Incident-duration range start (ISO 8601 or relative).
         #[arg(long = "duration-start")]
@@ -2742,10 +2752,9 @@ async fn main() -> Result<()> {
                     search_query,
                     search_field,
                     search_contextual_label,
-                    muted,
-                    unmuted,
-                    created_start,
-                    created_end,
+                    muting,
+                    start,
+                    end,
                     duration_start,
                     duration_end,
                     order_by,
@@ -2755,13 +2764,9 @@ async fn main() -> Result<()> {
                     limit,
                     all,
                 } => {
-                    let is_muted = if muted {
-                        Some(true)
-                    } else if unmuted {
-                        Some(false)
-                    } else {
-                        None
-                    };
+                    let is_muted = muting.map(|m| matches!(m, Muting::Muted));
+                    let show_next_page_token = incidents_list_arg_from_cli(&matches, "page_size")
+                        || incidents_list_arg_from_cli(&matches, "page_token");
                     let options = commands::incidents::ListIncidentsOptions {
                         statuses: status,
                         severities: severity,
@@ -2774,8 +2779,8 @@ async fn main() -> Result<()> {
                         search_field,
                         search_contextual_label,
                         is_muted,
-                        created_start,
-                        created_end,
+                        created_start: start,
+                        created_end: end,
                         duration_start,
                         duration_end,
                         order_by,
@@ -2783,6 +2788,7 @@ async fn main() -> Result<()> {
                         page_size,
                         page_token,
                         limit: if all { None } else { Some(limit as usize) },
+                        show_next_page_token,
                     };
                     commands::incidents::run_list(&targets, options, output).await?;
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use anyhow::{bail, Result};
 use clap::parser::ValueSource;
-use clap::{CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
+use clap::{ArgAction, CommandFactory, FromArgMatches, Parser, Subcommand, ValueEnum};
 use clap_complete::aot::Shell;
 use clap_complete::engine::ArgValueCompleter;
 use clap_complete::env::CompleteEnv;
@@ -192,6 +192,7 @@ Examples:
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Manage profiles (list, add, delete, set-default).
     Profiles {
@@ -944,25 +945,103 @@ Examples:
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum IncidentsCmd {
     /// List incidents with optional filters.
     #[command(after_help = "\
 Examples:
   cx incidents list
   cx incidents list --severity CRITICAL
-  cx incidents list --status TRIGGERED")]
+  cx incidents list --status TRIGGERED
+  cx incidents list --created-start now-24h --order-by created_at --limit 50")]
     List {
-        /// Filter by status (e.g. TRIGGERED, ACKNOWLEDGED, RESOLVED).
+        /// Filter by status. Repeatable. Values: TRIGGERED, ACKNOWLEDGED, RESOLVED.
         #[arg(long)]
-        status: Option<String>,
+        status: Vec<String>,
 
-        /// Filter by severity (e.g. CRITICAL, WARNING, INFO).
+        /// Filter by severity. Repeatable. Values: INFO, WARNING, ERROR, CRITICAL.
         #[arg(long)]
-        severity: Option<String>,
+        severity: Vec<String>,
 
-        /// Filter by assignee user ID.
+        /// Filter by incident state. Repeatable. Values: TRIGGERED, RESOLVED.
         #[arg(long)]
-        assignee: Option<String>,
+        state: Vec<String>,
+
+        /// Filter by assignee user ID. Repeatable.
+        #[arg(long)]
+        assignee: Vec<String>,
+
+        /// Filter by application name. Repeatable.
+        #[arg(long = "application-name")]
+        application_name: Vec<String>,
+
+        /// Filter by subsystem name. Repeatable.
+        #[arg(long = "subsystem-name")]
+        subsystem_name: Vec<String>,
+
+        /// Filter by contextual label as key=value. Repeatable.
+        #[arg(long = "contextual-label")]
+        contextual_label: Vec<String>,
+
+        /// Search query text.
+        #[arg(long = "query")]
+        search_query: Option<String>,
+
+        /// Incident field for --query (e.g. name, id, severity, status).
+        #[arg(long = "query-field")]
+        search_field: Option<String>,
+
+        /// Contextual label field for --query.
+        #[arg(long = "query-contextual-label")]
+        search_contextual_label: Option<String>,
+
+        /// Return only muted incidents.
+        #[arg(long, action = ArgAction::SetTrue, conflicts_with = "unmuted")]
+        muted: bool,
+
+        /// Return only unmuted incidents.
+        #[arg(long, action = ArgAction::SetTrue)]
+        unmuted: bool,
+
+        /// Created-at range start (ISO 8601 or relative, e.g. now-24h).
+        #[arg(long = "created-start")]
+        created_start: Option<String>,
+
+        /// Created-at range end (ISO 8601 or relative, e.g. now).
+        #[arg(long = "created-end")]
+        created_end: Option<String>,
+
+        /// Incident-duration range start (ISO 8601 or relative).
+        #[arg(long = "duration-start")]
+        duration_start: Option<String>,
+
+        /// Incident-duration range end (ISO 8601 or relative).
+        #[arg(long = "duration-end")]
+        duration_end: Option<String>,
+
+        /// Field to sort by (e.g. created_at, severity, name, status).
+        #[arg(long = "order-by")]
+        order_by: Option<String>,
+
+        /// Sort direction: ASC or DESC.
+        #[arg(long = "order-direction", default_value = "DESC")]
+        order_direction: String,
+
+        /// Number of incidents to request per API page.
+        #[arg(long = "page-size", default_value_t = 100, value_parser = clap::value_parser!(u32).range(1..))]
+        page_size: u32,
+
+        /// Page token returned by the API.
+        #[arg(long = "page-token")]
+        page_token: Option<String>,
+
+        /// Maximum incidents to return. Use --all to fetch every page.
+        #[arg(long, default_value_t = 100, conflicts_with = "all", value_parser = clap::value_parser!(u32).range(1..))]
+        limit: u32,
+
+        /// Fetch every available page.
+        #[arg(long, action = ArgAction::SetTrue)]
+        all: bool,
     },
     /// Get a single incident by ID.
     Get {
@@ -2613,16 +2692,57 @@ async fn main() -> Result<()> {
             IncidentsCmd::List {
                 status,
                 severity,
+                state,
                 assignee,
+                application_name,
+                subsystem_name,
+                contextual_label,
+                search_query,
+                search_field,
+                search_contextual_label,
+                muted,
+                unmuted,
+                created_start,
+                created_end,
+                duration_start,
+                duration_end,
+                order_by,
+                order_direction,
+                page_size,
+                page_token,
+                limit,
+                all,
             } => {
-                commands::incidents::run_list(
-                    &targets,
-                    status.as_deref(),
-                    severity.as_deref(),
-                    assignee.as_deref(),
-                    output,
-                )
-                .await?;
+                let is_muted = if muted {
+                    Some(true)
+                } else if unmuted {
+                    Some(false)
+                } else {
+                    None
+                };
+                let options = commands::incidents::ListIncidentsOptions {
+                    statuses: status,
+                    severities: severity,
+                    states: state,
+                    assignees: assignee,
+                    application_names: application_name,
+                    subsystem_names: subsystem_name,
+                    contextual_labels: contextual_label,
+                    search_query,
+                    search_field,
+                    search_contextual_label,
+                    is_muted,
+                    created_start,
+                    created_end,
+                    duration_start,
+                    duration_end,
+                    order_by,
+                    order_direction: Some(order_direction),
+                    page_size,
+                    page_token,
+                    limit: if all { None } else { Some(limit as usize) },
+                };
+                commands::incidents::run_list(&targets, options, output).await?;
             }
             IncidentsCmd::Get { id } => {
                 commands::incidents::run_get(&targets, &id, output).await?;

--- a/tests/e2e/incidents.rs
+++ b/tests/e2e/incidents.rs
@@ -6,6 +6,35 @@ fn incidents_list() {
     if harness::require_creds("incidents_list").is_none() {
         return;
     }
-    let v = harness::run_ok_json(&["incidents", "list", "-o", "json"]);
-    harness::assert_array(&v);
+    let v = harness::run_ok_json(&["incidents", "list", "--limit", "10", "-o", "json"]);
+    harness::assert_array_of_objects_with_keys(
+        &v,
+        &["id", "name", "severity", "state", "created_at"],
+    );
+}
+
+#[test]
+#[ignore]
+fn incidents_list_with_filters() {
+    if harness::require_creds("incidents_list_with_filters").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&[
+        "incidents",
+        "list",
+        "--status",
+        "TRIGGERED",
+        "--severity",
+        "CRITICAL",
+        "--page-size",
+        "1",
+        "--limit",
+        "1",
+        "-o",
+        "json",
+    ]);
+    harness::assert_array_of_objects_with_keys(
+        &v,
+        &["id", "name", "severity", "state", "created_at"],
+    );
 }

--- a/tests/incidents/main.rs
+++ b/tests/incidents/main.rs
@@ -1,0 +1,81 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use coralogix_cli::commands::incidents::{run_list, ListIncidentsOptions};
+use coralogix_cli::config::OutputFormat;
+
+#[tokio::test]
+async fn list_incidents_posts_filter_arrays_and_paginates() {
+    let server = MockServer::start().await;
+
+    let endpoint = "/mgmt/openapi/5/incidents/incidents/v1";
+
+    Mock::given(method("POST"))
+        .and(path(endpoint))
+        .and(body_json(json!({
+            "filter": {
+                "status": ["INCIDENT_STATUS_TRIGGERED"],
+                "severity": ["INCIDENT_SEVERITY_CRITICAL"],
+                "assignee": ["user-1"]
+            },
+            "pagination": {
+                "pageSize": 2
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "incidents": [
+                {"id": "inc-1", "name": "First"},
+                {"id": "inc-2", "name": "Second"}
+            ],
+            "pagination": {
+                "nextPageToken": "token-2"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(endpoint))
+        .and(body_json(json!({
+            "filter": {
+                "status": ["INCIDENT_STATUS_TRIGGERED"],
+                "severity": ["INCIDENT_SEVERITY_CRITICAL"],
+                "assignee": ["user-1"]
+            },
+            "pagination": {
+                "pageSize": 2,
+                "pageToken": "token-2"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "incidents": [
+                {"id": "inc-3", "name": "Third"},
+                {"id": "inc-4", "name": "Fourth"}
+            ],
+            "pagination": {}
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    run_list(
+        &[target],
+        ListIncidentsOptions {
+            statuses: vec!["triggered".to_string()],
+            severities: vec!["critical".to_string()],
+            assignees: vec!["user-1".to_string()],
+            page_size: 2,
+            limit: Some(3),
+            ..Default::default()
+        },
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_list should succeed");
+}

--- a/tests/incidents/main.rs
+++ b/tests/incidents/main.rs
@@ -1,6 +1,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+use assert_cmd::Command;
 use serde_json::json;
 use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -78,4 +79,47 @@ async fn list_incidents_posts_filter_arrays_and_paginates() {
     )
     .await
     .expect("run_list should succeed");
+}
+
+#[test]
+fn incidents_list_help_uses_ergonomic_flags() {
+    let output = Command::cargo_bin("cx")
+        .expect("cx binary should build")
+        .args(["incidents", "list", "--help"])
+        .output()
+        .expect("help command should run");
+
+    assert!(output.status.success(), "--help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(stdout.contains("--start <START>"), "stdout: {stdout}");
+    assert!(stdout.contains("--end <END>"), "stdout: {stdout}");
+    assert!(stdout.contains("--muting <MUTING>"), "stdout: {stdout}");
+    assert!(
+        !stdout.contains("--created-start"),
+        "stdout should not expose --created-start: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--created-end"),
+        "stdout should not expose --created-end: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--muted"),
+        "stdout should not expose --muted: {stdout}"
+    );
+    assert!(
+        !stdout.contains("--unmuted"),
+        "stdout should not expose --unmuted: {stdout}"
+    );
+}
+
+#[test]
+fn incidents_list_rejects_removed_flags() {
+    for flag in ["--created-start", "--created-end", "--muted", "--unmuted"] {
+        Command::cargo_bin("cx")
+            .expect("cx binary should build")
+            .args(["incidents", "list", flag])
+            .assert()
+            .failure();
+    }
 }


### PR DESCRIPTION
## Context
`cx incidents list` was producing frequent 400s because the v5 list endpoint expects repeated filter fields, fully qualified incident enum values, and paginated request/response shapes. The CLI was sending several filters as scalar strings and did not bound or paginate list responses, which made both API errors and oversized responses likely.

## Linked Issues
https://linear.app/coralogix/issue/AIAPP-1882/fix-incidents-list-endpoint

## Design
The list command now builds a typed `ListIncidentsOptions` object from clap arguments, converts that into the v5 JSON request body in one helper, and loops through `pagination.nextPageToken` until the requested limit is reached. The API layer accepts the v5 `pagination` response while retaining compatibility with older top-level `nextPageToken`. Rendering stays unchanged after the command has accumulated incidents across selected profiles.

## Key Decisions
The CLI accepts short user-facing values such as `CRITICAL`, `TRIGGERED`, and `created_at`, then normalizes them to v5 enum values like `INCIDENT_SEVERITY_CRITICAL`, `INCIDENT_STATUS_TRIGGERED`, and `INCIDENTS_FIELDS_CREATED_TIME`. Results are bounded to `--limit 100` by default to avoid unexpectedly large payloads; callers can opt into `--all` when they deliberately need every page. When every selected profile fails, list now exits nonzero instead of silently returning an empty result, since the previous behavior hid live API failures.

## Changes
- Changes `cx incidents list` filters from scalar request fields to v5 repeated fields for status, severity, state, assignee, application, and subsystem filters.
- Adds list flags for state, application/subsystem, contextual labels, query targeting, muted/unmuted, created and duration ranges, ordering, page size/token, bounded limits, and explicit `--all` pagination.
- Parses v5 pagination responses and fetches additional pages up to the requested limit.
- Validates contextual labels and `--query` target selection before sending malformed requests.
- Updates incident-management skill guidance to recommend bounded queries and the supported filter set.
- Extends ignored live e2e coverage and adds a wiremock integration test for request shape and pagination.

## Testing
- `cargo test --lib incidents --locked`
- `cargo test --test incidents --locked`
- `cargo test incidents --locked`
- `cargo test --test e2e incidents --locked`
- `cargo test --test e2e incidents --locked -- --ignored --nocapture`
- `cargo fmt --check`
- `cargo clippy --locked -- -D warnings`
- Manual live checks with `target/debug/cx incidents list` covering: `--limit`, status/severity filters, state filter, created range plus ordering, muted/unmuted, app/subsystem, contextual labels, repeated status/severity, duration range, and pagination across pages.
- Manual live search checks: contextual-label search and some `searchQuery.incidentField` values succeeded without 400s; `ID` and `SEVERITY` incident-field search returned v5 server 500s.

## Risks & Rollout
This changes the public `cx incidents list` interface by making existing `--status`, `--severity`, and `--assignee` repeatable while preserving single-use invocations. The default result set is now bounded to 100 incidents, which is safer for agents but may return fewer rows than before for users who expected an unbounded first response; `--all` restores full pagination. Rollback is the single commit if the v5 request shape causes unexpected compatibility issues.

## Out of Scope / Follow-ups
Grouping global help options is intentionally left for a separate task. v5 incident search has server-side inconsistencies: the OpenAPI schema says `searchQuery.field` is required, the live endpoint rejects that field, and `searchQuery.incidentField` with `ID` or `SEVERITY` returns 500. This PR avoids known malformed no-target search requests but does not attempt to work around those server-side search failures.