### PR TITLE
fix(iam): resolve users team ID via /identity/whoami, fix empty search results

### DIFF
--- a/src/commands/cases/api.rs
+++ b/src/commands/cases/api.rs
@@ -116,15 +116,6 @@ pub struct SearchUsersResponse {
     pub next_page_token: Option<i64>,
 }
 
-/// Response from `GET /identity/whoami`, which identifies the team (and user)
-/// the current API key belongs to. Fields are snake_case in the payload.
-#[derive(Debug, Deserialize)]
-pub struct Whoami {
-    pub team_id: Option<i64>,
-    pub team_name: Option<String>,
-    pub user_name: Option<String>,
-}
-
 /// In-memory lookup over the team-members list, used to convert between
 /// opaque user IDs (the API's currency) and email addresses (what humans
 /// recognize). Built once per command invocation per profile.
@@ -188,7 +179,6 @@ const CLOSED_BASE: &str = "/mgmt/openapi/5/cases/closed/v1";
 const RESOLVED_BASE: &str = "/mgmt/openapi/5/cases/resolved/v1";
 const NOTIFICATION_DELIVERIES_BASE: &str = "/mgmt/openapi/5/cases/notifications/v1/deliveries";
 const USERS_BASE: &str = "/mgmt/openapi/5/aaa/teams/v2";
-const WHOAMI_BASE: &str = "/identity/whoami";
 /// Page size for the paginated team-users search. The endpoint caps how many
 /// rows it returns per call, so we walk pages until `nextPageToken` is absent.
 const USERS_PAGE_SIZE: i64 = 300;
@@ -300,27 +290,11 @@ impl<'a> CasesApi<'a> {
         self.client.post(NOTIFICATION_DELIVERIES_BASE, &body).await
     }
 
