### PR TITLE
FORGE-244: align cases skill and add query rule validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -378,6 +378,7 @@ dependencies = [
  "keyring",
  "open",
  "rand",
+ "regex",
  "reqwest",
  "rustls",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ terminal_size = "0.4"
 chrono = { version = "0.4", features = ["serde"] }
 humantime = "2"
 
+# Regex (cases query rule validation)
+regex = "1"
+
 # URL building
 url = "2"
 

--- a/skills/cx-cases/references/case-analytics.md
+++ b/skills/cx-cases/references/case-analytics.md
@@ -91,8 +91,12 @@ A single events dataset that captures every state-change emitted by the Cases se
           "alertType": "METRIC_THRESHOLD",
           "priority": "P4",
           "groupingType": "COMBINATION_ALERT",
-          "groupings": { "service": "payment-api", "region": "us-west-2" },
-          "permutations": {},
+          "permutations": [
+            [
+              { "key": "coralogix.metadata.applicationName", "value": "monitoring24",       "permutationIndex": 0 },
+              { "key": "coralogix.metadata.subsystemName",   "value": "no_subsystem_name", "permutationIndex": 0 }
+            ]
+          ],
           "labels": { "metric": "cpu", "team": "platform" },
           "state": "TRIGGERED",
           "isNoData": false,
@@ -105,10 +109,12 @@ A single events dataset that captures every state-change emitted by the Cases se
         }
       ]
     },
-    "groupings": {
-      "service": ["payment-api"],
-      "region":  ["us-west-2"]
-    },
+    "permutations": [
+      [
+        { "key": "coralogix.metadata.applicationName", "value": "monitoring24",       "permutationIndex": 0 },
+        { "key": "coralogix.metadata.subsystemName",   "value": "no_subsystem_name", "permutationIndex": 0 }
+      ]
+    ],
     "labels": {
       "metric":          ["cpu"],
       "team":            ["platform"],
@@ -121,7 +127,7 @@ A single events dataset that captures every state-change emitted by the Cases se
       { "type": "pagerduty" },
       { "type": "email" }
     ],
