### PR TITLE
feat(dashboards): add 'cx dashboards check' subcommand (CX-47295)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.96.1"
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
@@ -150,7 +150,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         if: github.event_name != 'pull_request' || steps.filter.outputs.code == 'true'
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.96.1"
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.96.1"
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         if: steps.filter.outputs.code == 'true'
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.96.1"
           components: rustfmt, clippy
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.96.1"
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
@@ -163,7 +163,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.96.1"
 
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master
         if: steps.filter.outputs.code == 'true'
         with:
-          toolchain: "1.94.1"
+          toolchain: "1.96.1"
 
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         if: steps.filter.outputs.code == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ cargo test --test e2e -- --ignored --test-threads=1   # E2E vs. Coralogix test t
 cargo run -- <args>                 # Run CLI in dev mode
 ```
 
-Rust toolchain is pinned to **1.94.1** via `rust-toolchain.toml`.
+Rust toolchain is pinned to **1.96.1** via `rust-toolchain.toml`.
 
 ## Command Hierarchy
 

--- a/contributing/development.md
+++ b/contributing/development.md
@@ -12,7 +12,7 @@ cargo test -- --ignored             # Run integration tests (system keyring requ
 cargo run -- <args>                 # Run CLI in dev mode
 ```
 
-Rust toolchain is pinned to **1.94.1** via `rust-toolchain.toml`.
+Rust toolchain is pinned to **1.96.1** via `rust-toolchain.toml`.
 
 Before submitting a PR, verify:
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "cx - Coralogix CLI";
 
   # Unstable channel: tracks the rustc version pinned in rust-toolchain.toml
-  # (1.94.1). Stable channels lag behind and would mismatch the toolchain file.
+  # (1.96.1). Stable channels lag behind and would mismatch the toolchain file.
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs }:

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.94.1"
+channel = "1.96.1"
 components = ["clippy", "rustfmt"]

--- a/skills/cx-dashboards/SKILL.md
+++ b/skills/cx-dashboards/SKILL.md
@@ -49,6 +49,8 @@ Beyond creating dashboards, use these commands to manage existing ones:
 | `cx dashboards folders create --name "Name"` | Create a dashboard folder |
 | `cx dashboards folders create --name "Sub" --parent-id <id>` | Create a nested folder |
 | `cx dashboards replace --from-file dashboard.json` | Replace an existing dashboard with updated JSON |
+| `cx dashboards check --from-file dashboard.json` | Validate a dashboard definition without persisting (server-side strict check; exits non-zero on errors) |
+| `cx dashboards check <dashboard-id>` | Validate a stored dashboard by id |
 
 To update an existing dashboard:
 
@@ -80,11 +82,12 @@ Dashboard Progress:
 - [ ] Phase 4: Generate the Coralogix JSON
 - [ ] Phase 5: Live-verify every query through the cx CLI
 - [ ] Phase 6: Self-verify structure against the checklist
