### PR TITLE
bump version to 0.1.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "coralogix-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-cli"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Coralogix CLI - the observability backbone for AI agents and engineering teams."
 repository = "https://github.com/coralogix/cx-cli"


### PR DESCRIPTION
## Summary
- Bumps `Cargo.toml` version from `0.1.8` to `0.1.9`
- Updates `Cargo.lock` to reflect the new version

## Test plan
- [ ] `cargo fmt --check` passes (verified locally)
- [ ] CI build passes on the PR

Closes AIAPP-1997

🤖 Generated with [Claude Code](https://claude.com/claude-code)