### PR TITLE
Separate global and command help options

### DIFF
--- a/contributing/adding-a-command.md
+++ b/contributing/adding-a-command.md
@@ -428,7 +428,7 @@ The `Cli` struct uses a custom `after_help` string (not Clap's `next_help_headin
 
 ```rust
 #[command(
-    help_template = "{about-with-newline}\nUsage: {usage}{after-help}\n\nOptions:\n{options}",
+    help_template = "{about-with-newline}\n{usage-heading} {usage}{after-help}\n\nGlobal Options:\n{options}",
     after_help = "\
 Query:
   logs               Query logs using DataPrime syntax

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,78 +55,95 @@ pub enum SearchByValueDataset {
     version,
     about,
     long_about = None,
-    help_template = "{before-help}{about-with-newline}\nUsage: {usage}{after-help}\n\nOptions:\n{options}",
+    help_template = "{before-help}{about-with-newline}\n{usage-heading} {usage}{after-help}\n\n\x1b[1m\x1b[4mGlobal Options:\x1b[0m\n{options}",
     after_help = "\
-Query:
-  logs               Query logs using DataPrime syntax
-  spans              Query spans using DataPrime syntax
-  metrics            Query metrics using PromQL
-  dataprime          DataPrime language reference and raw queries
-  search-fields      Search log/span fields by description or value content
+\x1b[1m\x1b[4mQuery:\x1b[0m
+  \x1b[1mlogs\x1b[0m               Query logs using DataPrime syntax
+  \x1b[1mspans\x1b[0m              Query spans using DataPrime syntax
+  \x1b[1mmetrics\x1b[0m            Query metrics using PromQL
+  \x1b[1mdataprime\x1b[0m          DataPrime language reference and raw queries
+  \x1b[1msearch-fields\x1b[0m      Search log/span fields by description or value content
 
-Observe:
-  dashboards         Manage dashboards and dashboard folders
-  views              Manage saved views and view folders
-  slos               Manage SLO definitions
+\x1b[1m\x1b[4mObserve:\x1b[0m
+  \x1b[1mdashboards\x1b[0m         Manage dashboards and dashboard folders
+  \x1b[1mviews\x1b[0m              Manage saved views and view folders
+  \x1b[1mslos\x1b[0m               Manage SLO definitions
 
-Detect & Respond:
-  alerts             Manage alert definitions and suppression rules
-  incidents          Manage and triage incidents
+\x1b[1m\x1b[4mDetect & Respond:\x1b[0m
+  \x1b[1malerts\x1b[0m             Manage alert definitions and suppression rules
+  \x1b[1mincidents\x1b[0m          Manage and triage incidents
 
-Notifications:
-  notifications      Manage connectors, routers, presets, and notification testing
-  webhooks           Manage outgoing webhooks and automation actions
+\x1b[1m\x1b[4mNotifications:\x1b[0m
+  \x1b[1mnotifications\x1b[0m      Manage connectors, routers, presets, and notification testing
+  \x1b[1mwebhooks\x1b[0m           Manage outgoing webhooks and automation actions
 
-Data Pipeline:
-  parsing-rules      Manage log parsing rules
-  enrichments        Manage enrichment rules and custom enrichment tables
-  e2m                Manage Events2Metrics definitions
-  recording-rules    Manage Prometheus recording rule groups
+\x1b[1m\x1b[4mData Pipeline:\x1b[0m
+  \x1b[1mparsing-rules\x1b[0m      Manage log parsing rules
+  \x1b[1menrichments\x1b[0m        Manage enrichment rules and custom enrichment tables
+  \x1b[1me2m\x1b[0m                Manage Events2Metrics definitions
+  \x1b[1mrecording-rules\x1b[0m    Manage Prometheus recording rule groups
 
-Cost & Storage:
-  usage              View data usage and consumption metrics
-  tco                Manage TCO policies and settings
-  retentions         Manage data retention settings
-  archive (risky)    Manage data archive storage configuration
+\x1b[1m\x1b[4mCost & Storage:\x1b[0m
+  \x1b[1musage\x1b[0m              View data usage and consumption metrics
+  \x1b[1mtco\x1b[0m                Manage TCO policies and settings
+  \x1b[1mretentions\x1b[0m         Manage data retention settings
+  \x1b[1marchive\x1b[0m (risky)    Manage data archive storage configuration
 
-Integrations:
-  integrations       Manage integrations, extensions, and contextual data
+\x1b[1m\x1b[4mIntegrations:\x1b[0m
+  \x1b[1mintegrations\x1b[0m       Manage integrations, extensions, and contextual data
 
-Access:
-  iam (risky)        Manage API keys, roles, scopes, users, groups, and IP access
+\x1b[1m\x1b[4mAccess:\x1b[0m
+  \x1b[1miam\x1b[0m (risky)        Manage API keys, roles, scopes, users, groups, and IP access
 
-Agent:
-  schema             Output the full command tree as JSON for agent consumption
-  olly               Interact with the AI assistant
+\x1b[1m\x1b[4mAgent:\x1b[0m
+  \x1b[1mschema\x1b[0m             Output the full command tree as JSON for agent consumption
+  \x1b[1molly\x1b[0m               Interact with the AI assistant
 
-Local:
-  profiles           Manage profiles (list, add, delete, set-default)
-  cleanup            Remove stale temp files"
+\x1b[1m\x1b[4mLocal:\x1b[0m
+  \x1b[1mprofiles\x1b[0m           Manage profiles (list, add, delete, set-default)
+  \x1b[1mcleanup\x1b[0m            Remove stale temp files"
 )]
 struct Cli {
     /// Profile(s) to use. Repeat to fan out across multiple profiles simultaneously.
     /// Overrides the default profile set in config.
-    #[arg(long, short = 'p', global = true, env = "CX_PROFILE", add = ArgValueCompleter::new(complete_profile_names))]
+    #[arg(
+        long,
+        short = 'p',
+        global = true,
+        env = "CX_PROFILE",
+        help_heading = "Global Options",
+        add = ArgValueCompleter::new(complete_profile_names)
+    )]
     profile: Vec<String>,
 
     /// Coralogix API key (overrides a single profile; incompatible with multiple --profile).
-    #[arg(long, global = true, env = "CX_API_KEY")]
+    #[arg(
+        long,
+        global = true,
+        env = "CX_API_KEY",
+        help_heading = "Global Options"
+    )]
     api_key: Option<String>,
 
     /// Coralogix region (overrides a single profile; incompatible with multiple --profile).
-    #[arg(long, global = true, env = "CX_REGION")]
+    #[arg(
+        long,
+        global = true,
+        env = "CX_REGION",
+        help_heading = "Global Options"
+    )]
     region: Option<String>,
 
     /// Output format: text, json, or agents. Overrides the default set in config.
-    #[arg(long, short = 'o', global = true)]
+    #[arg(long, short = 'o', global = true, help_heading = "Global Options")]
     output: Option<OutputFormat>,
 
     /// Skip confirmation prompts for destructive operations.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, help_heading = "Global Options")]
     yes: bool,
 
     /// Block all write operations. Useful for safe agent/automation access.
-    #[arg(long, global = true)]
+    #[arg(long, global = true, help_heading = "Global Options")]
     read_only: bool,
 
     #[command(subcommand)]
@@ -2239,9 +2256,9 @@ async fn main() -> Result<()> {
 
     let mut cmd = Cli::command();
     if banner::should_show() {
-        cmd = cmd
-            .before_help(banner::render())
-            .help_template("{before-help}\nUsage: {usage}{after-help}\n\nOptions:\n{options}");
+        cmd = cmd.before_help(banner::render()).help_template(
+            "{before-help}\n{usage-heading} {usage}{after-help}\n\n\x1b[1m\x1b[4mGlobal Options:\x1b[0m\n{options}",
+        );
     }
     let matches = cmd.get_matches();
     let cli = Cli::from_arg_matches(&matches)?;


### PR DESCRIPTION
## Context
`cx <subcommand> --help` currently mixes global flags with command-specific flags under one `Options` section, which makes it harder to see what applies to the command itself. This PR separates inherited global options from per-command options in help output while preserving the existing top-level domain-grouped command catalog.

## Linked Issues
AIAPP-1887 — inferred from the branch name.

## Design
The CLI continues to use Clap derive in `src/main.rs`. Global flags remain on the top-level `Cli` struct with `global = true`, but each now has `help_heading = "Global Options"` so Clap renders them separately on subcommand help. The existing custom top-level help template keeps the curated domain grouping and is styled to match Clap's automatic help headings and command literals.

## Key Decisions
Clap does not provide a tag/label mechanism for grouping top-level subcommands by domain, so the custom top-level command catalog stays in place. Instead of replacing it with a flat generated `Commands:` section, this PR styles the custom headings and command names with the same ANSI styles Clap uses for generated help. The `(risky)` annotations remain plain text so only the command literal is styled.

## Changes
- Separates command-local options from inherited global options in subcommand help.
- Renames the top-level flag section from `Options` to `Global Options`.
- Applies Clap-like styling to custom top-level help headings and command names.
- Updates the contributor help-template example to use `{usage-heading}` and `Global Options`.

Original installed `cx logs --help` excerpt:

```text
Options:
  -p, --profile <PROFILE>
          Profile(s) to use. Repeat to fan out across multiple profiles simultaneously. Overrides the default profile set in config

      --start <START>
          Start time in ISO 8601 or relative format. e.g. "2024-01-01T00:00:00Z" or "now-1h"

      --api-key <API_KEY>
          Coralogix API key (overrides a single profile; incompatible with multiple --profile)

      --end <END>
          End time in ISO 8601 or relative format

      --limit <LIMIT>
          Maximum number of results

      --region <REGION>
          Coralogix region (overrides a single profile; incompatible with multiple --profile)

  -o, --output <OUTPUT>
          Output format: text, json, or agents. Overrides the default set in config

      --tier <TIER>
          Storage tier to search. Overrides the profile's default_tier setting. If neither is set, defaults to archive

      --yes
          Skip confirmation prompts for destructive operations

      --read-only
          Block all write operations. Useful for safe agent/automation access
```

New local `target/debug/cx logs --help` excerpt:

```text
Options:
      --start <START>
          Start time in ISO 8601 or relative format. e.g. "2024-01-01T00:00:00Z" or "now-1h"

      --end <END>
          End time in ISO 8601 or relative format

      --limit <LIMIT>
          Maximum number of results

      --tier <TIER>
          Storage tier to search. Overrides the profile's default_tier setting. If neither is set, defaults to archive

  -h, --help
          Print help (see a summary with '-h')

Global Options:
  -p, --profile <PROFILE>
          Profile(s) to use. Repeat to fan out across multiple profiles simultaneously. Overrides the default profile set in config

      --api-key <API_KEY>
          Coralogix API key (overrides a single profile; incompatible with multiple --profile)

      --region <REGION>
          Coralogix region (overrides a single profile; incompatible with multiple --profile)

  -o, --output <OUTPUT>
          Output format: text, json, or agents. Overrides the default set in config

      --yes
          Skip confirmation prompts for destructive operations

      --read-only
          Block all write operations. Useful for safe agent/automation access
```

## Testing
- `cargo fmt`
- `cargo run -- --help`
- `target/debug/cx --help`
- `target/debug/cx logs --help`
- `target/debug/cx dataprime query --help`
- `target/debug/cx metrics query-range --help`
- `target/debug/cx profiles add --help`
- `target/debug/cx --read-only profiles add --help`
- `env -u NO_COLOR CLICOLOR_FORCE=1 target/debug/cx --help | sed -n '1,36l'`
- `git diff --check`

Automated tests were not added or run because this is a help-text formatting change and manual validation was requested.

## Risks & Rollout
Low risk: parsing behavior is unchanged and all global flags remain global. The main risk is terminal styling portability for the custom top-level catalog; Clap/anstream strips ANSI styling when colors are disabled or unsupported, matching the behavior of generated help. Rollback is reverting this commit.

## Out of Scope / Follow-ups
N/A — this PR fully covers the requested help-output separation and styling alignment.