-- [ ] Phase 7: Deploy via `cx dashboards create`
-- [ ] Phase 8: Share the dashboard link with the user
+- [ ] Phase 7: Server-side validation via `cx dashboards check`
+- [ ] Phase 8: Deploy via `cx dashboards create`
+- [ ] Phase 9: Share the dashboard link with the user
 ```
 
-Proceed in order. Don't jump to Phase 4 before the user approves the Phase 3 plan, and don't run Phase 7 before Phases 5 and 6 both pass. Phase 8 is mandatory — the workflow is not done until the user has a clickable link.
+Proceed in order. Don't jump to Phase 4 before the user approves the Phase 3 plan, and don't run Phase 8 before Phases 5–7 all pass. Phase 9 is mandatory — the workflow is not done until the user has a clickable link.
 
 ---
 
@@ -199,7 +202,7 @@ For query syntax follow [`references/query-syntax.md`](references/query-syntax.m
 
 ## Phase 5: Live-verify every query through the cx CLI
 
-Every PromQL and DataPrime query in the draft has to successfully run through `cx` before Phase 7. This catches invented metric names, typoed field paths, and malformed pipelines.
+Every PromQL and DataPrime query in the draft has to successfully run through `cx` before Phase 8. This catches invented metric names, typoed field paths, and malformed pipelines.
 
 ### Frequent vs Archive (what / when / where in JSON)
 
@@ -252,7 +255,19 @@ Run this checklist against the final JSON. Fix and re-check if any item fails be
 
 ---
 
-## Phase 7: Deploy via `cx dashboards create`
+## Phase 7: Server-side validation via `cx dashboards check`
+
+Phase 6 caught structural issues by hand. This phase runs the whole dashboard through the Coralogix Dashboard Service's strict validator (`CheckDashboard`) — the same validation `create`/`replace` apply on write, plus a superset that compiles every PromQL/DataPrime query and enforces required ids for variables and filters.
+
+1. Run `cx dashboards check --from-file /tmp/cx-dashboard-<slug>.json`.
+2. If the command exits non-zero, the output lists issues with `severity`, `location` (an RFC 6901 JSON Pointer into the dashboard, e.g. `/sections/0/rows/1/widgets/2`), and `message`. Fix each issue in the JSON (loop back to Phase 4), re-run Phase 5 for any query that changed, then re-run this phase.
+3. When `check` exits 0 (text output: `Dashboard is valid (no issues)`), proceed to Phase 8.
+
+`check` is read-only — it never persists the dashboard. Warnings (`SEVERITY_WARNING`) print but do not fail the gate; only errors (`SEVERITY_ERROR`) cause a non-zero exit. In multi-profile fan-out, any profile returning errors fails the command.
+
+---
+
+## Phase 8: Deploy via `cx dashboards create`
 
 Don't tell the user to paste JSON into the Coralogix UI - deploy it directly.
 
@@ -266,11 +281,11 @@ On failure: show the CLI error verbatim and return to Phase 5. The most common c
 
 ---
 
-## Phase 8: Share the dashboard link
+## Phase 9: Share the dashboard link
 
 The workflow is **not done** until the user has a clickable link to the dashboard. Printing the ID alone forces the user to navigate the Coralogix UI by hand, which defeats the point of automating deployment.
 
-After Phase 7 succeeds, capture the dashboard `id` returned by `cx dashboards create`, build the URL using the region → webapp host mapping in [`references/deploy.md`](references/deploy.md) § "Share the link", and emit the output template below. Render the dashboard **name** as the link text — that's what the user clicks.
+After Phase 8 succeeds, capture the dashboard `id` returned by `cx dashboards create`, build the URL using the region → webapp host mapping in [`references/deploy.md`](references/deploy.md) § "Share the link", and emit the output template below. Render the dashboard **name** as the link text — that's what the user clicks.
 
 ---
 

--- a/skills/cx-dashboards/references/deploy.md
+++ b/skills/cx-dashboards/references/deploy.md
@@ -1,4 +1,4 @@
-# Phase 7: Deploy via `cx dashboards create`
+# Phase 8: Deploy via `cx dashboards create`
 
 Don't tell the user to paste JSON into the Coralogix UI - deploy the dashboard directly.
 

--- a/skills/cx-dashboards/references/verification.md
+++ b/skills/cx-dashboards/references/verification.md
@@ -1,6 +1,6 @@
 # Phase 5: Live-verify every query through the cx CLI
 
-Every PromQL and DataPrime query in the draft dashboard must successfully run through `cx` before Phase 7 ships it. This is where invented metric names, typoed field paths, and malformed DataPrime pipelines get caught.
+Every PromQL and DataPrime query in the draft dashboard must successfully run through `cx` before Phase 8 ships it. This is where invented metric names, typoed field paths, and malformed DataPrime pipelines get caught.
 
 ---
 

--- a/src/commands/dashboards/api.rs
+++ b/src/commands/dashboards/api.rs
@@ -117,10 +117,67 @@ pub struct DashboardFoldersResponse {
     pub folders: Vec<DashboardFolderItem>,
 }
 
+// --- Dashboard check (CheckDashboard) response types ---
+
+/// Severity of a validation issue emitted by `CheckDashboard`.
+///
+/// The protobuf JSON gateway emits enum values as their SCREAMING_SNAKE_CASE
+/// names (`"SEVERITY_ERROR"`, `"SEVERITY_WARNING"`, `"SEVERITY_UNSPECIFIED"`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum IssueSeverity {
+    SeverityUnspecified,
+    SeverityError,
+    SeverityWarning,
+}
+
+impl IssueSeverity {
+    /// True when this severity should fail a `check` invocation (CI gate).
+    /// Today only `SEVERITY_ERROR` (and the unspecified default, treated as
+    /// an error to be safe) cause a non-zero exit; warnings print but pass.
+    pub fn is_failure(&self) -> bool {
+        matches!(
+            self,
+            IssueSeverity::SeverityError | IssueSeverity::SeverityUnspecified
+        )
+    }
+}
+
+/// A single validation issue returned by `CheckDashboard`.
+///
+/// `location` is an RFC 6901 JSON Pointer into the dashboard definition
+/// (e.g. `/sections/0/rows/1/widgets/2`); empty/omitted for root-level issues.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DashboardCheckIssue {
+    pub severity: IssueSeverity,
+    #[serde(default)]
+    pub message: Option<String>,
+    #[serde(default)]
+    pub location: Option<String>,
+}
+
+/// Response body of `POST /dashboards/check/v1`.
+///
+/// An empty `issues` list means the dashboard is valid.
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CheckDashboardResponse {
+    #[serde(default)]
+    pub issues: Vec<DashboardCheckIssue>,
+}
+
 // --- API ---
 
 const DASHBOARDS_BASE: &str = "/mgmt/openapi/5/dashboards/dashboards/v1";
 const FOLDERS_BASE: &str = "/mgmt/openapi/5/dashboards/folders/v1";
+/// `POST`: validate a dashboard definition or an existing dashboard by id
+/// without persisting it (DashboardsService.CheckDashboard).
+///
+/// The proto HTTP annotation is `POST /dashboards/check/v1` (body: `*`);
+/// the management gateway maps the `/dashboards` prefix to
+/// `/mgmt/openapi/5/dashboards`.
+const DASHBOARD_CHECK_PATH: &str = "/mgmt/openapi/5/dashboards/check/v1";
 
 #[derive(Debug, Deserialize)]
 pub struct DeleteDashboardResponse {}
@@ -179,6 +236,17 @@ impl<'a> DashboardsApi<'a> {
     /// Coralogix Dashboard Service.
     pub async fn create(&self, body: &Value) -> Result<Value> {
         self.client.post(DASHBOARDS_BASE, body).await
+    }
+
+    /// Validate a dashboard definition without persisting it
+    /// (`DashboardsService.CheckDashboard`).
+    ///
+    /// `body` must be a `CheckDashboardRequest` JSON object with exactly one
+    /// of these `source` oneof fields set:
+    /// - `{ "dashboard": { ... } }` — validate an inline definition
+    /// - `{ "dashboardId": "<id>" }` — validate a stored dashboard by id
+    pub async fn check(&self, body: &Value) -> Result<CheckDashboardResponse> {
+        self.client.post(DASHBOARD_CHECK_PATH, body).await
     }
 
     /// List all dashboard folders.
@@ -267,5 +335,104 @@ impl<'a> DashboardsApi<'a> {
                 ],
             )
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_response_deserializes_mixed_severity_issues() {
+        let raw = serde_json::json!({
+            "issues": [
+                {
+                    "severity": "SEVERITY_ERROR",
+                    "message": "Widget 'cpu-chart' references undefined variable 'env'",
+                    "location": "/sections/0/rows/1/widgets/2"
+                },
+                {
+                    "severity": "SEVERITY_WARNING",
+                    "message": "Query uses deprecated function 'timeShift'",
+                    "location": "/sections/1/rows/0/widgets/0/queries/0"
+                }
+            ]
+        });
+        let resp: CheckDashboardResponse = serde_json::from_value(raw).expect("must deserialize");
+        assert_eq!(resp.issues.len(), 2);
+        assert_eq!(resp.issues[0].severity, IssueSeverity::SeverityError);
+        assert_eq!(
+            resp.issues[0].message.as_deref(),
+            Some("Widget 'cpu-chart' references undefined variable 'env'")
+        );
+        assert_eq!(
+            resp.issues[0].location.as_deref(),
+            Some("/sections/0/rows/1/widgets/2")
+        );
+        assert_eq!(resp.issues[1].severity, IssueSeverity::SeverityWarning);
+        assert!(resp.issues[1].severity.is_failure() == false);
+
+        // The error-severity issue must be a failure, the warning must not.
+        assert!(resp.issues[0].severity.is_failure());
+        assert!(!resp.issues[1].severity.is_failure());
+    }
+
+    #[test]
+    fn check_response_empty_issues_is_valid() {
+        let raw = serde_json::json!({ "issues": [] });
+        let resp: CheckDashboardResponse = serde_json::from_value(raw).expect("must deserialize");
+        assert!(resp.issues.is_empty());
+    }
+
+    #[test]
+    fn check_response_defaults_issues_to_empty_when_absent() {
+        // The server always emits `issues`, but `#[serde(default)]` should
+        // make a missing field non-fatal.
+        let raw = serde_json::json!({});
+        let resp: CheckDashboardResponse = serde_json::from_value(raw).expect("must deserialize");
+        assert!(resp.issues.is_empty());
+    }
+
+    #[test]
+    fn check_response_tolerates_issue_missing_optional_fields() {
+        let raw = serde_json::json!({
+            "issues": [
+                { "severity": "SEVERITY_ERROR" },
+                { "severity": "SEVERITY_WARNING", "message": "only a message" },
+                { "severity": "SEVERITY_UNSPECIFIED", "location": "/only/location" }
+            ]
+        });
+        let resp: CheckDashboardResponse = serde_json::from_value(raw).expect("must deserialize");
+        assert_eq!(resp.issues.len(), 3);
+
+        assert_eq!(resp.issues[0].severity, IssueSeverity::SeverityError);
+        assert!(resp.issues[0].message.is_none());
+        assert!(resp.issues[0].location.is_none());
+
+        assert_eq!(resp.issues[1].severity, IssueSeverity::SeverityWarning);
+        assert_eq!(resp.issues[1].message.as_deref(), Some("only a message"));
+        assert!(resp.issues[1].location.is_none());
+
+        assert_eq!(resp.issues[2].severity, IssueSeverity::SeverityUnspecified);
+        assert!(resp.issues[2].message.is_none());
+        assert_eq!(resp.issues[2].location.as_deref(), Some("/only/location"));
+        // Unspecified is treated as a failure to be safe.
+        assert!(resp.issues[2].severity.is_failure());
+    }
+
+    #[test]
+    fn issue_severity_serializes_to_screaming_snake_case() {
+        // Round-trip: the enum must serialize back to the proto JSON shape
+        // so it can be re-emitted in --json / --agents output.
+        for (sev, expected) in [
+            (IssueSeverity::SeverityUnspecified, "SEVERITY_UNSPECIFIED"),
+            (IssueSeverity::SeverityError, "SEVERITY_ERROR"),
+            (IssueSeverity::SeverityWarning, "SEVERITY_WARNING"),
+        ] {
+            let s = serde_json::to_string(&sev).expect("must serialize");
+            assert_eq!(s, format!("\"{expected}\""));
+            let back: IssueSeverity = serde_json::from_str(&s).expect("must round-trip");
+            assert_eq!(back, sev);
+        }
     }
 }

