### PR TITLE
fix(integrations): parse real response shape in cx integrations list

### DIFF
--- a/src/commands/integrations/api.rs
+++ b/src/commands/integrations/api.rs
@@ -14,10 +14,14 @@ pub struct Integration {
     #[serde(default, deserialize_with = "string_or_number")]
     pub id: Option<String>,
     pub name: Option<String>,
-    #[serde(rename = "type")]
-    pub integration_type: Option<String>,
-    pub status: Option<String>,
-    pub version: Option<u32>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    #[serde(default)]
+    pub versions: Vec<String>,
+    // `integrationType` is a oneof object whose single key is the type
+    // (e.g. `cloudformation`, `arm`, `managed`, `untracked`).
+    pub integration_type: Option<Value>,
 }
 
 impl Integration {
@@ -26,19 +30,32 @@ impl Integration {
     }
 
     pub fn display_type(&self) -> &str {
-        self.integration_type.as_deref().unwrap_or("-")
+        self.integration_type
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .and_then(|m| m.keys().next())
+            .map(String::as_str)
+            .unwrap_or("-")
     }
 
-    pub fn display_status(&self) -> &str {
-        self.status.as_deref().unwrap_or("-")
+    pub fn display_version(&self) -> &str {
+        self.versions.last().map(String::as_str).unwrap_or("-")
     }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IntegrationEntry {
+    pub integration: Integration,
+    #[serde(default)]
+    pub errors: Vec<Value>,
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListIntegrationsResponse {
     #[serde(default)]
-    pub deployments: Vec<Integration>,
+    pub integrations: Vec<IntegrationEntry>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -117,28 +134,35 @@ mod tests {
     #[test]
     fn deserialize_list_response() {
         let json = json!({
-            "deployments": [
+            "integrations": [
                 {
-                    "id": "int-001",
-                    "name": "AWS Integration",
-                    "type": "aws",
-                    "status": "active",
-                    "version": 1
+                    "integration": {
+                        "id": "aws-sns-shipper",
+                        "name": "AWS SNS",
+                        "description": "Ship logs via SNS",
+                        "tags": ["AWS", "Logs"],
+                        "versions": ["0.0.1", "0.0.40"],
+                        "integrationType": { "cloudformation": {} }
+                    },
+                    "errors": []
                 }
             ]
         });
         let resp: ListIntegrationsResponse = serde_json::from_value(json).unwrap();
-        assert_eq!(resp.deployments.len(), 1);
-        assert_eq!(resp.deployments[0].display_name(), "AWS Integration");
-        assert_eq!(resp.deployments[0].display_type(), "aws");
-        assert_eq!(resp.deployments[0].display_status(), "active");
+        assert_eq!(resp.integrations.len(), 1);
+        let i = &resp.integrations[0].integration;
+        assert_eq!(i.id.as_deref(), Some("aws-sns-shipper"));
+        assert_eq!(i.display_name(), "AWS SNS");
+        assert_eq!(i.display_type(), "cloudformation");
+        assert_eq!(i.display_version(), "0.0.40");
+        assert_eq!(i.tags, vec!["AWS", "Logs"]);
     }
 
     #[test]
     fn deserialize_empty_list() {
-        let json = json!({ "deployments": [] });
+        let json = json!({ "integrations": [] });
         let resp: ListIntegrationsResponse = serde_json::from_value(json).unwrap();
-        assert!(resp.deployments.is_empty());
+        assert!(resp.integrations.is_empty());
     }
 
     #[test]
@@ -153,12 +177,13 @@ mod tests {
         let i = Integration {
             id: None,
             name: None,
+            description: None,
+            tags: vec![],
+            versions: vec![],
             integration_type: None,
-            status: None,
-            version: None,
         };
         assert_eq!(i.display_name(), "-");
         assert_eq!(i.display_type(), "-");
-        assert_eq!(i.display_status(), "-");
+        assert_eq!(i.display_version(), "-");
     }
 }

--- a/src/commands/integrations/mod.rs
+++ b/src/commands/integrations/mod.rs
@@ -17,8 +17,8 @@ fn rg_to_json(integration: &Integration, include_profile: bool, profile: &str) -
         "id": integration.id,
         "name": integration.name,
         "type": integration.display_type(),
-        "status": integration.display_status(),
-        "version": integration.version.map(|v| v.to_string()).unwrap_or_default(),
+        "version": integration.display_version(),
+        "tags": integration.tags,
     });
     if include_profile {
         if let Value::Object(ref mut m) = v {
@@ -63,7 +63,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
-                for integration in resp.deployments {
+                for entry in resp.integrations {
+                    let integration = entry.integration;
                     all_json.push(rg_to_json(&integration, include_profile, &profile));
                     all_items.push((profile.clone(), integration));
                 }
@@ -92,16 +93,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                         integration.id.clone().unwrap_or_default(),
                         integration.name.clone().unwrap_or_default(),
                         integration.display_type().to_string(),
-                        integration.display_status().to_string(),
-                        integration
-                            .version
-                            .map(|v| v.to_string())
-                            .unwrap_or_default(),
+                        integration.display_version().to_string(),
+                        integration.tags.join(", "),
                     ]
                 })
                 .collect();
             render::render_table(
-                &["ID", "Name", "Type", "Status", "Version"],
+                &["ID", "Name", "Type", "Version", "Tags"],
                 rows,
                 include_profile,
             );

--- a/tests/integrations/main.rs
+++ b/tests/integrations/main.rs
@@ -13,8 +13,17 @@ async fn list_integrations_from_mock() {
     let server = MockServer::start().await;
 
     let body = json!({
-        "deployments": [
-            { "id": "int-001", "name": "AWS Integration", "type": "aws", "status": "active", "version": 1 }
+        "integrations": [
+            {
+                "integration": {
+                    "id": "aws-sns-shipper",
+                    "name": "AWS SNS",
+                    "tags": ["AWS", "Logs"],
+                    "versions": ["0.0.40"],
+                    "integrationType": { "cloudformation": {} }
+                },
+                "errors": []
+            }
         ]
     });
 
@@ -37,7 +46,7 @@ async fn list_integrations_empty() {
 
     Mock::given(method("GET"))
         .and(path("/mgmt/openapi/5/integrations/integrations/v1"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "deployments": [] })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "integrations": [] })))
         .expect(1)
         .mount(&server)
         .await;


### PR DESCRIPTION
## Summary

`cx integrations list` returned an empty result even when the account had integrations and a direct API call returned them.

**Root cause:** the list handler deserialized the response into a struct expecting a top-level `deployments[]` array of flat `{id, name, type, status, version}` objects. The real `/mgmt/openapi/5/integrations/integrations/v1` endpoint returns the list under `integrations[]`, with each item nested one level deeper under an `integration` key and a different shape:

```json
{ "integrations": [ { "integration": { "id", "name", "tags", "versions": ["0.0.40"], "integrationType": {"managed":{}} }, "errors": [] } ] }
```

Because the expected field was annotated `#[serde(default)]`, the total shape mismatch deserialized to an **empty Vec with no error** — so the command silently showed nothing while the API returned data. The struct was originally written against assumed field names with a mock that mirrored those assumptions, so tests passed without ever matching the real API.

## Behavior change

- `cx integrations list` now returns the integrations the API actually returns (verified end-to-end: 64 items in eu2 vs. previously empty).
- Output schema per row changed from `{id, name, type, status, version}` to `{id, name, type, version, tags}`:
  - `type` is derived from the `integrationType` oneof key (`cloudformation` / `arm` / `managed` / `untracked`).
  - `version` is the latest entry of the `versions[]` array (string, previously a `u32`).
  - `status` is dropped (not present in the API response); `tags` is added.
- Text table columns are now: ID, Name, Type, Version, Tags.

## Notes

- `?onlyDeployed=true` is silently ignored by the backend (still returns the full set), and `/integrations/v1` is the only listing endpoint — it returns the integration definitions/catalog, which is what a direct API call surfaces.
- The create/`SaveIntegrationResponse` (POST) shape was left untouched — it could not be verified without creating a real integration. Worth confirming separately if `cx integrations create` is in use.

## Test plan

- [x] `cargo build`, `cargo clippy`, `cargo fmt`
- [x] `cargo test integrations` (unit + wiremock) updated to the real payload shape
- [x] Manual: `cx integrations list -o text` / `-o json` against eu2 returns 64 integrations