### PR TITLE
SAG-7 | Change ASCII art banner color from green to blue

### DIFF
--- a/src/banner.rs
+++ b/src/banner.rs
@@ -64,14 +64,14 @@ pub fn render() -> String {
     out.push(format!(
         "{}{}",
         tag_pad,
-        TAGLINE.truecolor(0, 170, 110).italic()
+        TAGLINE.truecolor(60, 140, 220).italic()
     ));
 
     // ── Separator line ──
     let sep_width = logo_width.max(TAGLINE.len()) + 4;
     let sep_pad = center_pad(sep_width, width);
     let separator: String = "─".repeat(sep_width);
-    out.push(format!("{}{}", sep_pad, separator.truecolor(0, 90, 60)));
+    out.push(format!("{}{}", sep_pad, separator.truecolor(20, 60, 140)));
 
     out.join("\n")
 }
@@ -82,9 +82,9 @@ fn gradient_line(text: &str, row: usize, total_rows: usize) -> String {
     } else {
         row as f64 / (total_rows - 1) as f64
     };
-    // Vivid mint (#00FFB0) → bright emerald (#00E078)
-    let r = 0;
-    let g = (255.0 - 31.0 * t) as u8;
-    let b = (176.0 - 56.0 * t) as u8;
+    // Bright sky blue (#4FC3FF) → deep royal blue (#1E5BCC)
+    let r = (79.0 - 49.0 * t) as u8;
+    let g = (195.0 - 104.0 * t) as u8;
+    let b = (255.0 - 51.0 * t) as u8;
     format!("{}", text.truecolor(r, g, b).bold())
 }


### PR DESCRIPTION
## Context
The `cx` CLI displays a Unicode block-art "CX" logo before help text. It was rendered with a mint→emerald green gradient. This changes it to blue (sky→royal) as requested in SAG-7.

## Linked Issues
[SAG-7 — Change color of ascii art in cli help text to blue](https://linear.app/coralogix/issue/SAG-7)

## Design
All banner rendering lives in a single file: `src/banner.rs`. The file contains three color sites:
1. `gradient_line()` — applies a per-row truecolor gradient across the 6-line logo.
2. Tagline line — a single `truecolor()` call below the logo.
3. Separator line — a single `truecolor()` call for the `─` rule.

The change retunes only the RGB values at all three sites; the centering, terminal-width detection, `NO_COLOR` gate, TTY gate, and agent-mode suppression logic are completely untouched.

## Key Decisions
- **All three color sites changed together.** Leaving the tagline/separator green while the logo turned blue would produce a visually incoherent banner. They are trivially separable if product/design later wants to revert just the supporting elements.
- **Gradient approach kept.** The existing top→bottom gradient interpolation is retained; only the start/end RGB values change. This preserves the visual depth effect.
- **Chosen palette:** sky blue `#4FC3FF` (top) → royal blue `#1E5BCC` (bottom). Legible on both dark and light terminal backgrounds; not so light that it washes out on white, not so dark that it vanishes on black.

## Changes
- `src/banner.rs` — `gradient_line`: RGB math changed from mint→emerald green to sky→royal blue gradient.
- `src/banner.rs` — tagline: `truecolor(0, 170, 110)` → `truecolor(60, 140, 220)` (mid blue).
- `src/banner.rs` — separator: `truecolor(0, 90, 60)` → `truecolor(20, 60, 140)` (deep blue).
- Updated inline comment to describe the new color range.

## Testing
- `cargo fmt --check` — passed, no formatting changes needed.
- `cargo clippy --locked -- -D warnings` — passed, no warnings.
- `cargo test --locked` — 30 tests passed, 0 failed (no banner snapshot tests exist).
- Manual: `cargo run -- --help` visually confirmed sky-blue logo with blue tagline and separator.

## Risks & Rollout
N/A — purely cosmetic change to terminal color output. Gated by the existing `should_show()` check (TTY-only, respects `NO_COLOR`, suppressed in agent mode). No behavioral change, no API change, no config change.

## Out of Scope / Follow-ups
- Changing help text colors outside the banner (clap options/usage section).
- Making the banner color configurable via env var or config file.
- Adding snapshot/golden-file tests for banner output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)