-    "aiSummary": "CPU saturation on payment-api in us-west-2 cleared after autoscaler added two pods.",
+    "aiSummary": "CPU saturation on monitoring24 cleared after autoscaler added two pods.",
     "impactedEntities": [
       { "kind": "apmService",  "name": "payment-api", "language": "go" },
       { "kind": "apmDatabase", "name": "orders_db",   "system": "postgresql", "source": "db.name" }
@@ -185,15 +191,19 @@ Per-element fields:
 | `alertDefinitionId` / `alertVersionId` | Stable IDs. Useful for joining with alert-side data via the `alerts` skill / `get_alerts_object`. |
 | `priority` | Alert priority at trigger (independent of case priority). |
 | `groupingType` | `STANDARD` / `COMPOSITE_ALERT` / `COMBINATION_ALERT`. The latter two mean the indicator combines multiple sub-conditions. |
+| `permutations` | Per-indicator permutations list — same `[[{key, value, permutationIndex}]]` structure as the root field. Contains the actual observed label combinations that fired this indicator. |
 | `state` | `TRIGGERED` (still firing) / `RESOLVED` / `NO_DATA` (signal dropped, **not** a recovery) / `MUTED`. |
 | `triggeredAt` / `resolvedAt` | Indicator-side timing (different from case-level resolution). |
 
-#### Groupings & labels (routing / attribution)
+#### Permutations & labels (routing / attribution)
 
-Both `groupings` and `labels` are `{ key: string[] }`
+`permutations` — the actual observed label combinations that produced this case. Each element of `permutations` is a **permutation-group**: a list of `{key, value, permutationIndex}` objects representing one real co-occurring set of key/value pairs.
 
-- `groupings` — the dimensions used to group the case (e.g. `service`, `region`, `cluster`).
-- `labels` — free-form labels. The `routing.*` prefix is the convention for routing config:
+- Exists at two levels:
+  - **Per-indicator** (`indicators.alerts[].permutations`): the combinations that fired a specific alert indicator.
+  - **Root/case level** (`permutations`): a merged view across all indicators for the whole case.
+
+`labels` — free-form labels. The `routing.*` prefix is the convention for routing config:
   - `routing.team` — owner team (use this for "MTTR per team" style queries).
   - `routing.environment` — env (`prod`, `staging`, …).
   - `routing.service` — service tag.
@@ -248,8 +258,6 @@ After this, the full row stays at top level (`status`, `priority`, `createdAt`, 
 
 The two patterns are interchangeable; pick whichever keeps the rest of the pipeline shortest.
 
-**Exceptions** — you may skip dedup only when you are *intentionally* counting events (not cases), e.g. "how many `caseResolved` triggers fired"; in that case `filter metadata.trigger == 'caseResolved' | distinct caseId | count` is still the correct shape because `distinct caseId` is the dedup.
-
 ### Rule 3 — When asking about a one-time lifecycle event, filter on `metadata.trigger`
 
 Most questions about a single lifecycle moment (activation, resolution, closure, …) read better as a trigger filter than as dedup-then-filter. The trigger filter naturally excludes heartbeats *and* keeps the query simple:
@@ -268,6 +276,17 @@ This works because most lifecycle triggers fire **once per case** in the normal 
 | Heartbeat | Periodic | **Never** use as a lifecycle event; filter out or use Rule 2 dedup. |
 
 **When in doubt, ask:** am I counting **events of a kind** or **cases in a state**? Events of a kind → Rule 3 (trigger filter). Cases in a state → Rule 2 (dedup to latest row).
+
+### Dedup comes first
+
+**Always dedup before you do anything else** (bucket, explode, aggregate). Because heartbeats repeat the full event payload — including nested arrays like `kpiBreaches.breachedKpis` and `indicators.alerts` — any operation on raw events inflates row counts by the number of heartbeats per case. This causes double-counting and can OOM on large windows.
+
+The only exception is a trigger-filtered query (Rule 3), where `filter metadata.trigger == '...'` already excludes heartbeats.
+
+Do not be clever or try to do it in one pass: the first command after `source` is the per-case dedup keyed on `caseId` alone, then add buckets, explodes, filters, and a separate final `groupby`.
+
+- Don't fold a bucket into the dedup key: `| groupby day, caseId aggregate ...`. Dedup on `caseId` alone first, then bucket off `latest`/`last_seen`.
+- Don't rely on `caseId` inside an aggregate without dedup: `| groupby kpiType, breachStatus aggregate distinct_count(caseId)` still scans heartbeats; dedup first.
 
 ## Query examples
 
@@ -383,6 +402,26 @@ source system/labs.cases.state_updates
   | limit 1000
 ```
 
+### Week-over-week comparison
+
+Compare case or alert volume between two periods. Dedup per `caseId` across the full window first, then assign the period bucket from `last_seen` (see Rule 2). 
+
+```dataprime
+source system/labs.cases.state_updates
+  | groupby caseId aggregate
+      max_by($m.timestamp, $d) as latest,
+      max($m.timestamp) as last_seen
+  | create period from if(last_seen >= now() - 7d, 'this_week', 'last_week')
+  | explode latest.indicators.alerts into alert original preserve
+  | filter alert.state == 'TRIGGERED'
+  | groupby period aggregate distinct_count(caseId) as triggering_cases
+```
+
+Notes:
+- `max($m.timestamp) as last_seen` captures when the case was last seen in the window; this drives period assignment.
+- For open-case counts instead of triggered alerts, replace the `explode` + `filter alert.state` lines with `| filter latest.status == 'ACTIVE' | groupby period aggregate count() as active_cases`.
+- Adjust the split offset (`7d`) to match the user's intent — e.g. `30d` for month-over-month.
+
 ### MTTR / MTTA / MTBI per team
 
 Per-team KPIs, dedup-then-explode pattern. The `labels['routing.team']` label drives team attribution; missing values bucket as `unassigned`. Default window `last 14d` — adjust to the user's intent:
@@ -420,6 +459,79 @@ source system/labs.cases.state_updates
   | dedupeby id
 ```
 
+### Filtering / aggregating by permutations
+
+#### 1. Discover permutation keys and their values
+
+```dataprime
+source system/labs.cases.state_updates
+| dedupeby $d.caseId orderby $m.timestamp desc
+| explode permutations into perm original preserve
+| explode perm into kv original preserve
+| filter kv.key != null
+| create k from kv.key
+| create v from kv.value
+| groupby k, v aggregate count() as pair_count
+| groupby k aggregate collect(v) as values, count() as distinct_value_count
+| orderby distinct_value_count desc
+```
+
+Then filter cases by the matching key/value using the patterns below. Some keys (e.g. geo/city) have hundreds of values — add `| filter k ~ '<key-substr>'` before the final `groupby` to scope discovery to one dimension.
+
+#### 2. Filter by a single key/value pair
+
+```dataprime
+source system/labs.cases.state_updates
+| dedupeby $d.caseId orderby $m.timestamp desc
+| explode permutations into perm original preserve
+| explode perm into kv original preserve
+| filter kv.key ~ 'subsystemName' && kv.value == 'incident-helper'
+| dedupeby $d.caseId
+```
+
+#### 3. Filter by multiple key/value pairs that must co-occur in the same permutation
+
+Dataprime can't express "N conditions in the same exploded group" in one pass. Workaround: group on `permutationIndex` and use `count_if` per condition.
+
+**Recommended — `inArray` subquery** (keeps full `$d` access on the outer query; no per-field `any_value` re-export needed; avoids OOM from re-exporting the whole `$d`):
+
+```dataprime
+source system/labs.cases.state_updates
+| filter $d.caseId.inArray((|
+  source system/labs.cases.state_updates
+  | dedupeby $d.caseId orderby $m.timestamp desc
+  | explode permutations into perm original preserve
+  | explode perm into kv original preserve
+  | groupby $d.caseId, kv.permutationIndex aggregate
+    count_if(kv.key ~ 'applicationName' && kv.value == 'cx10') as application_name_hit,
+    count_if(kv.key ~ 'subsystemName' && kv.value == 'incident-helper') as subsystem_name_hit
+  | filter application_name_hit > 0 && subsystem_name_hit > 0
+  | distinct $d.caseId
+|))
+| dedupeby $d.caseId
+```
+
+**Fallback — `groupby` + `any_value`** (use when you need only a few specific fields in the output; re-export each field you need via `any_value(...)`; do not re-export the whole `$d` — that OOMs):
+
+```dataprime
+source system/labs.cases.state_updates
+| dedupeby $d.caseId orderby $m.timestamp desc
+| explode permutations into perm original preserve
+| explode perm into kv original preserve
+| groupby $d.caseId, kv.permutationIndex aggregate
+    count_if(kv.key ~ 'applicationName' && kv.value == 'cx10') as application_name_hit,
+    count_if(kv.key ~ 'subsystemName' && kv.value == 'incident-helper') as subsystem_name_hit,
+    any_value($d.caseId)     as case_id,
+    any_value($d.caseNumber) as case_number,
+    any_value($d.title)      as title,
+    any_value($d.status)     as status,
+    any_value($d.caseUrl)    as case_url,
+    any_value($m.timestamp)  as timestamp
+    // any_value(...) needed for every field you want to re-export/show
+| filter application_name_hit > 0 && subsystem_name_hit > 0
+| dedupeby case_id
+```
+
 ## Best Practices
 - See the query examples for default queries to base off for user questions.
 - When building a query, **ALWAYS** follow the **Hard Rules**
@@ -429,5 +541,7 @@ source system/labs.cases.state_updates
   1. Source the dataset: `source system/labs.cases.state_updates` with a time
   2. Filter to the events you care about (e.g. `filter metadata.trigger == 'caseResolved'` for resolution analytics, or no trigger filter when you want the latest state of every case).
   3. Dedup per `caseId` if you're answering a "cases" question (Pattern A or B).
-  4. Explode any array you need to fan out over (`indicators.alerts`, `kpiBreaches.breachedKpis`, `labels['routing.<key>']`, `impactedEntities`).
+  4. Explode any array you need to fan out over (`indicators.alerts`, `kpiBreaches.breachedKpis`, `labels['routing.<key>']`, `impactedEntities`, or double-explode `permutations` → `perm` → `kv`).
   5. Aggregate / project / order / limit.
+- A user's term (a service, country, application, etc.) may be a permutation key or value. When a user asks about such a term, *always* first check if it's a group by key or value using the "Discover permutation keys and their values" example.
+- Hard rules: Dedup always precedes bucketing, period assignment, and derived field creation. Any `create`, `groupby`, or `explode` on raw events before dedup operates on heartbeat-inflated rows and produces wrong results. For example, in a week-over-week comparison: dedup across the full window first and derive `last_seen` from the dedup step, then assign the period bucket from `last_seen` — never use `create period from if($m.timestamp ...)` on raw events, and never use `$m.timestamp` directly for period assignment.

--- a/src/cases_query_rules.rs
+++ b/src/cases_query_rules.rs
@@ -10,6 +10,12 @@ pub const CASES_DATASET_SOURCE: &str = "system/labs.cases.state_updates";
 
 const MIN_CASES_WINDOW_SECS: i64 = 3600;
 
+static INLINE_SOURCE_RE: LazyLock<Regex> = LazyLock::new(|| {
+    // Matches the DataPrime `source <dataset>` command at the start of a query
+    // or immediately after a pipe `|`, capturing the dataset name.
+    Regex::new(r"(?i)(?:^|\|)\s*source\s+([\w/\.]+)").unwrap()
+});
+
 static CASES_SAFE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
     let case_id_ref = r"(?:\$d\.|userdata\.)?caseid";
     vec![
@@ -36,7 +42,16 @@ pub fn check_cases_query_rules(
     start_ts: &str,
     end_ts: &str,
 ) -> Option<String> {
-    if source != CASES_DATASET_SOURCE {
+    let effective_source = if source == CASES_DATASET_SOURCE {
+        source.to_string()
+    } else {
+        INLINE_SOURCE_RE
+            .captures(query)
+            .and_then(|c| c.get(1))
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default()
+    };
+    if effective_source != CASES_DATASET_SOURCE {
         return None;
     }
 
@@ -89,6 +104,21 @@ mod tests {
     #[test]
     fn non_cases_source_returns_none() {
         assert!(check_cases_query_rules("logs", "source logs | count", START, END).is_none());
+        assert!(check_cases_query_rules("", "source logs | count", START, END).is_none());
+    }
+
+    #[test]
+    fn inline_source_in_query_triggers_rules() {
+        let end = "2024-01-01T00:30:00.000Z";
+        let warning = check_cases_query_rules(
+            "",
+            "source system/labs.cases.state_updates | count",
+            START,
+            end,
+        )
+        .unwrap();
+        assert!(warning.contains("Rule 1"));
+        assert!(warning.contains("Rule 2/3"));
     }
 
     #[test]

--- a/src/cases_query_rules.rs
+++ b/src/cases_query_rules.rs
@@ -1,0 +1,134 @@
+//! Hard-rule validation for fleet case analytics DataPrime queries.
+//!
+//! Port of olly's `cases_query_rules.py`.
+
+use chrono::{DateTime, Utc};
+use regex::Regex;
+use std::sync::LazyLock;
+
+pub const CASES_DATASET_SOURCE: &str = "system/labs.cases.state_updates";
+
+const MIN_CASES_WINDOW_SECS: i64 = 3600;
+
+static CASES_SAFE_PATTERNS: LazyLock<Vec<Regex>> = LazyLock::new(|| {
+    let case_id_ref = r"(?:\$d\.|userdata\.)?caseid";
+    vec![
+        Regex::new(&format!(r"(?i)\bgroupby\s+{case_id_ref}\b")).unwrap(),
+        Regex::new(&format!(r"(?i)\bdedupeby\s+{case_id_ref}\b")).unwrap(),
+        Regex::new(&format!(r"(?i)\bdistinct\s+{case_id_ref}\b")).unwrap(),
+        Regex::new(r"(?i)\bfilter\b[^|]*\bmetadata\.trigger\b").unwrap(),
+    ]
+});
+
+/// Parse an API-formatted timestamp (`2006-01-02T15:04:05.000Z`) into UTC.
+fn parse_api_timestamp(ts: &str) -> Option<DateTime<Utc>> {
+    DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+/// Check hard rules for queries against `system/labs.cases.state_updates`.
+///
+/// Returns an actionable warning string, or `None` when everything looks fine.
+pub fn check_cases_query_rules(
+    source: &str,
+    query: &str,
+    start_ts: &str,
+    end_ts: &str,
+) -> Option<String> {
+    if source != CASES_DATASET_SOURCE {
+        return None;
+    }
+
+    let mut violations: Vec<&str> = Vec::new();
+
+    // Rule 1 — minimum 1h window
+    if let (Some(start), Some(end)) = (parse_api_timestamp(start_ts), parse_api_timestamp(end_ts)) {
+        let window_secs = (end - start).num_seconds();
+        if window_secs < MIN_CASES_WINDOW_SECS {
+            violations.push(
+                "Rule 1 (time range): the time window is shorter than the 1h minimum \
+                 required for `system/labs.cases.state_updates`. \
+                 Widen the window to at least `1h`.",
+            );
+        }
+    }
+
+    // Rule 2/3 — per-case dedup or lifecycle-trigger filter
+    if !CASES_SAFE_PATTERNS.iter().any(|re| re.is_match(query)) {
+        violations.push(
+            "Rule 2/3 (dedup): no per-case dedup or lifecycle trigger filter detected. \
+             Add one of: \
+             `| dedupeby caseId orderby $m.timestamp desc`, \
+             `| groupby caseId aggregate ...`, \
+             `| distinct caseId`, \
+             or `| filter metadata.trigger == '...'`.",
+        );
+    }
+
+    if violations.is_empty() {
+        return None;
+    }
+
+    let mut lines = vec!["\n\n> **[Cases query warning]** This query targets \
+         `system/labs.cases.state_updates` but may violate hard rules:"
+        .to_string()];
+    for violation in violations {
+        lines.push(format!("> - {violation}"));
+    }
+    Some(lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const START: &str = "2024-01-01T00:00:00.000Z";
+    const END: &str = "2024-01-01T02:00:00.000Z";
+
+    #[test]
+    fn non_cases_source_returns_none() {
+        assert!(check_cases_query_rules("logs", "source logs | count", START, END).is_none());
+    }
+
+    #[test]
+    fn short_window_triggers_rule1() {
+        let end = "2024-01-01T00:30:00.000Z";
+        let warning = check_cases_query_rules(CASES_DATASET_SOURCE, "| count", START, end).unwrap();
+        assert!(warning.contains("Rule 1"));
+    }
+
+    #[test]
+    fn missing_dedup_triggers_rule2() {
+        let warning = check_cases_query_rules(
+            CASES_DATASET_SOURCE,
+            "source system/labs.cases.state_updates | count",
+            START,
+            END,
+        )
+        .unwrap();
+        assert!(warning.contains("Rule 2/3"));
+    }
+
+    #[test]
+    fn dedupeby_caseid_is_safe() {
+        assert!(check_cases_query_rules(
+            CASES_DATASET_SOURCE,
+            "| dedupeby caseId orderby $m.timestamp desc",
+            START,
+            END
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn trigger_filter_is_safe() {
+        assert!(check_cases_query_rules(
+            CASES_DATASET_SOURCE,
+            "| filter metadata.trigger == 'caseResolved'",
+            START,
+            END
+        )
+        .is_none());
+    }
+}

--- a/src/cases_query_rules.rs
+++ b/src/cases_query_rules.rs
@@ -36,22 +36,15 @@ fn parse_api_timestamp(ts: &str) -> Option<DateTime<Utc>> {
 /// Check hard rules for queries against `system/labs.cases.state_updates`.
 ///
 /// Returns an actionable warning string, or `None` when everything looks fine.
-pub fn check_cases_query_rules(
-    source: &str,
-    query: &str,
-    start_ts: &str,
-    end_ts: &str,
-) -> Option<String> {
-    let effective_source = if source == CASES_DATASET_SOURCE {
-        source.to_string()
-    } else {
-        INLINE_SOURCE_RE
-            .captures(query)
-            .and_then(|c| c.get(1))
-            .map(|m| m.as_str().to_string())
-            .unwrap_or_default()
-    };
-    if effective_source != CASES_DATASET_SOURCE {
+///
+/// Only inspects inline `source` in the query text — not the CLI `--source` flag,
+/// which can disagree with what the query actually executes.
+pub fn check_cases_query_rules(query: &str, start_ts: &str, end_ts: &str) -> Option<String> {
+    let effective_source = INLINE_SOURCE_RE
+        .captures(query)
+        .and_then(|c| c.get(1))
+        .map(|m| m.as_str());
+    if effective_source != Some(CASES_DATASET_SOURCE) {
         return None;
     }
 
@@ -103,20 +96,15 @@ mod tests {
 
     #[test]
     fn non_cases_source_returns_none() {
-        assert!(check_cases_query_rules("logs", "source logs | count", START, END).is_none());
-        assert!(check_cases_query_rules("", "source logs | count", START, END).is_none());
+        assert!(check_cases_query_rules("source logs | count", START, END).is_none());
     }
 
     #[test]
     fn inline_source_in_query_triggers_rules() {
         let end = "2024-01-01T00:30:00.000Z";
-        let warning = check_cases_query_rules(
-            "",
-            "source system/labs.cases.state_updates | count",
-            START,
-            end,
-        )
-        .unwrap();
+        let warning =
+            check_cases_query_rules("source system/labs.cases.state_updates | count", START, end)
+                .unwrap();
         assert!(warning.contains("Rule 1"));
         assert!(warning.contains("Rule 2/3"));
     }
@@ -124,27 +112,24 @@ mod tests {
     #[test]
     fn short_window_triggers_rule1() {
         let end = "2024-01-01T00:30:00.000Z";
-        let warning = check_cases_query_rules(CASES_DATASET_SOURCE, "| count", START, end).unwrap();
+        let warning =
+            check_cases_query_rules("source system/labs.cases.state_updates | count", START, end)
+                .unwrap();
         assert!(warning.contains("Rule 1"));
     }
 
     #[test]
     fn missing_dedup_triggers_rule2() {
-        let warning = check_cases_query_rules(
-            CASES_DATASET_SOURCE,
-            "source system/labs.cases.state_updates | count",
-            START,
-            END,
-        )
-        .unwrap();
+        let warning =
+            check_cases_query_rules("source system/labs.cases.state_updates | count", START, END)
+                .unwrap();
         assert!(warning.contains("Rule 2/3"));
     }
 
     #[test]
     fn dedupeby_caseid_is_safe() {
         assert!(check_cases_query_rules(
-            CASES_DATASET_SOURCE,
-            "| dedupeby caseId orderby $m.timestamp desc",
+            "source system/labs.cases.state_updates | dedupeby caseId orderby $m.timestamp desc",
             START,
             END
         )
@@ -154,8 +139,7 @@ mod tests {
     #[test]
     fn trigger_filter_is_safe() {
         assert!(check_cases_query_rules(
-            CASES_DATASET_SOURCE,
-            "| filter metadata.trigger == 'caseResolved'",
+            "source system/labs.cases.state_updates | filter metadata.trigger == 'caseResolved'",
             START,
             END
         )

--- a/src/commands/dataprime/mod.rs
+++ b/src/commands/dataprime/mod.rs
@@ -312,12 +312,7 @@ pub fn merge_results(
                 }
             }
             Err(e) => {
-                let msg = if let Some(w) = cases_warning {
-                    format!("{w}\n\nerror from profile '{profile}': {e:#}")
-                } else {
-                    format!("error from profile '{profile}': {e:#}")
-                };
-                eprintln!("{}", msg.red());
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
             }
         }
     }
@@ -406,7 +401,7 @@ pub async fn run_query(
 
     let start_fmt = parse_timestamp(start)?;
     let end_fmt = parse_timestamp(end)?;
-    let cases_warning = check_cases_query_rules(source, query, &start_fmt, &end_fmt);
+    let cases_warning = check_cases_query_rules(query, &start_fmt, &end_fmt);
 
     let include_profile = targets.len() > 1;
     let query = query.to_string();
@@ -583,19 +578,15 @@ category: ["Commands reference", "test"]
 
     // ── check_cases_query_rules integration via merge_results ────────────────
 
-    use crate::cases_query_rules::{check_cases_query_rules, CASES_DATASET_SOURCE};
+    use crate::cases_query_rules::check_cases_query_rules;
 
     const CASES_START: &str = "2024-01-01T00:00:00.000Z";
     const CASES_END: &str = "2024-01-01T02:00:00.000Z";
+    const CASES_QUERY: &str = "source system/labs.cases.state_updates | count";
 
     #[test]
     fn cases_warning_prepended_to_merged_warnings() {
-        let warning = check_cases_query_rules(
-            CASES_DATASET_SOURCE,
-            "source system/labs.cases.state_updates | count",
-            CASES_START,
-            CASES_END,
-        );
+        let warning = check_cases_query_rules(CASES_QUERY, CASES_START, CASES_END);
         assert!(
             warning.is_some(),
             "expected a warning from check_cases_query_rules"
@@ -616,8 +607,7 @@ category: ["Commands reference", "test"]
 
     #[test]
     fn cases_warning_plus_profile_warning_both_appear() {
-        let cases_warn =
-            check_cases_query_rules(CASES_DATASET_SOURCE, "| count", CASES_START, CASES_END);
+        let cases_warn = check_cases_query_rules(CASES_QUERY, CASES_START, CASES_END);
         assert!(cases_warn.is_some());
 
         let mut resp = make_generic_response(vec![], false);
@@ -636,15 +626,13 @@ category: ["Commands reference", "test"]
     }
 
     #[test]
-    fn cases_warning_prepended_to_profile_error_message() {
-        let cases_warn =
-            check_cases_query_rules(CASES_DATASET_SOURCE, "| count", CASES_START, CASES_END);
+    fn cases_warning_present_when_profile_errors() {
+        let cases_warn = check_cases_query_rules(CASES_QUERY, CASES_START, CASES_END);
         assert!(cases_warn.is_some());
         let warning_text = cases_warn.clone().unwrap();
 
-        // With a cases warning and a failed profile, the error printed to stderr
-        // embeds the cases_warning prefix. Verify the logic in merge_results
-        // by checking the warning path: the cases warning is still in merged.warnings.
+        // With a cases warning and a failed profile, the warning is still in
+        // merged.warnings (printed by render_results), not embedded in errors.
         let per_profile: Vec<(String, anyhow::Result<QueryGenericResponse>)> = vec![
             (
                 "good".to_string(),
@@ -671,8 +659,7 @@ category: ["Commands reference", "test"]
     #[test]
     fn no_cases_warning_when_query_has_dedup() {
         let warning = check_cases_query_rules(
-            CASES_DATASET_SOURCE,
-            "| dedupeby caseId orderby $m.timestamp desc",
+            "source system/labs.cases.state_updates | dedupeby caseId orderby $m.timestamp desc",
             CASES_START,
             CASES_END,
         );
@@ -687,8 +674,7 @@ category: ["Commands reference", "test"]
 
     #[test]
     fn no_cases_warning_for_non_cases_source() {
-        let warning =
-            check_cases_query_rules("logs", "source logs | limit 10", CASES_START, CASES_END);
+        let warning = check_cases_query_rules("source logs | limit 10", CASES_START, CASES_END);
         assert!(warning.is_none());
 
         let per_profile = vec![(

--- a/src/commands/dataprime/mod.rs
+++ b/src/commands/dataprime/mod.rs
@@ -596,7 +596,10 @@ category: ["Commands reference", "test"]
             CASES_START,
             CASES_END,
         );
-        assert!(warning.is_some(), "expected a warning from check_cases_query_rules");
+        assert!(
+            warning.is_some(),
+            "expected a warning from check_cases_query_rules"
+        );
 
         let per_profile = vec![(
             "prod".to_string(),
@@ -613,12 +616,8 @@ category: ["Commands reference", "test"]
 
     #[test]
     fn cases_warning_plus_profile_warning_both_appear() {
-        let cases_warn = check_cases_query_rules(
-            CASES_DATASET_SOURCE,
-            "| count",
-            CASES_START,
-            CASES_END,
-        );
+        let cases_warn =
+            check_cases_query_rules(CASES_DATASET_SOURCE, "| count", CASES_START, CASES_END);
         assert!(cases_warn.is_some());
 
         let mut resp = make_generic_response(vec![], false);
@@ -638,12 +637,8 @@ category: ["Commands reference", "test"]
 
     #[test]
     fn cases_warning_prepended_to_profile_error_message() {
-        let cases_warn = check_cases_query_rules(
-            CASES_DATASET_SOURCE,
-            "| count",
-            CASES_START,
-            CASES_END,
-        );
+        let cases_warn =
+            check_cases_query_rules(CASES_DATASET_SOURCE, "| count", CASES_START, CASES_END);
         assert!(cases_warn.is_some());
         let warning_text = cases_warn.clone().unwrap();
 
@@ -661,7 +656,10 @@ category: ["Commands reference", "test"]
 
         // The cases warning appears in merged.warnings regardless of profile errors.
         assert!(
-            merged.warnings.iter().any(|w| w.contains("[Cases query warning]")),
+            merged
+                .warnings
+                .iter()
+                .any(|w| w.contains("[Cases query warning]")),
             "cases warning must be present even when a profile errors"
         );
         // The good profile's row is still included.
@@ -678,10 +676,7 @@ category: ["Commands reference", "test"]
             CASES_START,
             CASES_END,
         );
-        let per_profile = vec![(
-            "prod".to_string(),
-            Ok(make_generic_response(vec![], false)),
-        )];
+        let per_profile = vec![("prod".to_string(), Ok(make_generic_response(vec![], false)))];
         let merged = merge_results(per_profile, false, warning.as_deref());
 
         assert!(
@@ -692,7 +687,8 @@ category: ["Commands reference", "test"]
 
     #[test]
     fn no_cases_warning_for_non_cases_source() {
-        let warning = check_cases_query_rules("logs", "source logs | limit 10", CASES_START, CASES_END);
+        let warning =
+            check_cases_query_rules("logs", "source logs | limit 10", CASES_START, CASES_END);
         assert!(warning.is_none());
 
         let per_profile = vec![(

--- a/src/commands/dataprime/mod.rs
+++ b/src/commands/dataprime/mod.rs
@@ -13,6 +13,7 @@ pub mod semantic_search;
 
 use api::{DataprimeApi, QueryGenericResponse};
 
+use crate::cases_query_rules::check_cases_query_rules;
 use crate::config::OutputFormat;
 use crate::execution::{fan_out, ExecutionTarget};
 use crate::spill::{maybe_spill, transform_for_agents, SpillOutcome};
@@ -257,17 +258,15 @@ pub fn run_help(name: &str, output: OutputFormat) -> Result<()> {
 async fn execute_query(
     target: Arc<ExecutionTarget>,
     query: &str,
-    start: &str,
-    end: &str,
+    start_ts: &str,
+    end_ts: &str,
     limit: u32,
     tier: Tier,
     source: &str,
 ) -> Result<QueryGenericResponse> {
     let api = DataprimeApi::new(&target.client);
-    let start_ts = parse_timestamp(start)?;
-    let end_ts = parse_timestamp(end)?;
     Ok(api
-        .query_generic(query, &start_ts, &end_ts, limit, tier, source)
+        .query_generic(query, start_ts, end_ts, limit, tier, source)
         .await?)
 }
 
@@ -283,9 +282,13 @@ pub struct MergedResults {
 pub fn merge_results(
     per_profile: Vec<(String, Result<QueryGenericResponse>)>,
     include_profile: bool,
+    cases_warning: Option<&str>,
 ) -> MergedResults {
     let mut rows: Vec<Value> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
+    if let Some(w) = cases_warning {
+        warnings.push(w.to_string());
+    }
     let mut is_aggregate: Option<bool> = None;
 
     for (profile, result) in per_profile {
@@ -308,7 +311,14 @@ pub fn merge_results(
                     rows.extend(resp.raw_results);
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                let msg = if let Some(w) = cases_warning {
+                    format!("{w}\n\nerror from profile '{profile}': {e:#}")
+                } else {
+                    format!("error from profile '{profile}': {e:#}")
+                };
+                eprintln!("{}", msg.red());
+            }
         }
     }
 
@@ -394,16 +404,18 @@ pub async fn run_query(
 ) -> Result<()> {
     eprintln!("{}", "Querying...".dimmed());
 
+    let start_fmt = parse_timestamp(start)?;
+    let end_fmt = parse_timestamp(end)?;
+    let cases_warning = check_cases_query_rules(source, query, &start_fmt, &end_fmt);
+
     let include_profile = targets.len() > 1;
     let query = query.to_string();
     let source = source.to_string();
-    let start = start.to_string();
-    let end = end.to_string();
     let per_profile = fan_out(targets, |t| {
         let q = query.clone();
         let src = source.clone();
-        let s = start.clone();
-        let e = end.clone();
+        let s = start_fmt.clone();
+        let e = end_fmt.clone();
         async move {
             let effective_tier = tier.unwrap_or(t.cfg.default_tier);
             execute_query(t, &q, &s, &e, limit, effective_tier, &src).await
@@ -411,7 +423,7 @@ pub async fn run_query(
     })
     .await;
 
-    let merged = merge_results(per_profile, include_profile);
+    let merged = merge_results(per_profile, include_profile, cases_warning.as_deref());
     render_results(&merged, output, max_direct, temp_dir, text_renderer)
 }
 
@@ -501,7 +513,7 @@ category: ["Commands reference", "test"]
     fn merge_single_profile_omits_profile_field() {
         let rows = vec![json!({"userData": {"message": "hello"}})];
         let per_profile = vec![("prod".to_string(), Ok(make_generic_response(rows, false)))];
-        let merged = merge_results(per_profile, false);
+        let merged = merge_results(per_profile, false, None);
 
         assert_eq!(merged.rows.len(), 1);
         assert!(!merged.include_profile);
@@ -526,7 +538,7 @@ category: ["Commands reference", "test"]
                 )),
             ),
         ];
-        let merged = merge_results(per_profile, true);
+        let merged = merge_results(per_profile, true, None);
 
         assert_eq!(merged.rows.len(), 2);
         assert_eq!(merged.rows[0]["profile"], json!("prod"));
@@ -542,7 +554,7 @@ category: ["Commands reference", "test"]
             ),
             ("bad".to_string(), Err(anyhow::anyhow!("network error"))),
         ];
-        let merged = merge_results(per_profile, true);
+        let merged = merge_results(per_profile, true, None);
 
         assert_eq!(merged.rows.len(), 1);
         assert_eq!(merged.rows[0]["profile"], json!("good"));
@@ -553,7 +565,7 @@ category: ["Commands reference", "test"]
         let mut resp = make_generic_response(vec![], false);
         resp.warnings = vec!["too many results".to_string()];
         let per_profile = vec![("prod".to_string(), Ok(resp))];
-        let merged = merge_results(per_profile, true);
+        let merged = merge_results(per_profile, true, None);
 
         assert_eq!(merged.warnings.len(), 1);
         assert!(merged.warnings[0].contains("[prod]"));
@@ -565,7 +577,131 @@ category: ["Commands reference", "test"]
             ("p1".to_string(), Ok(make_generic_response(vec![], true))),
             ("p2".to_string(), Ok(make_generic_response(vec![], true))),
         ];
-        let merged = merge_results(per_profile, true);
+        let merged = merge_results(per_profile, true, None);
         assert!(merged.is_aggregate);
+    }
+
+    // ── check_cases_query_rules integration via merge_results ────────────────
+
+    use crate::cases_query_rules::{check_cases_query_rules, CASES_DATASET_SOURCE};
+
+    const CASES_START: &str = "2024-01-01T00:00:00.000Z";
+    const CASES_END: &str = "2024-01-01T02:00:00.000Z";
+
+    #[test]
+    fn cases_warning_prepended_to_merged_warnings() {
+        let warning = check_cases_query_rules(
+            CASES_DATASET_SOURCE,
+            "source system/labs.cases.state_updates | count",
+            CASES_START,
+            CASES_END,
+        );
+        assert!(warning.is_some(), "expected a warning from check_cases_query_rules");
+
+        let per_profile = vec![(
+            "prod".to_string(),
+            Ok(make_generic_response(vec![json!({"data": 1})], false)),
+        )];
+        let merged = merge_results(per_profile, false, warning.as_deref());
+
+        assert_eq!(merged.warnings.len(), 1);
+        assert!(
+            merged.warnings[0].contains("[Cases query warning]"),
+            "cases warning should be in merged warnings"
+        );
+    }
+
+    #[test]
+    fn cases_warning_plus_profile_warning_both_appear() {
+        let cases_warn = check_cases_query_rules(
+            CASES_DATASET_SOURCE,
+            "| count",
+            CASES_START,
+            CASES_END,
+        );
+        assert!(cases_warn.is_some());
+
+        let mut resp = make_generic_response(vec![], false);
+        resp.warnings = vec!["too many results".to_string()];
+        let per_profile = vec![("prod".to_string(), Ok(resp))];
+        let merged = merge_results(per_profile, true, cases_warn.as_deref());
+
+        assert_eq!(
+            merged.warnings.len(),
+            2,
+            "should have one cases warning and one profile warning"
+        );
+        assert!(merged.warnings[0].contains("[Cases query warning]"));
+        assert!(merged.warnings[1].contains("[prod]"));
+        assert!(merged.warnings[1].contains("too many results"));
+    }
+
+    #[test]
+    fn cases_warning_prepended_to_profile_error_message() {
+        let cases_warn = check_cases_query_rules(
+            CASES_DATASET_SOURCE,
+            "| count",
+            CASES_START,
+            CASES_END,
+        );
+        assert!(cases_warn.is_some());
+        let warning_text = cases_warn.clone().unwrap();
+
+        // With a cases warning and a failed profile, the error printed to stderr
+        // embeds the cases_warning prefix. Verify the logic in merge_results
+        // by checking the warning path: the cases warning is still in merged.warnings.
+        let per_profile: Vec<(String, anyhow::Result<QueryGenericResponse>)> = vec![
+            (
+                "good".to_string(),
+                Ok(make_generic_response(vec![json!({"ok": true})], false)),
+            ),
+            ("bad".to_string(), Err(anyhow::anyhow!("timeout"))),
+        ];
+        let merged = merge_results(per_profile, true, cases_warn.as_deref());
+
+        // The cases warning appears in merged.warnings regardless of profile errors.
+        assert!(
+            merged.warnings.iter().any(|w| w.contains("[Cases query warning]")),
+            "cases warning must be present even when a profile errors"
+        );
+        // The good profile's row is still included.
+        assert_eq!(merged.rows.len(), 1);
+        // The warning text is non-empty (contains Rule content).
+        assert!(warning_text.contains("Rule"));
+    }
+
+    #[test]
+    fn no_cases_warning_when_query_has_dedup() {
+        let warning = check_cases_query_rules(
+            CASES_DATASET_SOURCE,
+            "| dedupeby caseId orderby $m.timestamp desc",
+            CASES_START,
+            CASES_END,
+        );
+        let per_profile = vec![(
+            "prod".to_string(),
+            Ok(make_generic_response(vec![], false)),
+        )];
+        let merged = merge_results(per_profile, false, warning.as_deref());
+
+        assert!(
+            merged.warnings.is_empty(),
+            "no warnings expected for a compliant cases query"
+        );
+    }
+
+    #[test]
+    fn no_cases_warning_for_non_cases_source() {
+        let warning = check_cases_query_rules("logs", "source logs | limit 10", CASES_START, CASES_END);
+        assert!(warning.is_none());
+
+        let per_profile = vec![(
+            "prod".to_string(),
+            Ok(make_generic_response(vec![json!({"msg": "hi"})], false)),
+        )];
+        let merged = merge_results(per_profile, false, warning.as_deref());
+
+        assert!(merged.warnings.is_empty());
+        assert_eq!(merged.rows.len(), 1);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod api_client;
 pub mod banner;
+pub mod cases_query_rules;
 pub mod commands;
 pub mod config;
 pub mod error;


### PR DESCRIPTION
## Context
Two related improvements to the `cases` command and skill. First, the `case-analytics.md` reference was misaligned with the real API shape — `groupings` was replaced by `permutations` in the Coralogix Cases service but the docs still showed the old field. Second, agents running case analytics queries against `system/labs.cases.state_updates` frequently produce double-counted results by forgetting to dedup heartbeats; this adds a runtime guardrail that catches the most common violations before the user gets back garbage data.

## Linked Issues
FORGE-244

## Design
Two separate pieces:

**1. Reference doc alignment (`skills/cx-cases/references/case-analytics.md`)**
- Replaces all `groupings` references with `permutations`, matching the real event shape (`[[{key, value, permutationIndex}]]`).
- Adds a "Dedup comes first" rule section that consolidates the existing dedup guidance into a hard-rule statement with explicit anti-patterns.
- Adds a "week-over-week comparison" query example and a full "filtering/aggregating by permutations" section (key discovery, single-kv filter, multi-kv co-occurrence).

**2. Runtime query rule validation (`src/cases_query_rules.rs` + `dataprime/mod.rs`)**
- New `cases_query_rules.rs` module (port of olly's `cases_query_rules.py`) exposes `check_cases_query_rules(source, query, start_ts, end_ts) -> Option<String>`.
- Rule 1: rejects windows shorter than 1h.
- Rule 2/3: requires one of `dedupeby caseId`, `groupby caseId`, `distinct caseId`, or `filter metadata.trigger == ...`.
- `run_query` in `dataprime/mod.rs` calls the checker after timestamp parsing (before fan-out) and passes the warning into `merge_results`, which prepends it to the warnings list. This means it surfaces in every output format (text, JSON, agents) without blocking the query.
- Timestamps are now parsed once before fan-out rather than once per profile (minor efficiency fix pulled in as part of refactoring `execute_query`'s signature).

## Key Decisions
- **Warn, don't block**: violations emit a structured `[Cases query warning]` rather than erroring out. The query still runs. This avoids breaking valid edge-case queries that pattern-match poorly (e.g., a query that does dedup inside a subquery expression).
- **Regex-based detection**: simple and fast. The alternative (parsing the DataPrime AST) doesn't exist in this codebase and would be a large dependency. The regex set covers all documented safe patterns from the skill.
- **`cases_warning` threaded through `merge_results`**: the warning is associated with the query, not a profile, so it belongs at the merge level rather than being emitted per-profile. This avoids duplicating it N times in multi-profile fan-out.

## Changes
- New `src/cases_query_rules.rs` module with `check_cases_query_rules` and unit tests.
- `merge_results` in `dataprime/mod.rs` gains a `cases_warning: Option<&str>` parameter; all existing call sites updated to pass `None`.
- `run_query` parses timestamps once and passes formatted strings into `execute_query` (signature change); warning is injected at query time.
- `skills/cx-cases/references/case-analytics.md`: `groupings` → `permutations` throughout; new dedup-first rule; new query examples (week-over-week, permutation filtering patterns).
- `regex = "1"` added to `Cargo.toml`.

## Testing
- Unit tests in `src/cases_query_rules.rs`: non-cases source, short window, missing dedup, `dedupeby` safe, trigger-filter safe.
- Integration tests in `dataprime/mod.rs`: cases warning prepended to merged warnings, warning + profile warning both appear, warning present even when a profile errors, no warning for compliant query, no warning for non-cases source.
- `cargo test` — all tests pass.
- `cargo clippy` — no warnings.
- `cargo fmt` — no diffs.

## Risks & Rollout
Low risk. The validator is additive and warns-only; no queries are blocked. The `permutations` doc fix is a correctness improvement — agents using the old `groupings` shape would have received DataPrime errors at runtime anyway.

## Out of Scope / Follow-ups
- AST-based query validation (would eliminate false-negative regex edge cases).
- Extending `check_cases_query_rules` to other datasets with similar heartbeat semantics.

Made with [Cursor](https://cursor.com)