### PR TITLE
Fix integration and notification endpoint paths

### DIFF
--- a/src/commands/contextual_data/api.rs
+++ b/src/commands/contextual_data/api.rs
@@ -128,12 +128,12 @@ impl<'a> ContextualDataApi<'a> {
     }
 
     pub async fn get_definition(&self, id: &str) -> Result<Value> {
-        let path = format!("{CONTEXTUAL_DATA_BASE}/{id}/definition");
+        let path = format!("{CONTEXTUAL_DATA_BASE}/definitions/{id}");
         self.client.get(&path, &[]).await
     }
 
     pub async fn test(&self, id: &str) -> Result<Value> {
-        let path = format!("{CONTEXTUAL_DATA_BASE}/{id}/test");
+        let path = format!("{CONTEXTUAL_DATA_BASE}/test/{id}");
         self.client.post(&path, &serde_json::json!({})).await
     }
 }

--- a/src/commands/extensions/api.rs
+++ b/src/commands/extensions/api.rs
@@ -63,7 +63,7 @@ impl<'a> ExtensionsApi<'a> {
     }
 
     pub async fn get(&self, id: &str) -> Result<Value> {
-        let path = format!("{EXTENSIONS_BASE}/{id}");
+        let path = format!("{EXTENSIONS_BASE}/catalog/{id}");
         self.client.get(&path, &[]).await
     }
 

--- a/src/commands/notification_testing/api.rs
+++ b/src/commands/notification_testing/api.rs
@@ -28,27 +28,27 @@ impl<'a> NotificationTestingApi<'a> {
     }
 
     pub async fn test_connector(&self, body: &Value) -> Result<Value> {
-        let path = format!("{NOTIFICATION_TEST_BASE}/connectors/tests/config");
+        let path = format!("{NOTIFICATION_TEST_BASE}/connectors:testConfig");
         self.client.post(&path, body).await
     }
 
     pub async fn test_destination(&self, body: &Value) -> Result<Value> {
-        let path = format!("{NOTIFICATION_TEST_BASE}/destinations/tests");
+        let path = format!("{NOTIFICATION_TEST_BASE}/destinations:test");
         self.client.post(&path, body).await
     }
 
     pub async fn test_preset(&self, body: &Value) -> Result<Value> {
-        let path = format!("{NOTIFICATION_TEST_BASE}/presets/tests/config");
+        let path = format!("{NOTIFICATION_TEST_BASE}/presets:testConfig");
         self.client.post(&path, body).await
     }
 
     pub async fn test_routing_condition(&self, body: &Value) -> Result<Value> {
-        let path = format!("{NOTIFICATION_TEST_BASE}/routing-conditions/tests");
+        let path = format!("{NOTIFICATION_TEST_BASE}/routers:testCondition");
         self.client.post(&path, body).await
     }
 
     pub async fn test_template_render(&self, body: &Value) -> Result<Value> {
-        let path = format!("{NOTIFICATION_TEST_BASE}/template-render/tests");
+        let path = format!("{NOTIFICATION_TEST_BASE}/templates:test");
         self.client.post(&path, body).await
     }
 }

--- a/tests/notification_testing/main.rs
+++ b/tests/notification_testing/main.rs
@@ -14,7 +14,7 @@ async fn test_connector_from_mock() {
 
     Mock::given(method("POST"))
         .and(path(
-            "/mgmt/openapi/5/notifications/notification-center/v1/connectors/tests/config",
+            "/mgmt/openapi/5/notifications/notification-center/v1/connectors:testConfig",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({"success": true})))
         .expect(1)


### PR DESCRIPTION
## Context
AIAPP-1842 updates CLI clients to call the current Coralogix OpenAPI v5 endpoint shapes for integrations extensions, contextual data definitions/tests, and notification testing actions. The previous path layout caused affected `cx` commands to hit stale URLs.

## Linked Issues
AIAPP-1842

## Design
The change stays inside the command API client layer: each affected command continues to flow through its existing `run_*` command handler, builds the same request bodies, and uses the shared HTTP client as before. Only the path strings produced by `ContextualDataApi`, `ExtensionsApi`, and `NotificationTestingApi` are changed so the same command paths reach the updated backend routes.

## Key Decisions
The implementation avoids changing command flags, request payloads, response parsing, or shared HTTP behavior because the contract mismatch is isolated to route construction. Notification testing uses the backend's action-style route names such as `connectors:testConfig` and `templates:test`, while extensions and contextual data keep resource-style paths where the API now expects `catalog/{id}`, `definitions/{id}`, and `test/{id}`.

## Changes
- Updates contextual data definition and test requests to use `/definitions/{id}` and `/test/{id}`.
- Updates extension get requests to use `/catalog/{id}`.
- Updates notification testing requests for connectors, destinations, presets, routing conditions, and template rendering to the current action-style endpoints.
- Updates the notification testing mock test expectation for the connector test endpoint.

## Testing
- `cargo test --test notification_testing --test contextual_data --test extensions` passed outside the sandbox so WireMock could bind local mock-server ports.

## Risks & Rollout
Low risk and limited to the affected CLI commands. The main compatibility risk is if any environment still serves the old endpoint paths; rollback is to revert this branch and restore the previous route strings.

## Out of Scope / Follow-ups
This PR does not add mock coverage for every notification testing action path; it only updates the existing connector-path assertion that failed after the endpoint correction.