-    /// Resolve the team ID for the current API key. The team-users search
-    /// endpoint embeds the team ID in its path, so we ask `/identity/whoami`,
-    /// which every key can read and which returns the caller's team.
-    async fn resolve_team_id(&self) -> anyhow::Result<String> {
-        let whoami: Whoami = self
-            .client
-            .get(WHOAMI_BASE, &[])
-            .await
-            .map_err(|e| anyhow!("failed to resolve team ID via /identity/whoami: {e:#}"))?;
-        whoami
-            .team_id
-            .map(|id| id.to_string())
-            .ok_or_else(|| anyhow!("/identity/whoami returned no team_id"))
-    }
-
     /// List all team members by walking the paginated team-users search
     /// endpoint (`GET /mgmt/openapi/5/aaa/teams/v2/{team_id}/search`) in pages
     /// of [`USERS_PAGE_SIZE`], following `nextPageToken` until it is absent.
     pub async fn list_teammates(&self) -> Result<Vec<TeamUser>> {
-        let team_id = self
-            .resolve_team_id()
+        let team_id = crate::identity::resolve_team_id(self.client)
             .await
             .map_err(|e| crate::error::CxError::Api {
                 status: 0,

--- a/src/commands/users/mod.rs
+++ b/src/commands/users/mod.rs
@@ -7,7 +7,6 @@ use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
-use crate::commands::saml::api::SamlApi;
 use crate::config::OutputFormat;
 use crate::execution::{fan_out, ExecutionTarget};
 use crate::render;
@@ -46,24 +45,6 @@ fn read_from_file(path: &str) -> Result<Value> {
     Ok(serde_json::from_str(&raw)?)
 }
 
-async fn resolve_team_id(client: &crate::api_client::CxClient) -> anyhow::Result<String> {
-    let saml = SamlApi::new(client);
-    let config = saml.get_config().await.map_err(|e| {
-        let msg = e.to_string();
-        if msg.contains("Permission denied") || msg.contains("Authentication failed") {
-            anyhow::anyhow!(
-                "Cannot resolve team ID: API key lacks SAML scope (required by the users API)"
-            )
-        } else {
-            anyhow::anyhow!("Failed to resolve team ID from SAML config: {e}")
-        }
-    })?;
-    config
-        .team_id
-        .map(|id| id.to_string())
-        .ok_or_else(|| anyhow::anyhow!("SAML config returned no team ID"))
-}
-
 pub async fn run_search(
     targets: &[Arc<ExecutionTarget>],
     query: Option<&str>,
@@ -87,7 +68,7 @@ pub async fn run_search(
         let page_token = page_token.clone();
         async move {
             let api = UsersApi::new(&t.client);
-            let team_id = resolve_team_id(&t.client).await?;
+            let team_id = crate::identity::resolve_team_id(&t.client).await?;
             let team_id = team_id.as_str();
             let mut params: Vec<(&str, String)> = Vec::new();
             if let Some(ref q) = query {
@@ -96,19 +77,17 @@ pub async fn run_search(
             if let Some(ref s) = status {
                 params.push(("status", s.clone()));
             }
-            if let Some(ref ps) = page_size {
-                params.push(("pageSize", ps.clone()));
-            }
+            // pageSize is required — the server returns an empty list without it.
+            params.push((
+                "pageSize",
+                page_size.clone().unwrap_or_else(|| "300".to_string()),
+            ));
             if let Some(ref pt) = page_token {
                 params.push(("pageToken", pt.clone()));
             }
             let params_refs: Vec<(&str, &str)> =
                 params.iter().map(|(k, v)| (*k, v.as_str())).collect();
-            if params_refs.is_empty() {
-                Ok(api.search(team_id).await?)
-            } else {
-                Ok(api.search_with_params(team_id, &params_refs).await?)
-            }
+            Ok(api.search_with_params(team_id, &params_refs).await?)
         }
     })
     .await;
@@ -175,7 +154,7 @@ pub async fn run_get(
         let user_id = user_id.clone();
         async move {
             let api = UsersApi::new(&t.client);
-            let team_id = resolve_team_id(&t.client).await?;
+            let team_id = crate::identity::resolve_team_id(&t.client).await?;
             let team_id = team_id.as_str();
             Ok(api.get(team_id, &user_id).await?)
         }
@@ -226,7 +205,7 @@ pub async fn run_create(
         let body = body.clone();
         async move {
             let api = UsersApi::new(&t.client);
-            let team_id = resolve_team_id(&t.client).await?;
+            let team_id = crate::identity::resolve_team_id(&t.client).await?;
             let team_id = team_id.as_str();
             api.create(team_id, &body).await?;
             Ok(())
@@ -264,7 +243,7 @@ pub async fn run_update(
         let body = body.clone();
         async move {
             let api = UsersApi::new(&t.client);
-            let team_id = resolve_team_id(&t.client).await?;
+            let team_id = crate::identity::resolve_team_id(&t.client).await?;
             let team_id = team_id.as_str();
             Ok(api.update(team_id, &body).await?)
         }
@@ -327,7 +306,7 @@ pub async fn run_set_status(
         let body = body.clone();
         async move {
             let api = UsersApi::new(&t.client);
-            let team_id = resolve_team_id(&t.client).await?;
+            let team_id = crate::identity::resolve_team_id(&t.client).await?;
             let team_id = team_id.as_str();
             api.update_statuses(team_id, &body).await?;
             Ok(())

--- a/src/identity.rs
+++ b/src/identity.rs
@@ -1,0 +1,52 @@
+use anyhow::anyhow;
+use serde::Deserialize;
+
+use crate::api_client::CxClient;
+
+const WHOAMI_BASE: &str = "/identity/whoami";
+
+/// Response from `GET /identity/whoami`. Identifies the team (and caller) that
+/// the current API key belongs to. Payload uses snake_case field names.
+#[derive(Debug, Deserialize)]
+pub struct Whoami {
+    pub team_id: Option<i64>,
+    pub team_name: Option<String>,
+    pub user_name: Option<String>,
+}
+
+/// Resolve the team ID for the current API key via `GET /identity/whoami`.
+///
+/// Preferred over the SAML config endpoint because `/identity/whoami` is
+/// readable by every API key regardless of scopes, and works on teams that
+/// have not configured SAML.
+pub async fn resolve_team_id(client: &CxClient) -> anyhow::Result<String> {
+    let whoami: Whoami = client
+        .get(WHOAMI_BASE, &[])
+        .await
+        .map_err(|e| anyhow!("failed to resolve team ID via /identity/whoami: {e:#}"))?;
+    whoami
+        .team_id
+        .map(|id| id.to_string())
+        .ok_or_else(|| anyhow!("/identity/whoami returned no team_id"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_whoami() {
+        let json = serde_json::json!({ "team_id": 53623, "team_name": "acme", "user_name": "alice@example.com" });
+        let w: Whoami = serde_json::from_value(json).unwrap();
+        assert_eq!(w.team_id, Some(53623));
+        assert_eq!(w.team_name.as_deref(), Some("acme"));
+    }
+
+    #[test]
+    fn deserialize_whoami_minimal() {
+        let json = serde_json::json!({ "team_id": 12345 });
+        let w: Whoami = serde_json::from_value(json).unwrap();
+        assert_eq!(w.team_id, Some(12345));
+        assert!(w.team_name.is_none());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod commands;
 pub mod config;
 pub mod error;
 pub mod execution;
+pub mod identity;
 pub mod install_method;
 pub mod keyring_store;
 pub mod oauth;

--- a/tests/users/main.rs
+++ b/tests/users/main.rs
@@ -2,7 +2,7 @@
 mod common;
 
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{method, path, query_param};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use coralogix_cli::commands::users::run_search;
@@ -13,10 +13,8 @@ async fn search_users_from_mock() {
     let server = MockServer::start().await;
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/5/aaa/team-saml/v1/configuration"))
-        .respond_with(
-            ResponseTemplate::new(200).set_body_json(json!({"teamId": 12345, "enabled": false})),
-        )
+        .and(path("/identity/whoami"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "team_id": 12345 })))
         .mount(&server)
         .await;
 
@@ -28,6 +26,7 @@ async fn search_users_from_mock() {
 
     Mock::given(method("GET"))
         .and(path("/mgmt/openapi/5/aaa/teams/v2/12345/search"))
+        .and(query_param("pageSize", "300"))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)


### PR DESCRIPTION
## Context
`cx iam users search` (and `get`/`create`/`update`/`set-status`) was broken for most real-world API keys. Users with full user-management scopes were hitting one of two errors — either an explicit SAML scope rejection or a silent empty result — even on teams with many users. Root-caused to two independent bugs in the team ID resolution and search request construction.

## Linked Issues
FORGE-246

## Design
Every users API call needs the team ID embedded in the path (`/aaa/teams/v2/{team_id}/...`), so the CLI must resolve it client-side first. Previously this was done by calling the SAML configuration endpoint (`GET /aaa/team-saml/v1/configuration`) and reading `team_id` out of the response. That endpoint requires a SAML-specific scope unrelated to user management.

The replacement is `GET /identity/whoami`, which returns `team_id` + `team_name` + `user_name` and is readable by every API key regardless of scopes. The `cases` command already used this exact approach for its own team-user lookups; the logic is now extracted into a shared `src/identity.rs` module so both commands use a single implementation with no cross-command dependency.

The `pageSize` fix is simpler: the search endpoint silently returns `{"users": [], "totalCount": 0}` when `pageSize` is absent from the query string. The fix always sends `pageSize` (defaulting to 300 when the caller doesn't specify one), matching how `cases` calls the same endpoint.

## Key Decisions
- **`src/identity.rs` as the shared home** — neutral location in the top-level `src/` infra layer avoids an awkward cross-command import (users importing from cases) and keeps CODEOWNERS clean. Both commands point at `crate::identity::resolve_team_id`.
- **Default `pageSize=300`** — same value `cases` uses for the same endpoint. The search endpoint has no documented default and silently returns empty without it, so a hardcoded safe default is the right call.
- **SAML module untouched** — `src/commands/saml/` remains a standalone command. Only `users`'s dependency on it is removed.

## Changes
- `cx iam users search` no longer fails with "Cannot resolve team ID: API key lacks SAML scope" — team ID is now resolved via `/identity/whoami`
- `cx iam users search` now returns results on teams that have users (was silently returning empty due to missing `pageSize`)
- `cx iam users search --page-size N` still works; user-supplied value is forwarded as before
- `src/identity.rs` (new): `Whoami` struct + `pub async fn resolve_team_id(client)` backed by `GET /identity/whoami`
- `src/commands/cases/api.rs`: private `Whoami`, `WHOAMI_BASE`, and `resolve_team_id` removed; `list_teammates` delegates to the shared helper — no behavioral change
- `src/commands/users/mod.rs`: SAML-based `resolve_team_id` and `SamlApi` import removed; all 5 operation handlers use `crate::identity::resolve_team_id`

## Testing
- `cargo fmt --check && cargo clippy --locked -- -D warnings && cargo test --locked` — all pass, 0 failures
- Integration test `tests/users/main.rs` updated: SAML mock replaced with `/identity/whoami` mock, `pageSize=300` query param matcher added
- Manual `cargo run -- iam users search --profile test` against stg1: previously failed with SAML error, now returns results correctly
- Raw `curl` against `GET /aaa/teams/v2/{team_id}/search` confirmed the `pageSize` requirement: without it the API returns `{"users":[],"totalCount":0}`; with `?pageSize=100` it returns the full user list

## Risks & Rollout
Low risk. Both `/identity/whoami` and the users search endpoint are already called by `cx cases` in production. The change is a client-side fix with no server-side impact. Rollback is a revert of this PR.

## Out of Scope / Follow-ups
- `cx iam users search` is still single-page (like other `iam` subcommands). Auto-pagination across all pages (like `cases list_teammates` does) is a separate feature decision.