### PR TITLE
Deepen E2M coverage in cx-data-pipeline skill

### DIFF
--- a/skills/cx-data-pipeline/SKILL.md
+++ b/skills/cx-data-pipeline/SKILL.md
@@ -192,7 +192,7 @@ The axis is **tier / processing level — NOT "Frequent Search vs archive"** (Me
 
 ### 1. Design the metric
 
-Choose `logs2metrics` vs `spans2metrics`, the source field(s) + aggregations, and labels (with cardinality in mind — see `references/e2m-schemas.md`). **Datasets are UI-only:** the API/CLI supports logs and spans only; for a dataset-source E2M, direct the user to the UI for now.
+Choose `logs2metrics` vs `spans2metrics`, the source field(s) + aggregations, and labels (with cardinality in mind — see `references/e2m-schemas.md`). To scope the E2M to a **dataset**, set the optional `dataSource` field to `"<dataspace>/<dataset>"` (supported via the API/CLI); omit it for the standard logs/spans stream.
 
 ### 2. Size it: check limits & cardinality
 

--- a/skills/cx-data-pipeline/SKILL.md
+++ b/skills/cx-data-pipeline/SKILL.md
@@ -192,16 +192,16 @@ The axis is **tier / processing level — NOT "Frequent Search vs archive"** (Me
 
 ### 1. Design the metric
 
-Choose `logs2metrics` vs `spans2metrics`, the source field(s) + aggregations, and labels (with cardinality in mind — see `references/e2m-schemas.md`). To scope the E2M to a **dataset**, set the optional `dataSource` field to `"<dataspace>/<dataset>"` (supported via the API/CLI); omit it for the standard logs/spans stream.
+Choose `logs2metrics` vs `spans2metrics`, the source field(s) + aggregations, and labels (with cardinality in mind — see `references/e2m-schemas.md`). To scope the E2M to a **dataset**, set the optional `dataSource` field to `"<dataspace>/<dataset>"`; this requires the account feature `e2m_dataset_source_enabled` (otherwise the API rejects it with "dataSource is not enabled for this company"). Omit it for the standard logs/spans stream.
 
 ### 2. Size it: check limits & cardinality
 
 ```bash
 cx e2m limits -o json              # account E2M count limit + used
-cx e2m labels-cardinality -o json  # current label cardinality (existing E2Ms)
+cx e2m labels-cardinality -o json  # see caveat below
 ```
 
-`cx e2m labels-cardinality` reports **existing** cardinality — it is **not** a forecast from a draft. Estimate permutations for a new E2M manually (product of distinct label values) and set `permutationsLimit` accordingly. Never use high-cardinality fields (IDs, raw URLs, IPs) as labels.
+The labels-cardinality endpoint is a **draft forecast** — given proposed labels + query it returns the per-day distinct-permutation count over the last 7 days, so you can size a design before creating it. **But `cx e2m labels-cardinality` currently takes no arguments**, so it sends no draft and returns an empty list (a CLI gap — it can't forecast yet). Until that's wired up, forecast via the UI or estimate permutations manually (product of distinct label values) and set `permutationsLimit`. Never use high-cardinality fields (IDs, raw URLs, IPs) as labels. Note the forecast only sees Frequent-Search (High-tier) data.
 
 ### 3. Template from an existing definition
 
@@ -229,7 +229,7 @@ cx metrics query "<target_metric_name>" --time now
 ### Troubleshooting: E2M produces no metric series
 
 1. **Check the source data's TCO tier** — if it's routed to **Low/compliance** (or blocked), E2M cannot run. Fix with a TCO change (`cx tco list` / `cx-cost-optimization`), **not** an E2M change.
-2. **Verify the query matches streaming data** — run the E2M's `lucene` filter as a live `cx logs`/`cx spans` query and confirm it returns recent results.
+2. **Verify the query matches streaming data** — run the E2M's `lucene` filter as a live `cx logs`/`cx spans` query and confirm it returns recent results. Note `cx logs` queries Frequent-Search (High-tier) by default; for a **Medium-tier (archive)** source add `--tier archive`, since the data won't appear in a default Frequent-Search query even though E2M still produces series.
 3. **Remember it's forward-only** — no series exist for data ingested before the E2M was created.
 
 ### Cost optimization: convert High-tier logs to metrics

--- a/skills/cx-data-pipeline/SKILL.md
+++ b/skills/cx-data-pipeline/SKILL.md
@@ -10,6 +10,8 @@ description: >
   "configure data pipeline", "transform log data", "data processing rules",
   "rule group", "enrichment settings", "E2M definition", "labels cardinality",
   "bulk delete rules", "enrichment limits", "search enrichment table",
+  "what should I convert to metrics", "E2M not producing metrics", "E2M no series",
+  "reduce log cost with E2M", "logs to metrics aggregation", "spans to metrics",
   or wants to configure how Coralogix processes, enriches, or transforms ingested data.
 metadata:
   version: "0.1.0"
@@ -171,37 +173,73 @@ cx logs 'source logs | filter $d.enriched_field != null | limit 5' -o json
 
 ## Events2Metrics Workflow
 
-### 1. Design the Metric
+E2M derives Prometheus metrics from log/span events. See **[`references/e2m-schemas.md`](references/e2m-schemas.md)** for the full JSON wire format, enums, and cardinality rules.
 
-Decide the metric name, labels, and aggregation type before creating.
+### How E2M is computed (read this first)
 
-### 2. Check Limits
+E2M aggregates events **as they stream through the real-time ingestion pipeline** into metric series (~1-min resolution). It is **forward-only** — metrics start from the moment the E2M is created; there is **no backfill**.
 
-```bash
-cx e2m limits -o json
-cx e2m labels-cardinality -o json
-```
+All ingested data flows through the pipeline; a **TCO policy** routes each stream into a tier, and the tier decides what's possible:
 
-### 3. Get a Template
+| TCO tier | Storage | E2M / alerts / dashboards |
+|---|---|---|
+| **High** | Frequent Search (hot, OpenSearch) | ✅ available |
+| **Medium** | S3 archive (not hot storage) | ✅ available — still processed by the pipeline |
+| **Low** | Compliance only | ❌ no aggregation features |
+| **Blocked** | dropped | ❌ |
 
-```bash
-cx e2m list -o json
-cx e2m get <existing-e2m-id> -o json > e2m-template.json
-```
+The axis is **tier / processing level — NOT "Frequent Search vs archive"** (Medium *is* archive and E2M works on it). Do not tell users to "point E2M at archive instead of Frequent Search" — that is incorrect.
 
-### 4. Create E2M Definition
+### 1. Design the metric
 
-```bash
-cx e2m create --from-file e2m-definition.json
-```
+Choose `logs2metrics` vs `spans2metrics`, the source field(s) + aggregations, and labels (with cardinality in mind — see `references/e2m-schemas.md`). **Datasets are UI-only:** the API/CLI supports logs and spans only; for a dataset-source E2M, direct the user to the UI for now.
 
-### 5. Verify Metric
-
-Confirm the new metric appears (load `cx-telemetry-querying` for metrics querying):
+### 2. Size it: check limits & cardinality
 
 ```bash
-cx metrics search --name "new_metric_name"
+cx e2m limits -o json              # account E2M count limit + used
+cx e2m labels-cardinality -o json  # current label cardinality (existing E2Ms)
 ```
+
+`cx e2m labels-cardinality` reports **existing** cardinality — it is **not** a forecast from a draft. Estimate permutations for a new E2M manually (product of distinct label values) and set `permutationsLimit` accordingly. Never use high-cardinality fields (IDs, raw URLs, IPs) as labels.
+
+### 3. Template from an existing definition
+
+Only `cx e2m get` returns the full payload (`{"e2m": {...}}`); `list` prints a summary. Extract `.e2m` and drop read-only fields:
+
+```bash
+cx e2m get <existing-e2m-id> -o json | jq '.e2m | del(.id, .permutations, .createTime, .updateTime, .metricName)' > e2m.json
+```
+
+### 4. Create the E2M
+
+```bash
+cx e2m create --from-file e2m.json
+```
+
+### 5. Verify the metric
+
+Confirm series are being produced (load `cx-telemetry-querying` for metrics querying):
+
+```bash
+cx metrics search --name "<targetBaseMetricName>"
+cx metrics query "<target_metric_name>" --time now
+```
+
+### Troubleshooting: E2M produces no metric series
+
+1. **Check the source data's TCO tier** — if it's routed to **Low/compliance** (or blocked), E2M cannot run. Fix with a TCO change (`cx tco list` / `cx-cost-optimization`), **not** an E2M change.
+2. **Verify the query matches streaming data** — run the E2M's `lucene` filter as a live `cx logs`/`cx spans` query and confirm it returns recent results.
+3. **Remember it's forward-only** — no series exist for data ingested before the E2M was created.
+
+### Cost optimization: convert High-tier logs to metrics
+
+When the **aggregated/metric view is what the customer most cares about**, convert **High-tier logs → metrics**, then downgrade the raw logs **High → Medium**. Medium still supports E2M/alerts/dashboards and costs less (S3 archive, no hot storage) — you keep cheap, detailed metrics while dropping expensive Frequent-Search retention.
+
+1. Find high-volume High-tier sources: `cx usage summary` / `cx tco list` (see `cx-cost-optimization`).
+2. Confirm which fields drive dashboards/alerts (see `cx-telemetry-querying`).
+3. Build + **verify the E2M first** (steps above).
+4. **Then** change the TCO policy to move the raw logs High → Medium. Keep data on High or Medium (both support E2M); do **not** drop it to Low/compliance if metrics or alerts are still needed.
 
 ---
 
@@ -246,6 +284,15 @@ cx metrics query "new_precomputed_metric" --time now
 
 ---
 
+## Additional Resources
+
+### Reference Files
+
+- **[`references/e2m-schemas.md`](references/e2m-schemas.md)** - Complete Events2Metrics JSON wire format: `type`/`aggType` enum values, `logsQuery`/`spansQuery` filters, metric labels & fields, the TCO-tier compute model, cardinality/permutations sizing, and gotchas
+
+---
+
 ## Related Skills
 
-- **`cx-telemetry-querying`** - discover what data is available before configuring pipeline, and verify parsing results and enriched fields via log/metrics queries
+- **`cx-telemetry-querying`** - discover what data is available before configuring pipeline, and verify parsing results, enriched fields, and E2M metric series via log/metrics queries
+- **`cx-cost-optimization`** - find high-volume High-tier sources worth converting to metrics, and move the raw logs High→Medium (TCO) after the E2M is verified

--- a/skills/cx-data-pipeline/references/e2m-schemas.md
+++ b/skills/cx-data-pipeline/references/e2m-schemas.md
@@ -28,7 +28,9 @@ The `type` field + `query` oneof select what events are aggregated:
 
 `E2M_TYPE_UNSPECIFIED` (0) is never used in a real definition.
 
-**Datasets (`dataSource`):** an optional top-level `dataSource` string in `"<dataspace>/<dataset>"` format (e.g. `"my_dataspace/my_dataset"`) scopes the E2M to a specific dataset instead of the standard logs/spans stream. It is **supported via the API/CLI** — add it to the create body. If omitted, the E2M defaults to the standard logs/spans stream for the chosen `type`.
+**Datasets (`dataSource`):** an optional top-level `dataSource` string in `"<dataspace>/<dataset>"` format (e.g. `"my_dataspace/my_dataset"`) scopes the E2M to a specific dataset instead of the standard logs/spans stream. It is supported via the API/CLI — add it to the create body. If omitted, the E2M defaults to the standard logs/spans stream for the chosen `type`.
+
+> **Requires an account feature flag.** `dataSource` is gated behind `e2m_dataset_source_enabled` per company. If the feature isn't enabled, the API rejects the definition with `"dataSource is not enabled for this company"`. If you hit that error, the account needs the feature turned on — it's not a payload problem.
 
 ```json
 { "type": "E2M_TYPE_LOGS2METRICS", "dataSource": "my_dataspace/my_dataset", "logsQuery": { ... } }
@@ -177,17 +179,19 @@ Each aggregation: `enabled` (bool), `aggType` (string enum), `targetMetricName` 
 - Keep labels to bounded, low-cardinality dimensions (app, subsystem, region, status class, severity, endpoint *group*).
 - `permutationsLimit` caps the design; if exceeded, the read-back `permutations.hasExceededLimit` is `true` and new permutations stop being produced.
 
-**Checking limits and cardinality:**
+**Checking limits and forecasting cardinality:**
 
 ```bash
 cx e2m limits -o json              # account E2M count limit + used
-cx e2m labels-cardinality -o json  # current label cardinality data (existing E2Ms)
+cx e2m labels-cardinality -o json  # see caveat below
 ```
 
 - `cx e2m limits` reports the E2M **count** limit and how many are used (the underlying API also tracks labels/permutations/metrics caps).
-- `cx e2m labels-cardinality` reports **existing** label cardinality — it is **not** a pre-create forecast from a draft. To size a new E2M, estimate permutations manually (product of distinct label values) and set `permutationsLimit` accordingly.
+- **The labels-cardinality endpoint is a draft forecast tool.** Given a proposed query + `metricLabels`, the backend runs a cardinality aggregation over the **last 7 days** of the company's logs/spans and returns the distinct label-permutation count **per day** for exactly that draft design — so you can size a design *before* creating it. With no labels supplied it returns an empty result.
+- **CLI limitation:** `cx e2m labels-cardinality` currently takes **no arguments**, so it sends no draft and returns an **empty list** — it does not expose the forecast yet (it would need `--metric-labels`/`--query`). Until then, forecast a draft via the **Coralogix UI** (the create flow calls this endpoint with your labels+query), or estimate manually (below) as a rough check.
+- **The forecast only sees Frequent-Search (High-tier) data** — it queries the hot `*_newlogs*` index. For a Medium-tier (archive) source it will undercount, so treat manual estimates as the floor.
 
-**Worked example — sizing a 2-label design:**
+**Manual estimate (rough fallback) — sizing a 2-label design:**
 - Labels: `app` (~12 distinct), `severity` (6 distinct).
 - Estimated permutations = 12 × 6 = **72** — comfortably under any limit.
 - Adding `endpoint` (~300 distinct) → 12 × 6 × 300 = **21,600**. Closer to limits; prefer grouping endpoints into a bounded `route` field, or drop the label and filter in `lucene` instead.

--- a/skills/cx-data-pipeline/references/e2m-schemas.md
+++ b/skills/cx-data-pipeline/references/e2m-schemas.md
@@ -19,27 +19,40 @@ If an E2M produces **zero metric series**, the usual cause is that its source da
 
 ## Source types
 
-The API/CLI supports two source types via the `query` oneof:
+The `type` field + `query` oneof select what events are aggregated:
 
 | `type` (string enum) | `query` field | Source |
 |---|---|---|
 | `E2M_TYPE_LOGS2METRICS` | `logsQuery` | Logs |
 | `E2M_TYPE_SPANS2METRICS` | `spansQuery` | Spans |
 
-> **Datasets are UI-only.** The Coralogix UI additionally lets you create an E2M on a **Dataset** (datasource selection), but the v2 API/CLI exposes **logs and spans only** (dataset support is coming to the API). For a dataset-based E2M, use the UI for now.
-
 `E2M_TYPE_UNSPECIFIED` (0) is never used in a real definition.
+
+**Datasets (`dataSource`):** an optional top-level `dataSource` string in `"<dataspace>/<dataset>"` format (e.g. `"my_dataspace/my_dataset"`) scopes the E2M to a specific dataset instead of the standard logs/spans stream. It is **supported via the API/CLI** — add it to the create body. If omitted, the E2M defaults to the standard logs/spans stream for the chosen `type`.
+
+```json
+{ "type": "E2M_TYPE_LOGS2METRICS", "dataSource": "my_dataspace/my_dataset", "logsQuery": { ... } }
+```
 
 ---
 
 ## Top-level structure
 
-`cx e2m create` posts the **bare definition object** (the HTTP body maps to the `e2m` field). A `cx e2m get` *response* wraps the same object as `{"e2m": { ... }}`, so when templating, extract `.e2m` and drop the read-only fields:
+`cx e2m create` and `cx e2m update` post the **bare definition object** (the HTTP body maps to the `e2m` field). A `cx e2m get` *response* wraps the same object as `{"e2m": { ... }}`, so when templating, extract `.e2m`.
+
+**Creating a new E2M** — drop `id` (and other read-only fields); the server assigns a fresh id:
 
 ```bash
 cx e2m get <id> -o json | jq '.e2m | del(.id, .permutations, .createTime, .updateTime, .metricName)' > e2m.json
-# edit e2m.json, then:
 cx e2m create --from-file e2m.json
+```
+
+**Updating an existing E2M** — `cx e2m update` is a PUT with **no id in the path**, so the body **must keep `id`** (it's the only identifier the API uses). Drop only the server-derived fields:
+
+```bash
+cx e2m get <id> -o json | jq '.e2m | del(.permutations, .createTime, .updateTime, .metricName)' > e2m.json
+# edit e2m.json (keep "id"), then:
+cx e2m update --from-file e2m.json
 ```
 
 ### Create payload (`E2MCreateParams`)
@@ -82,11 +95,14 @@ cx e2m create --from-file e2m.json
 | `description` | string | Optional. |
 | `permutationsLimit` | int | Create-only. Caps the label permutation cardinality (e.g. `30000`). |
 | `type` | enum string | `E2M_TYPE_LOGS2METRICS` or `E2M_TYPE_SPANS2METRICS`. Required. |
+| `dataSource` | string | Optional. `"<dataspace>/<dataset>"` to scope to a dataset; omit for the standard logs/spans stream. |
 | `logsQuery` / `spansQuery` | object | The `query` oneof — exactly one, matching `type`. |
 | `metricLabels[]` | array | Each label becomes a Prometheus label. **Each distinct value set multiplies permutations.** |
 | `metricFields[]` | array | **Max 10.** Each holds a source field + its aggregations. |
 
-**Read-only fields** (present in `get` responses, omit from create/update bodies): `id` (UUID — *required* on `update`/replace), `permutations` (`{limit, hasExceededLimit}`), `createTime`, `updateTime`, `metricName`, `isInternal`.
+**`id`** — UUID. **Omit on `create`** (server assigns it); **required in the body on `update`** (the PUT has no path id). Present in `get` responses.
+
+**Server-derived fields** (present in `get` responses; drop from create/update bodies): `permutations` (`{limit, hasExceededLimit}`), `createTime`, `updateTime`, `metricName`, `isInternal`.
 
 ### `logsQuery`
 
@@ -182,8 +198,9 @@ cx e2m labels-cardinality -o json  # current label cardinality data (existing E2
 
 - **Enums are strings, not integers.** Use `"type": "E2M_TYPE_LOGS2METRICS"` and `"aggType": "AGG_TYPE_AVG"` — not `1` / `4`. (Some internal/legacy exports use integers and a `$case` discriminator; the `cx` CLI uses the OpenAPI string form.)
 - **Template from `get`, not `list`.** `cx e2m list` / `create` print a simplified summary; only `cx e2m get <id> -o json` returns the full definition (`{"e2m": {...}}`).
-- **Create body is the bare object**, not wrapped in `{"e2m": ...}`. Extract `.e2m` from a `get` response before creating.
-- **`update` (replace) requires `id`** in the body; `create` must omit it.
+- **Create/update body is the bare object**, not wrapped in `{"e2m": ...}`. Extract `.e2m` from a `get` response first.
+- **`update` (replace) requires `id` in the body** — the PUT has no path id, so dropping `id` makes the update fail to find the rule. `create` must omit `id`.
+- **Simple aggregations (MIN/MAX/COUNT/AVG/SUM) need no `agg_metadata`** — only `histogram` and `samples` carry metadata. (The proto models the empty case as a `none` marker; in JSON, just omit the metadata.)
 - **Max 10 metric fields** per E2M.
 - **`targetMetricName` must be unique** within the definition; collisions silently clobber series.
 - **Forward-only.** Creating an E2M never backfills historical data — only events ingested after creation produce series.

--- a/skills/cx-data-pipeline/references/e2m-schemas.md
+++ b/skills/cx-data-pipeline/references/e2m-schemas.md
@@ -1,0 +1,190 @@
+# Events2Metrics (E2M) Schema Reference
+
+Complete JSON schema reference for Coralogix Events2Metrics definitions, using the **actual REST API wire format** that `cx e2m` reads and writes. Use this when constructing payloads for `cx e2m create` / `cx e2m update`.
+
+> **Tip:** The most reliable way to build an E2M is to fetch an existing one with `cx e2m get <id> -o json`, strip the read-only fields, modify, and pipe it into `cx e2m create --from-file -`. Note that `cx e2m list` and `cx e2m create` print a *simplified* view (id/name/type/metric_name) — **only `cx e2m get` returns the full definition** you can template from.
+
+## How E2M is computed (read this first)
+
+E2M is **not** a stored query — it aggregates events **as they stream through the real-time ingestion pipeline** into metric series (~1-minute resolution). It is **forward-only**: metrics start accumulating from the moment the E2M is created; there is no backfill.
+
+- All ingested data flows through the ingestion pipeline; a **TCO policy** routes each stream into a tier.
+- E2M works on data in **High tier** (Frequent Search / hot storage) **and Medium tier** (lands in S3 archive, but still processed by the pipeline).
+- E2M does **NOT** work on **Low / compliance tier** (compliance storage only, no aggregation features) or blocked data.
+- The axis is **tier / processing level — not "Frequent Search vs archive"** (Medium *is* archive and E2M works on it).
+
+If an E2M produces **zero metric series**, the usual cause is that its source data is routed to Low/compliance (or the query matches nothing) — the fix is a TCO change, not an E2M change. See the SKILL workflow's troubleshooting section.
+
+---
+
+## Source types
+
+The API/CLI supports two source types via the `query` oneof:
+
+| `type` (string enum) | `query` field | Source |
+|---|---|---|
+| `E2M_TYPE_LOGS2METRICS` | `logsQuery` | Logs |
+| `E2M_TYPE_SPANS2METRICS` | `spansQuery` | Spans |
+
+> **Datasets are UI-only.** The Coralogix UI additionally lets you create an E2M on a **Dataset** (datasource selection), but the v2 API/CLI exposes **logs and spans only** (dataset support is coming to the API). For a dataset-based E2M, use the UI for now.
+
+`E2M_TYPE_UNSPECIFIED` (0) is never used in a real definition.
+
+---
+
+## Top-level structure
+
+`cx e2m create` posts the **bare definition object** (the HTTP body maps to the `e2m` field). A `cx e2m get` *response* wraps the same object as `{"e2m": { ... }}`, so when templating, extract `.e2m` and drop the read-only fields:
+
+```bash
+cx e2m get <id> -o json | jq '.e2m | del(.id, .permutations, .createTime, .updateTime, .metricName)' > e2m.json
+# edit e2m.json, then:
+cx e2m create --from-file e2m.json
+```
+
+### Create payload (`E2MCreateParams`)
+
+```json
+{
+  "name": "service_catalog_latency",
+  "description": "avg + sum latency for catalog service",
+  "permutationsLimit": 30000,
+  "type": "E2M_TYPE_LOGS2METRICS",
+  "logsQuery": {
+    "lucene": "coralogix.metadata.applicationName:catalog",
+    "applicationnameFilters": [],
+    "subsystemnameFilters": [],
+    "severityFilters": ["SEVERITY_ERROR", "SEVERITY_CRITICAL"]
+  },
+  "metricLabels": [
+    { "targetLabel": "app",       "sourceField": "coralogix.metadata.applicationName" },
+    { "targetLabel": "subsystem", "sourceField": "coralogix.metadata.subsystemName" }
+  ],
+  "metricFields": [
+    {
+      "targetBaseMetricName": "latency_ms",
+      "sourceField": "log_obj.latency_ms",
+      "aggregations": [
+        { "enabled": true, "aggType": "AGG_TYPE_COUNT", "targetMetricName": "latency_ms_count" },
+        { "enabled": true, "aggType": "AGG_TYPE_AVG",   "targetMetricName": "latency_ms_avg" },
+        { "enabled": true, "aggType": "AGG_TYPE_SUM",   "targetMetricName": "latency_ms_sum" }
+      ]
+    }
+  ]
+}
+```
+
+### Field reference
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | **Required.** |
+| `description` | string | Optional. |
+| `permutationsLimit` | int | Create-only. Caps the label permutation cardinality (e.g. `30000`). |
+| `type` | enum string | `E2M_TYPE_LOGS2METRICS` or `E2M_TYPE_SPANS2METRICS`. Required. |
+| `logsQuery` / `spansQuery` | object | The `query` oneof — exactly one, matching `type`. |
+| `metricLabels[]` | array | Each label becomes a Prometheus label. **Each distinct value set multiplies permutations.** |
+| `metricFields[]` | array | **Max 10.** Each holds a source field + its aggregations. |
+
+**Read-only fields** (present in `get` responses, omit from create/update bodies): `id` (UUID — *required* on `update`/replace), `permutations` (`{limit, hasExceededLimit}`), `createTime`, `updateTime`, `metricName`, `isInternal`.
+
+### `logsQuery`
+
+| Field | Type |
+|---|---|
+| `lucene` | string (Lucene filter) |
+| `alias` | string (optional) |
+| `applicationnameFilters[]` | string[] |
+| `subsystemnameFilters[]` | string[] |
+| `severityFilters[]` | enum string[] — see below |
+
+Severity enum values: `SEVERITY_DEBUG`, `SEVERITY_VERBOSE`, `SEVERITY_INFO`, `SEVERITY_WARNING`, `SEVERITY_ERROR`, `SEVERITY_CRITICAL`.
+
+### `spansQuery`
+
+| Field | Type |
+|---|---|
+| `lucene` | string (Lucene filter) |
+| `applicationnameFilters[]` | string[] |
+| `subsystemnameFilters[]` | string[] |
+| `actionFilters[]` | string[] |
+| `serviceFilters[]` | string[] |
+
+### `metricLabels[]`
+
+```json
+{ "targetLabel": "app", "sourceField": "coralogix.metadata.applicationName" }
+```
+
+- `targetLabel` — the output Prometheus label name. Pattern `^[\w/-]+$`.
+- `sourceField` — the event field to read the value from (e.g. `coralogix.metadata.applicationName`, `log_obj.region`).
+
+### `metricFields[]` and `aggregations[]`
+
+```json
+{
+  "targetBaseMetricName": "latency_ms",
+  "sourceField": "log_obj.latency_ms",
+  "aggregations": [
+    { "enabled": true, "aggType": "AGG_TYPE_HISTOGRAM", "targetMetricName": "latency_ms_histogram",
+      "histogram": { "buckets": [10, 50, 100, 500, 1000] } },
+    { "enabled": true, "aggType": "AGG_TYPE_SAMPLES",   "targetMetricName": "latency_ms_max",
+      "samples": { "sampleType": "SAMPLE_TYPE_MAX" } }
+  ]
+}
+```
+
+- `targetBaseMetricName` — base name; each aggregation gets its own `targetMetricName`. Pattern `^[\w/-]+$`.
+- `sourceField` — numeric event field to aggregate. (For `AGG_TYPE_COUNT` the value is irrelevant — it counts matching events.)
+
+**`aggType` values:**
+
+| `aggType` (string enum) | Meaning | Extra metadata |
+|---|---|---|
+| `AGG_TYPE_MIN` | minimum | - |
+| `AGG_TYPE_MAX` | maximum | - |
+| `AGG_TYPE_COUNT` | event count | - |
+| `AGG_TYPE_AVG` | average | - |
+| `AGG_TYPE_SUM` | sum | - |
+| `AGG_TYPE_HISTOGRAM` | bucketed distribution | `histogram.buckets`: `float[]` (bucket boundaries; ≥1 bucket) |
+| `AGG_TYPE_SAMPLES` | sampled min/max | `samples.sampleType`: `SAMPLE_TYPE_MIN` or `SAMPLE_TYPE_MAX` |
+
+Each aggregation: `enabled` (bool), `aggType` (string enum), `targetMetricName` (string), plus the `agg_metadata` oneof (`histogram` or `samples`) only for those two types.
+
+---
+
+## Cardinality & Limits
+
+**Permutations = the product of the number of distinct values across all `metricLabels`.** A label on `app` (20 values) × `subsystem` (15) × `status_code` (40) = 12,000 permutations. Add one high-cardinality label and it explodes.
+
+- **Never** use high-cardinality fields as labels: user IDs, request/trace IDs, session IDs, raw URLs, full paths, IPs, timestamps. These multiply permutations without bound and will breach the limit.
+- Keep labels to bounded, low-cardinality dimensions (app, subsystem, region, status class, severity, endpoint *group*).
+- `permutationsLimit` caps the design; if exceeded, the read-back `permutations.hasExceededLimit` is `true` and new permutations stop being produced.
+
+**Checking limits and cardinality:**
+
+```bash
+cx e2m limits -o json              # account E2M count limit + used
+cx e2m labels-cardinality -o json  # current label cardinality data (existing E2Ms)
+```
+
+- `cx e2m limits` reports the E2M **count** limit and how many are used (the underlying API also tracks labels/permutations/metrics caps).
+- `cx e2m labels-cardinality` reports **existing** label cardinality — it is **not** a pre-create forecast from a draft. To size a new E2M, estimate permutations manually (product of distinct label values) and set `permutationsLimit` accordingly.
+
+**Worked example — sizing a 2-label design:**
+- Labels: `app` (~12 distinct), `severity` (6 distinct).
+- Estimated permutations = 12 × 6 = **72** — comfortably under any limit.
+- Adding `endpoint` (~300 distinct) → 12 × 6 × 300 = **21,600**. Closer to limits; prefer grouping endpoints into a bounded `route` field, or drop the label and filter in `lucene` instead.
+
+---
+
+## Gotchas
+
+- **Enums are strings, not integers.** Use `"type": "E2M_TYPE_LOGS2METRICS"` and `"aggType": "AGG_TYPE_AVG"` — not `1` / `4`. (Some internal/legacy exports use integers and a `$case` discriminator; the `cx` CLI uses the OpenAPI string form.)
+- **Template from `get`, not `list`.** `cx e2m list` / `create` print a simplified summary; only `cx e2m get <id> -o json` returns the full definition (`{"e2m": {...}}`).
+- **Create body is the bare object**, not wrapped in `{"e2m": ...}`. Extract `.e2m` from a `get` response before creating.
+- **`update` (replace) requires `id`** in the body; `create` must omit it.
+- **Max 10 metric fields** per E2M.
+- **`targetMetricName` must be unique** within the definition; collisions silently clobber series.
+- **Forward-only.** Creating an E2M never backfills historical data — only events ingested after creation produce series.
+- **Verify with metrics, not logs:** `cx metrics search --name "<targetBaseMetricName>"` then a PromQL query.


### PR DESCRIPTION
## Why

The `cx-data-pipeline` skill covered `cx e2m` in ~35 generic lines — a flat command table and a generic create flow — with **no schema reference**, no cardinality guidance, and an **incorrect mental model**: it implied E2M should target archive data instead of Frequent Search. A $1.2M POC hit that wrong answer in practice ([Slack thread](https://coralogix-dev.slack.com/archives/C08DLTHQ8P6/p1781595760962069)).

## What

**New `skills/cx-data-pipeline/references/e2m-schemas.md`** (mirrors `cx-alerts/references/alert-schemas.md`):
- Full OpenAPI wire format — `type`/`aggType` **string** enums, `logsQuery`/`spansQuery` filters (incl. severity enum), metric labels & fields, histogram/samples aggregation metadata
- The TCO-tier compute model
- Permutation/cardinality sizing with a worked example + "never use as labels" list
- Gotchas (string-not-integer enums, template-from-`get`, bare-object create body, max 10 fields, forward-only)

**Rewrote the Events2Metrics workflow in `SKILL.md`:**
- **How E2M is computed** — a TCO tier table making the correct model explicit: E2M works on **High + Medium** tiers (Medium *is* S3 archive and works), **not** Low/compliance. Framed by *tier*, never "FS vs archive."
- Design (with **dataSource / dataset scoping** — API-supported when `e2m_dataset_source_enabled` is on) → size (`limits`/`labels-cardinality`) → template-from-`get` → create → verify
- **Zero-series troubleshooting** (check the source's TCO tier first; fix is a TCO change, not an E2M change)
- **Cost-optimization play**: convert High-tier logs → metrics, then downgrade raw logs High→Medium
- Added E2M trigger phrases, a Reference Files section, and a `cx-cost-optimization` cross-link

## Verification

- Schema grounded in the actual CLI (`src/commands/e2m/{mod,api}.rs`) and the `openapi-facade-lts` proto — which corrected three assumptions: enums are **strings**, `labels-cardinality` is a no-arg GET (not a draft forecast), and only `cx e2m get` returns the full definition.
- `scripts/verify-skills.sh` → `cx-data-pipeline` **PASS** (33 triggers, 298 lines).

> Note: the create-body envelope (bare object, per the gateway `body: "e2m"` mapping) is inferred from the proto; worth a live `cx e2m create`/`get` round-trip in review to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)