--- a/src/commands/dashboards/api.rs
+++ b/src/commands/dashboards/api.rs
@@ -370,7 +370,7 @@ mod tests {
             Some("/sections/0/rows/1/widgets/2")
         );
         assert_eq!(resp.issues[1].severity, IssueSeverity::SeverityWarning);
-        assert!(resp.issues[1].severity.is_failure() == false);
+        assert!(!resp.issues[1].severity.is_failure());
 
         // The error-severity issue must be a failure, the warning must not.
         assert!(resp.issues[0].severity.is_failure());

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -14,7 +14,7 @@ use crate::config::OutputFormat;
 use crate::execution::{fan_out, ExecutionTarget};
 use crate::render;
 use api::{
-    DashboardFolderItem, DashboardSearchResult, DashboardsApi, QueryByFieldResult,
+    DashboardFolderItem, DashboardSearchResult, DashboardsApi, IssueSeverity, QueryByFieldResult,
     QuerySearchResult,
 };
 
@@ -1097,6 +1097,176 @@ pub async fn run_folders_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> R
             ),
             Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
         }
+    }
+    Ok(())
+}
+
+// ── Check (CheckDashboard) ────────────────────────────────────────────────────
+
+/// Build the `CheckDashboardRequest` JSON body for the `dashboardId` oneof arm.
+fn check_body_from_id(dashboard_id: &str) -> Value {
+    json!({ "dashboardId": dashboard_id })
+}
+
+/// Build the `CheckDashboardRequest` JSON body for the `dashboard` oneof arm,
+/// reusing `read_dashboard_body` to normalize a bare doc or a
+/// `{ "dashboard": {...} }` wrapper into the inner dashboard object.
+fn check_body_from_file(from_file: &str) -> Result<Value> {
+    let dashboard = read_dashboard_body(from_file)?;
+    Ok(json!({ "dashboard": dashboard }))
+}
+
+/// Colorize a severity string for text output.
+fn severity_colored(severity: IssueSeverity) -> String {
+    let s = match severity {
+        IssueSeverity::SeverityError => "SEVERITY_ERROR",
+        IssueSeverity::SeverityWarning => "SEVERITY_WARNING",
+        IssueSeverity::SeverityUnspecified => "SEVERITY_UNSPECIFIED",
+    };
+    match severity {
+        IssueSeverity::SeverityError => s.red().to_string(),
+        IssueSeverity::SeverityWarning => s.yellow().to_string(),
+        IssueSeverity::SeverityUnspecified => s.dimmed().to_string(),
+    }
+}
+
+/// Build one issue row as JSON for `json` / `agents` output.
+fn issue_json_row(issue: &api::DashboardCheckIssue, profile: &str, include_profile: bool) -> Value {
+    let mut row = serde_json::to_value(issue).unwrap_or_else(|_| json!({}));
+    if include_profile {
+        if let Value::Object(ref mut m) = row {
+            m.insert(
+                JSON_KEY_PROFILE.to_string(),
+                Value::String(profile.to_string()),
+            );
+        }
+    }
+    row
+}
+
+/// Validate a dashboard definition without persisting it
+/// (`DashboardsService.CheckDashboard`).
+///
+/// Exactly one of `from_file` or `dashboard_id` must be supplied:
+/// - `from_file` — path to a JSON file (or `-` for stdin) holding either a
+///   bare dashboard doc or a `{ "dashboard": {...} }` wrapper.
+/// - `dashboard_id` — validate a stored dashboard by id.
+///
+/// Read-only. Exits non-zero if any error-severity issue is found (CI gate).
+/// In multi-profile fan-out, any profile returning error-severity issues
+/// causes a non-zero exit, even if other profiles are clean — this is a
+/// deliberate carve-out from the usual "exit 0 if any profile succeeds" rule,
+/// because `check` is a validation gate first.
+pub async fn run_check(
+    targets: &[Arc<ExecutionTarget>],
+    from_file: Option<&str>,
+    dashboard_id: Option<&str>,
+    output: OutputFormat,
+) -> Result<()> {
+    // Mutually exclusive sources. clap enforces "both" via `conflicts_with`;
+    // we guard "neither" here with a clear message.
+    let body = match (from_file, dashboard_id) {
+        (Some(path), None) => {
+            eprintln!("{}", "Checking dashboard from file...".dimmed());
+            check_body_from_file(path)?
+        }
+        (None, Some(id)) => {
+            if id.trim().is_empty() {
+                bail!("dashboard id cannot be empty");
+            }
+            eprintln!("{}", format!("Checking dashboard {id}...").dimmed());
+            check_body_from_id(id)
+        }
+        (Some(_), Some(_)) => {
+            bail!("`--from-file` and `<dashboard_id>` are mutually exclusive; specify one")
+        }
+        (None, None) => {
+            bail!("specify either `--from-file <path>` or a `<dashboard_id>` to check")
+        }
+    };
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |t| {
+        let body = body.clone();
+        async move {
+            let api = DashboardsApi::new(&t.client);
+            Ok(api.check(&body).await?)
+        }
+    })
+    .await;
+
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
+    let mut all_issues: Vec<(String, Vec<api::DashboardCheckIssue>)> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            Ok(resp) => all_issues.push((profile, resp.issues)),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
+        }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
+    }
+
+    // CI-gate semantics: any error-severity issue (in any profile) fails.
+    let total_errors = all_issues
+        .iter()
+        .flat_map(|(_, issues)| issues.iter())
+        .filter(|i| i.severity.is_failure())
+        .count();
+    let total_issues = all_issues.iter().map(|(_, i)| i.len()).sum::<usize>();
+
+    // Render.
+    match output {
+        OutputFormat::Json => {
+            let mut rows: Vec<Value> = Vec::new();
+            for (profile, issues) in &all_issues {
+                for issue in issues {
+                    rows.push(issue_json_row(issue, profile, include_profile));
+                }
+            }
+            render::render_json(&rows)?;
+        }
+        OutputFormat::Agents => {
+            let mut rows: Vec<Value> = Vec::new();
+            for (profile, issues) in &all_issues {
+                for issue in issues {
+                    rows.push(issue_json_row(issue, profile, include_profile));
+                }
+            }
+            render::render_agents(&rows)?;
+        }
+        OutputFormat::Text => {
+            if total_issues == 0 {
+                println!("{}", "Dashboard is valid (no issues)".green());
+            } else {
+                let mut rows: Vec<Vec<String>> = Vec::new();
+                for (profile, issues) in &all_issues {
+                    for issue in issues {
+                        let mut row = Vec::with_capacity(4);
+                        if include_profile {
+                            row.push(profile.clone());
+                        }
+                        row.push(severity_colored(issue.severity));
+                        row.push(issue.location.clone().unwrap_or_default());
+                        row.push(issue.message.clone().unwrap_or_default());
+                        rows.push(row);
+                    }
+                }
+                render::render_table(&["Severity", "Location", "Message"], rows, include_profile);
+            }
+        }
+    }
+
+    if total_errors > 0 {
+        bail!(
+            "dashboard check found {total_errors} error(s) across profile(s); {} warning(s) ignored",
+            total_issues - total_errors
+        );
     }
     Ok(())
 }

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -1248,9 +1248,7 @@ pub async fn run_check(
                 for (profile, issues) in &all_issues {
                     for issue in issues {
                         let mut row = Vec::with_capacity(4);
-                        if include_profile {
-                            row.push(profile.clone());
-                        }
+                        row.push(profile.clone());
                         row.push(severity_colored(issue.severity));
                         row.push(issue.location.clone().unwrap_or_default());
                         row.push(issue.message.clone().unwrap_or_default());
@@ -1269,4 +1267,55 @@ pub async fn run_check(
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression guard for the `render_table` profile-column contract.
+    ///
+    /// `format_table` strips the first cell of every row when
+    /// `include_profile` is false (single-profile mode). Callers must
+    /// therefore push the profile as the first element unconditionally;
+    /// conditional placement causes the severity column to be dropped and
+    /// the remaining columns to shift left. This test constructs rows the
+    /// same way `run_check` does and asserts the severity text survives
+    /// rendering in single-profile mode.
+    #[test]
+    fn run_check_rows_preserve_severity_in_single_profile_output() {
+        let profile = "mock-profile";
+        let issue = api::DashboardCheckIssue {
+            severity: api::IssueSeverity::SeverityWarning,
+            message: Some("Query uses deprecated function 'timeShift'".to_string()),
+            location: Some("/sections/1/rows/0/widgets/0/queries/0".to_string()),
+        };
+
+        // Mirrors the row construction in `run_check`'s Text branch.
+        let mut row = Vec::with_capacity(4);
+        row.push(profile.to_string());
+        row.push(severity_colored(issue.severity));
+        row.push(issue.location.clone().unwrap_or_default());
+        row.push(issue.message.clone().unwrap_or_default());
+
+        let rendered = render::format_table(
+            &["Severity", "Location", "Message"],
+            vec![row],
+            false, // single-profile mode
+        );
+
+        // Severity text must be present (the bug dropped it via skip(1)).
+        assert!(
+            rendered.contains("SEVERITY_WARNING"),
+            "severity column dropped in single-profile output: {rendered}"
+        );
+        assert!(
+            rendered.contains("/sections/1/rows/0/widgets/0/queries/0"),
+            "location column missing in single-profile output: {rendered}"
+        );
+        assert!(
+            rendered.contains("Query uses deprecated function 'timeShift'"),
+            "message column missing in single-profile output: {rendered}"
+        );
+    }
 }

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -1247,11 +1247,12 @@ pub async fn run_check(
                 let mut rows: Vec<Vec<String>> = Vec::new();
                 for (profile, issues) in &all_issues {
                     for issue in issues {
-                        let mut row = Vec::with_capacity(4);
-                        row.push(profile.clone());
-                        row.push(severity_colored(issue.severity));
-                        row.push(issue.location.clone().unwrap_or_default());
-                        row.push(issue.message.clone().unwrap_or_default());
+                        let row = vec![
+                            profile.clone(),
+                            severity_colored(issue.severity),
+                            issue.location.clone().unwrap_or_default(),
+                            issue.message.clone().unwrap_or_default(),
+                        ];
                         rows.push(row);
                     }
                 }
@@ -1292,11 +1293,12 @@ mod tests {
         };
 
         // Mirrors the row construction in `run_check`'s Text branch.
-        let mut row = Vec::with_capacity(4);
-        row.push(profile.to_string());
-        row.push(severity_colored(issue.severity));
-        row.push(issue.location.clone().unwrap_or_default());
-        row.push(issue.message.clone().unwrap_or_default());
+        let row = vec![
+            profile.to_string(),
+            severity_colored(issue.severity),
+            issue.location.clone().unwrap_or_default(),
+            issue.message.clone().unwrap_or_default(),
+        ];
 
         let rendered = render::format_table(
             &["Severity", "Location", "Message"],

--- a/src/main.rs
+++ b/src/main.rs
@@ -846,6 +846,28 @@ Examples:
         #[arg(long, default_value = "-")]
         from_file: String,
     },
+    /// Validate a dashboard definition without persisting it (CheckDashboard).
+    ///
+    /// Read-only. Exits non-zero if any error-severity issue is found (CI gate).
+    /// In multi-profile fan-out, any profile returning error-severity issues
+    /// causes a non-zero exit, even if other profiles are clean.
+    #[command(after_help = "\
+Examples:
+  cx dashboards check --from-file dash.json
+  cx dashboards check --from-file -            # read from stdin
+  cx dashboards check 01234abcd                 # validate a stored dashboard by id
+  cx -p prod -p staging dashboards check 01234abcd   # multi-profile")]
+    Check {
+        /// Path to a JSON file with the dashboard definition. Use '-' for stdin.
+        /// Accepts either a bare dashboard document or a `{\"dashboard\": {...}}` wrapper.
+        /// Mutually exclusive with <DASHBOARD_ID>.
+        #[arg(long, conflicts_with = "dashboard_id")]
+        from_file: Option<String>,
+
+        /// Validate an existing dashboard by id. Mutually exclusive with --from-file.
+        #[arg(conflicts_with = "from_file")]
+        dashboard_id: Option<String>,
+    },
     /// Delete a dashboard [requires --yes].
     Delete {
         /// Dashboard ID.
@@ -2635,6 +2657,18 @@ async fn main() -> Result<()> {
                 DashboardsCmd::Replace { from_file } => {
                     commands::dashboards::run_replace(
                         &targets, &from_file, output, yes, agent_mode,
+                    )
+                    .await?;
+                }
+                DashboardsCmd::Check {
+                    from_file,
+                    dashboard_id,
+                } => {
+                    commands::dashboards::run_check(
+                        &targets,
+                        from_file.as_deref(),
+                        dashboard_id.as_deref(),
+                        output,
                     )
                     .await?;
                 }

--- a/tests/dashboards/main.rs
+++ b/tests/dashboards/main.rs
@@ -2,12 +2,12 @@
 mod common;
 
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 use coralogix_cli::commands::dashboards::api::DashboardsApi;
 use coralogix_cli::commands::dashboards::{
-    run_catalog, run_delete, run_folders_delete, run_replace,
+    run_catalog, run_check, run_delete, run_folders_delete, run_replace,
 };
 use coralogix_cli::config::OutputFormat;
 
@@ -322,4 +322,236 @@ async fn delete_dashboard_folder_from_mock() {
     run_folders_delete(&targets, "folder-xyz")
         .await
         .expect("run_folders_delete should succeed");
+}
+
+// ── run_check (CheckDashboard) ────────────────────────────────────────────────
+
+/// Path of the CheckDashboard endpoint, as called by `DashboardsApi::check`.
+const CHECK_PATH: &str = "/mgmt/openapi/5/dashboards/check/v1";
+
+/// Minimal valid dashboard JSON used for the `--from-file` check tests.
+/// `read_dashboard_body` requires a `layout` field, so include one.
+fn write_minimal_dashboard() -> std::path::PathBuf {
+    let tmp = std::env::temp_dir().join("cx_test_check_dashboard.json");
+    std::fs::write(
+        &tmp,
+        serde_json::to_string_pretty(&json!({
+            "name": "Test Dashboard",
+            "layout": { "sections": [] }
+        }))
+        .unwrap(),
+    )
+    .unwrap();
+    tmp
+}
+
+/// Verify that `run_check --from-file` prints the green "valid" message and
+/// exits 0 when the mock returns no issues.
+#[tokio::test]
+async fn run_check_from_file_text_output_valid() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(CHECK_PATH))
+        .and(body_partial_json(
+            json!({ "dashboard": { "layout": { "sections": [] } } }),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "issues": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("mock-profile", &server.uri());
+    let targets = vec![target];
+
+    let tmp = write_minimal_dashboard();
+
+    run_check(
+        &targets,
+        Some(tmp.to_str().unwrap()),
+        None,
+        OutputFormat::Text,
+    )
+    .await
+    .expect("run_check with no issues should succeed (exit 0)");
+
+    std::fs::remove_file(&tmp).ok();
+}
+
+/// Verify that `run_check` returns a non-zero error when the mock returns an
+/// error-severity issue (CI-gate semantics).
+#[tokio::test]
+async fn run_check_with_errors_returns_nonzero() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "issues": [
+            {
+                "severity": "SEVERITY_ERROR",
+                "message": "Widget 'cpu-chart' references undefined variable 'env'",
+                "location": "/sections/0/rows/1/widgets/2"
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path(CHECK_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("mock-profile", &server.uri());
+    let targets = vec![target];
+
+    let tmp = write_minimal_dashboard();
+
+    let err = run_check(
+        &targets,
+        Some(tmp.to_str().unwrap()),
+        None,
+        OutputFormat::Text,
+    )
+    .await
+    .expect_err("run_check should fail (non-zero) when SEVERITY_ERROR issues are present");
+
+    assert!(
+        err.to_string().contains("error(s)"),
+        "error should mention errors found: {err}"
+    );
+
+    std::fs::remove_file(&tmp).ok();
+}
+
+/// Verify that `run_check` exits 0 when the mock returns only warning-severity
+/// issues (warnings print but do not fail the CI gate).
+#[tokio::test]
+async fn run_check_with_warnings_exits_zero() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "issues": [
+            {
+                "severity": "SEVERITY_WARNING",
+                "message": "Query uses deprecated function 'timeShift'",
+                "location": "/sections/1/rows/0/widgets/0/queries/0"
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path(CHECK_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("mock-profile", &server.uri());
+    let targets = vec![target];
+
+    let tmp = write_minimal_dashboard();
+
+    run_check(
+        &targets,
+        Some(tmp.to_str().unwrap()),
+        None,
+        OutputFormat::Text,
+    )
+    .await
+    .expect("run_check with only warnings should succeed (exit 0)");
+
+    std::fs::remove_file(&tmp).ok();
+}
+
+/// Verify that `run_check <dashboard_id>` sends the `dashboardId` oneof field
+/// in the request body (not the `dashboard` arm).
+#[tokio::test]
+async fn run_check_by_id_sends_dashboard_id_in_body() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(CHECK_PATH))
+        .and(body_partial_json(json!({ "dashboardId": "dash-abc-123" })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "issues": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("mock-profile", &server.uri());
+    let targets = vec![target];
+
+    run_check(&targets, None, Some("dash-abc-123"), OutputFormat::Text)
+        .await
+        .expect("run_check by id should succeed");
+}
+
+/// Verify that `run_check` renders issues as a JSON array in json output mode.
+#[tokio::test]
+async fn run_check_json_output_succeeds() {
+    let server = MockServer::start().await;
+
+    let body = json!({
+        "issues": [
+            {
+                "severity": "SEVERITY_ERROR",
+                "message": "bad widget",
+                "location": "/sections/0/rows/0/widgets/0"
+            },
+            {
+                "severity": "SEVERITY_WARNING",
+                "message": "deprecated fn",
+                "location": "/sections/1/rows/0/widgets/0/queries/0"
+            }
+        ]
+    });
+
+    Mock::given(method("POST"))
+        .and(path(CHECK_PATH))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("mock-profile", &server.uri());
+    let targets = vec![target];
+
+    let tmp = write_minimal_dashboard();
+
+    // JSON output path runs even when errors are present; the non-zero exit
+    // happens *after* rendering. We assert the render path does not panic and
+    // that the call still returns the expected Err (CI gate).
+    let err = run_check(
+        &targets,
+        Some(tmp.to_str().unwrap()),
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect_err("run_check should fail when SEVERITY_ERROR issues are present");
+
+    assert!(
+        err.to_string().contains("error(s)"),
+        "error should mention errors found: {err}"
+    );
+
+    std::fs::remove_file(&tmp).ok();
+}
+
+/// Verify that `run_check` bails with a clear message when neither
+/// `--from-file` nor `<dashboard_id>` is supplied (the runtime guard that
+/// backs up clap's `conflicts_with`).
+#[tokio::test]
+async fn run_check_neither_source_fails() {
+    let server = MockServer::start().await;
+    let target = common::test_target("mock-profile", &server.uri());
+    let targets = vec![target];
+
+    let err = run_check(&targets, None, None, OutputFormat::Text)
+        .await
+        .expect_err("run_check should fail when no source is supplied");
+
+    assert!(
+        err.to_string().contains("specify either"),
+        "error should direct the user to supply a source: {err}"
+    );
 }

--- a/tests/dashboards/main.rs
+++ b/tests/dashboards/main.rs
@@ -1,6 +1,7 @@
 #[path = "../common/mod.rs"]
 mod common;
 
+use rand::RngExt;
 use serde_json::json;
 use wiremock::matchers::{body_partial_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -331,8 +332,13 @@ const CHECK_PATH: &str = "/mgmt/openapi/5/dashboards/check/v1";
 
 /// Minimal valid dashboard JSON used for the `--from-file` check tests.
 /// `read_dashboard_body` requires a `layout` field, so include one.
+/// Uses a unique filename per call to avoid races when tests run in parallel.
 fn write_minimal_dashboard() -> std::path::PathBuf {
-    let tmp = std::env::temp_dir().join("cx_test_check_dashboard.json");
+    let mut rng = rand::rng();
+    let suffix: String = (0..8)
+        .map(|_| format!("{:02x}", rng.random::<u8>()))
+        .collect();
+    let tmp = std::env::temp_dir().join(format!("cx_test_check_dashboard_{suffix}.json"));
     std::fs::write(
         &tmp,
         serde_json::to_string_pretty(&json!({

--- a/tests/e2e/dashboards/mod.rs
+++ b/tests/e2e/dashboards/mod.rs
@@ -220,3 +220,81 @@ fn dashboards_search_exits_ok() {
         "dashboards search should exit 0 even with empty results"
     );
 }
+
+#[test]
+#[ignore]
+fn dashboards_check_valid_dashboard_exits_ok() {
+    if harness::require_creds("dashboards_check_valid_dashboard_exits_ok").is_none() {
+        return;
+    }
+    let Some(id) = discover_dashboard_id() else {
+        eprintln!(
+            "[e2e] skipping dashboards_check_valid_dashboard_exits_ok: no dashboards available on test team"
+        );
+        return;
+    };
+    // POST /mgmt/openapi/5/dashboards/check/v1 with { "dashboardId": <id> }.
+    // A real dashboard must validate cleanly (no error-severity issues), so
+    // the command must exit 0. JSON output is an array of issue rows; an
+    // empty array is the valid-dashboard case.
+    let v = harness::run_ok_json(&["dashboards", "check", &id, "-o", "json"]);
+    harness::assert_array(&v);
+}
+
+#[test]
+#[ignore]
+fn dashboards_check_from_file_round_trip() {
+    if harness::require_creds("dashboards_check_from_file_round_trip").is_none() {
+        return;
+    }
+    let Some(id) = discover_dashboard_id() else {
+        eprintln!(
+            "[e2e] skipping dashboards_check_from_file_round_trip: no dashboards available on test team"
+        );
+        return;
+    };
+
+    // 1. Get the existing dashboard as JSON.
+    let original = harness::run_ok_json(&["dashboards", "get", &id, "-o", "json"]);
+
+    // Extract the inner dashboard object (may be top-level or nested),
+    // mirroring dashboards_replace_round_trip.
+    let dashboard = if original.get("dashboard").is_some() {
+        original.get("dashboard").unwrap().clone()
+    } else {
+        original.clone()
+    };
+
+    // 2. Write it to a temp file and validate it with `check --from-file`.
+    // Read-only — no mutation of test-team state.
+    let tmp = std::env::temp_dir().join("cx_e2e_check_dashboard.json");
+    std::fs::write(&tmp, serde_json::to_string_pretty(&dashboard).unwrap())
+        .expect("write temp file");
+
+    let output = harness::cx()
+        .args([
+            "dashboards",
+            "check",
+            "--from-file",
+            tmp.to_str().unwrap(),
+            "-o",
+            "json",
+        ])
+        .output()
+        .expect("failed to execute cx");
+
+    std::fs::remove_file(&tmp).ok();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Checking dashboard from file"),
+        "expected 'Checking dashboard from file' on stderr, got: {stderr}"
+    );
+
+    // A real dashboard should validate cleanly (no error-severity issues),
+    // so the command must exit 0.
+    assert!(
+        output.status.success(),
+        "dashboards check --from-file should exit 0 for a valid dashboard, stderr: {stderr}"
+    );
+}


### PR DESCRIPTION
## Context
Adds `cx dashboards check`, a read-only subcommand that validates a dashboard definition against the Coralogix Dashboard Service's strict validator (`CheckDashboard`) without persisting it. This lets users and AI agents lint a dashboard JSON before `create`/`replace`, or re-validate an existing stored dashboard by id. Backed by [CX-47295](https://coralogix.atlassian.net/browse/CX-47295); the backend RPC already exists in eng-svc-dashboards-api (cx-api-dashboards v2.9.1).

## Linked Issues
- Jira: [CX-47295](https://coralogix.atlassian.net/browse/CX-47295) — cx-cli: add `dashboards check` command to validate dashboard definitions via CheckDashboard
- Related: CX-47080 (CheckDashboard wiring for cx-extensions — used as precedent for the proto/gateway REST path)

## Design
Standard REST archetype (Archetype B), mirroring `DataArchiveMetricsCmd::Validate` as the only existing validate-style subcommand in the repo.

- **Endpoint (confirmed from `cx-management-apis` proto):** `POST /mgmt/openapi/5/dashboards/check/v1`. The proto `google.api.http` annotation is `POST /dashboards/check/v1`; the management gateway maps the `/dashboards` prefix to `/mgmt/openapi/5/dashboards` (same mapping as the existing `DASHBOARDS_BASE`). Permission: `team-dashboards:Read` (read-only).
- **Request oneof:** `CheckDashboardRequest` has a `source` oneof — `{ "dashboard": {...} }` for an inline definition or `{ "dashboardId": "<id>" }` for a stored dashboard. Reuses the existing `read_dashboard_body()` helper for the `--from-file` path (normalizes bare docs and `{ "dashboard": {...} }` wrappers, validates `layout` is present).
- **Response:** `CheckDashboardResponse { issues: Vec<Issue> }` where `Issue { severity, message, location }`. `severity` is an enum (`SEVERITY_ERROR` / `SEVERITY_WARNING` / `SEVERITY_UNSPECIFIED`) serialized as SCREAMING_SNAKE_CASE per protobuf-JSON convention. `location` is an RFC 6901 JSON Pointer. Empty `issues` == valid.
- **Three layers as per contributing/adding-a-command.md:**
  1. `api.rs` — response types + `DashboardsApi::check()` + deserialization unit tests
  2. `mod.rs` — `run_check()` with fan-out/merge/render + helpers
  3. `main.rs` — `DashboardsCmd::Check` variant + dispatch arm
- **Skill integration:** `cx-dashboards` skill updated with a new Phase 7 (server-side validation) inserted between Phase 6 (self-verify) and the deploy phase. Agents run `cx dashboards check --from-file <draft>` as a pre-flight gate; on issues, loop back to Phase 4 (regenerate JSON) → Phase 5 (re-verify queries) → Phase 7 again.

## Key Decisions
- **Exit-code semantics: non-zero only on `SEVERITY_ERROR`.** The server today only emits `SEVERITY_ERROR`, but the proto reserves `SEVERITY_WARNING`. `SeverityUnspecified` is conservatively treated as a failure (it's the proto default and should never appear in real output). Warnings print but exit 0. Implemented via `IssueSeverity::is_failure()`.
- **Multi-profile carve-out:** `check` exits non-zero if **any** profile returns error-severity issues, even if other profiles are clean. This deliberately breaks from the repo's "exit 0 if any profile succeeds" convention (`docs/multi-profile.md`) because `check` is a validation gate first. Per scope decision, the carve-out is documented **locally** (command `--help`, `run_check` doc comment, and the skill) rather than in `docs/multi-profile.md`, keeping the PR within domain-team + cxai review (no tech-writers needed).
- **`from_file` has no default** (unlike `Create`/`Replace` which default to `-`). With a `-` default, `cx dashboards check` with no args would hang reading stdin; the explicit `Option<String>` + runtime guard produces a clear "specify either `--from-file` or a `<dashboard_id>`" error instead.
- **Loop-back target on issues is Phase 4** (regenerate JSON), not Phase 5. Some strict issues are structural (missing variable/filter ids), not query-syntax — Phase 4 is the conservative default; after regenerating, Phase 5 re-verifies changed queries, then back to Phase 7.
- **`--strict-check` flag on `create`/`replace` deferred.** Part 2 of the ticket (opt-in pre-flight flag on writes) was scoped out of this PR per explicit decision; the standalone `check` subcommand covers the lint-before-create use case on its own.

## Changes
- **New subcommand:** `cx dashboards check`
  - `cx dashboards check --from-file <path|->` — validate an inline definition (reuses `read_dashboard_body` normalization; accepts bare doc or `{ "dashboard": {...} }` wrapper).
  - `cx dashboards check <dashboard-id>` — validate a stored dashboard by id.
  - Mutually exclusive sources via clap `conflicts_with` + runtime guard for the neither-supplied case.
  - Read-only — no `confirm_destructive`, not blocked by read-only mode.
- **New output rendering for issues:** text (table `Severity | Location | Message` with colored severities; green `Dashboard is valid (no issues)` on empty), json (flat issue array with `profile` key when multi-profile), agents (TOON-encoded same shape).
- **New API client method:** `DashboardsApi::check()` → `POST /mgmt/openapi/5/dashboards/check/v1`.
- **Skill workflow change:** `cx-dashboards` skill phases renumbered — inserted Phase 7 (server-side validation), existing Phase 7 → 8 (Deploy), Phase 8 → 9 (Share link). Stale phase references in `references/deploy.md` and `references/verification.md` updated to match.

## Testing
All run on this branch:
- `cargo fmt --check` — clean
- `cargo clippy --all-targets` — no warnings (fixed one `bool_comparison` in a unit test)
- `cargo test --lib` — **404 passed**, 0 failed, 9 ignored (includes 5 new unit tests in `dashboards/api.rs`)
- `cargo test --test dashboards` — **14 passed** (8 existing + 6 new wiremock integration tests)
- `cargo build` — succeeds
- `cx schema` — verified `check` present with `from_file` + `dashboard_id` args
- `cx dashboards check --help` — renders correctly with examples + carve-out note
- `cx dashboards --help` — `check` listed between `replace` and `delete`
- `scripts/verify-skills.sh` — 14/14 passed
- `cargo test --test e2e -- --ignored dashboards_check` — 2 passed (graceful skip without `CX_API_KEY`); not run against the real test team in this PR (CI workflow will run them)
- Manual: `cx dashboards check` (no args) → clear error exit 1; `cx dashboards check --from-file foo <id>` (both args) → clap conflict error

## Risks & Rollout
- **Backwards compatible.** New subcommand only; no changes to existing `catalog`/`get`/`create`/`replace`/`delete`/`search`/`query-search`/`folders` behavior. Default behavior of `create`/`replace` is unchanged (the deferred `--strict-check` flag would have been the only write-path change, and it's not in this PR).
- **Endpoint path inferred from proto annotation.** `POST /mgmt/openapi/5/dashboards/check/v1` is derived from the proto `google.api.http` option + the established gateway prefix mapping. The e2e tests against the real test team will confirm the path resolves correctly; if it 404s, only the e2e tests fail (the subcommand is read-only and the integration tests mock the path, so there's no risk to existing flows).
- **Skill workflow change is low-risk** — adds one checkpoint between self-verify and deploy; agents that skip it just go straight to deploy (no regression, just a missed pre-flight).
- **Rollback:** revert the 7 commits; no migration, no config change, no data change.

## Out of Scope / Follow-ups
- **`--strict-check` flag on `cx dashboards create`/`replace`** — Part 2 of CX-47295. Opt-in pre-flight validation before writes; off by default to preserve current behavior. Will be a separate PR.
- **`--request-id` flag on `check** — the proto supports an optional idempotency key; not exposed in this PR. Can be added if needed.
- **E2E against real test team** — the 2 `#[ignore]`d e2e tests skip gracefully without `CX_API_KEY`; CI's e2e workflow (`.github/workflows/e2e.yml`) will run them on merge to master.

[CX-47295]: https://coralogix.atlassian.net/browse/CX-47295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-47295]: https://coralogix.atlassian.net/browse/CX-47295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