### PR TITLE
AIAPP-1946 | redesign OAuth authentication success page

### DIFF
--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -184,10 +184,10 @@ fn wait_for_callback_blocking(listener: TcpListener, expected_state: String) -> 
 
 /// HTML returned to the browser after a successful OAuth login.
 ///
-/// Self-contained (no shipped or remote image assets): brand colours, an inline
-/// SVG checkmark, and Nunito Sans loaded from Google Fonts with a system-font
-/// fallback. Mirrors the Figma "Auth callback / Success" design (node 9428-15414),
-/// with two intentional omissions for this localhost flow:
+/// Fully self-contained — no remote resources. Avoids third-party network requests
+/// from the callback URL (which still holds the OAuth `code` and `state` params in
+/// the query string). Mirrors the Figma "Auth callback / Success" design
+/// (node 9428-15414), with two intentional omissions for this localhost flow:
 ///   - the reCAPTCHA footer (there is no reCAPTCHA on a local callback page), and
 ///   - a "Close tab" button: browsers block `window.close()` for tabs they did not
 ///     open, so — like `gh`, `gcloud`, etc. — we just tell the user to close the tab.
@@ -197,9 +197,6 @@ const SUCCESS_PAGE_HTML: &str = r##"<!DOCTYPE html>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>Authentication successful</title>
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:opsz,wght@6..12,400;6..12,500;6..12,700&display=swap" rel="stylesheet">
 <style>
   :root {
     --text-primary: #0e141d;
@@ -216,8 +213,7 @@ const SUCCESS_PAGE_HTML: &str = r##"<!DOCTYPE html>
     padding: 24px;
     background: linear-gradient(160deg, #edeff1 0%, #f7f8f9 45%, #ffffff 100%);
     color: var(--text-primary);
-    font-family: "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    font-optical-sizing: auto;
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
   }

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -182,6 +182,95 @@ fn wait_for_callback_blocking(listener: TcpListener, expected_state: String) -> 
     }
 }
 
+/// HTML returned to the browser after a successful OAuth login.
+///
+/// Self-contained (no shipped or remote image assets): brand colours, an inline
+/// SVG checkmark, and Nunito Sans loaded from Google Fonts with a system-font
+/// fallback. Mirrors the Figma "Auth callback / Success" design (node 9428-15414),
+/// with two intentional omissions for this localhost flow:
+///   - the reCAPTCHA footer (there is no reCAPTCHA on a local callback page), and
+///   - a "Close tab" button: browsers block `window.close()` for tabs they did not
+///     open, so — like `gh`, `gcloud`, etc. — we just tell the user to close the tab.
+const SUCCESS_PAGE_HTML: &str = r##"<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Authentication successful</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Nunito+Sans:opsz,wght@6..12,400;6..12,500;6..12,700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    --text-primary: #0e141d;
+    --text-secondary: #5e6164;
+    --green-badge: #02763a;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; margin: 0; }
+  body {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 24px;
+    background: linear-gradient(160deg, #edeff1 0%, #f7f8f9 45%, #ffffff 100%);
+    color: var(--text-primary);
+    font-family: "Nunito Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    font-optical-sizing: auto;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+  .card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    width: fit-content;
+    max-width: calc(100vw - 48px);
+    text-align: center;
+  }
+  .badge {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    margin-bottom: 8px;
+    border-radius: 50%;
+    background: var(--green-badge);
+  }
+  .badge svg { display: block; }
+  h1 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 700;
+    line-height: 1.5;
+    color: var(--text-primary);
+  }
+  .subtitle {
+    margin: 8px 0 0;
+    font-size: 14px;
+    font-weight: 500;
+    line-height: 1.5;
+    color: var(--text-secondary);
+    white-space: nowrap;
+  }
+  @media (max-width: 340px) { .subtitle { white-space: normal; } }
+</style>
+</head>
+<body>
+  <main class="card">
+    <div class="badge">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true" focusable="false">
+        <path d="M5 12.5L10 17.5L19.5 7" stroke="#ffffff" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+      </svg>
+    </div>
+    <h1>Authentication successful</h1>
+    <p class="subtitle">You are now connected to Coralogix.<br>You may close this tab and return to your application.</p>
+  </main>
+</body>
+</html>"##;
+
 /// Parse one HTTP connection and send an appropriate response.
 ///
 /// Returns `Ok(Some(code))` when a valid OAuth callback is received,
@@ -222,9 +311,7 @@ fn extract_and_respond(stream: TcpStream, expected_state: &str) -> Result<Option
         bail!("OAuth state mismatch – possible CSRF attempt, aborting.");
     }
 
-    let body = "<html><body><h2>Authentication successful!</h2>\
-                <p>You may close this tab and return to the terminal.</p></body></html>";
-    send_http_response(&stream, 200, body);
+    send_http_response(&stream, 200, SUCCESS_PAGE_HTML);
     Ok(Some(code))
 }
 


### PR DESCRIPTION
## Summary

- Replaces the bare `<html><body>` fallback string served after a successful OAuth login with a fully-styled, self-contained page that matches the Figma \"Auth callback / Success\" design ([node 9428-15414](https://www.figma.com/design/qkFbyWADay9Ua66dq5XJQz/MCP?node-id=9428-15414)).
- Brand colours (`#0e141d`, `#5e6164`, `#02763a`) and a subtle gradient background extracted from Figma design tokens.
- Inline SVG checkmark badge, Nunito Sans via Google Fonts (with full system-font fallback stack).
- Intentionally omits a "Close tab" button — browsers block `window.close()` for tabs opened by the OS (via `open::that()`), not by script. This matches the industry standard set by `gh`, `gcloud`, `aws sso`, etc.

## Screenshot

<img width="861" height="462" alt="image" src="https://github.com/user-attachments/assets/021b8c93-cb80-4a9b-8068-66ec4ab499f2" />

## Test plan

- [x] Run `cargo build` — no compile errors
- [x] Run `cargo clippy` — no new warnings
- [x] Run `cargo fmt -- --check` — code is formatted
- [x] Trigger `cx login` (or equivalent OAuth flow) and confirm the success page renders correctly in a browser
- [x] Verify the page renders with fallback system fonts when Google Fonts is unavailable (e.g. offline / ad-blocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)