### PR TITLE
AIAPP-1770 | udpate error msg

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -167,7 +167,7 @@ impl CxClient {
                     .into(),
             })),
             StatusCode::FORBIDDEN => Err(CxError::Permission(match detail {
-                Some(d) => format!("{d}. Check your API key's scopes."),
+                Some(d) => d,
                 None => {
                     "You do not have permission for this operation. Check your API key's scopes."
                         .into()

--- a/tests/api_client/main.rs
+++ b/tests/api_client/main.rs
@@ -52,12 +52,38 @@ async fn error_403_with_message() {
         "expected server message in error, got: {msg}"
     );
     assert!(
-        msg.contains("Check your API key's scopes"),
-        "expected scope hint in error, got: {msg}"
+        !msg.contains("Check your API key's scopes"),
+        "scope hint should not be appended when server provides detail, got: {msg}"
     );
     assert!(
         msg.contains("Permission denied"),
         "expected permission error, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn error_403_quota_exceeded() {
+    init_tls();
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/test"))
+        .respond_with(
+            ResponseTemplate::new(403).set_body_json(json!({"message": "quota exceeded"})),
+        )
+        .mount(&server)
+        .await;
+
+    let client = CxClient::new(server.uri(), "test-key").unwrap();
+    let err = client.get::<Value>("/test", &[]).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("quota exceeded"),
+        "expected server message in error, got: {msg}"
+    );
+    assert!(
+        !msg.contains("Check your API key's scopes"),
+        "scope hint should not be appended for quota errors, got: {msg}"
     );
 }
 


### PR DESCRIPTION
AIAP-1453

before: 

<img width="1017" height="69" alt="Screenshot 2026-06-02 at 14 34 41" src="https://github.com/user-attachments/assets/37924452-8417-4fa4-b4ea-1942d75e4e7d" />

after:

<img width="961" height="76" alt="Screenshot 2026-06-02 at 14 34 46" src="https://github.com/user-attachments/assets/e895192f-754c-44e3-8e62-78ba98c9b8e8" />

