### PR TITLE
ci(sync): trigger docs sync on skills/ changes

### DIFF
--- a/.github/workflows/trigger-docs-sync.yml
+++ b/.github/workflows/trigger-docs-sync.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'README.md'
       - 'docs/*.md'
+      - 'skills/**'
 
 jobs:
   trigger_action:


### PR DESCRIPTION
## What

Adds `skills/**` to the `trigger-docs-sync.yml` path filter.

## Why

`skills/README.md` is mirrored into the Coralogix docs site via `external_repos.json`, but the dispatch trigger only watched `README.md` and `docs/*.md`. So edits under `skills/` never fired a docs deploy — the **2026-06-09 `skills/README.md` change never synced** to the docs portal.

This closes that coverage gap so any `skills/` change publishes immediately, like the other synced paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)