### PR TITLE
AICE-244 | cx ai-center commands + skill (AI v3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 
 # Claude Code
 .claude/scheduled_tasks.lock
+
+# Local graphify knowledge-graph output (never commit)
+graphify-out/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,9 @@ Observe:
   views              Manage saved views and view folders
   slos               Manage SLO definitions
 
+AI:
+  ai-center (risky)  Manage AI Center applications, evaluations, policies, and pricing
+
 Detect & Respond:
   alerts             Manage alert definitions and suppression rules
   cases              Manage and triage cases
@@ -98,7 +101,7 @@ All use the Olly KB semantic-search-service API with gateway permission `legacy-
 - `integrations` = extensions + contextual-data
 - `iam` = api-keys + roles + scopes + users + team-groups + ip-access
 
-**Risky commands:** `iam` and `archive` are marked `(risky)` in help output. All write operations (create, update, delete, enable, disable, set, set-status) under these commands require interactive confirmation. Pass `--yes` to skip the prompt (e.g., in scripts or CI). Non-interactive terminals without `--yes` get a clear error. The confirmation logic lives in `src/safety.rs`.
+**Risky commands:** `iam`, `archive`, and `ai-center` are marked `(risky)` in help output. All write operations (create, update, delete, enable, disable, set, set-status) under these commands require interactive confirmation. Pass `--yes` to skip the prompt (e.g., in scripts or CI). Non-interactive terminals without `--yes` get a clear error. The confirmation logic lives in `src/safety.rs`.
 
 ## Architecture
 
@@ -186,6 +189,7 @@ Which CLI commands have user-facing skills in `skills/`:
 | `cx retentions` | `cx-cost-optimization` | Covered |
 | `cx archive` | `cx-cost-optimization` | Covered |
 | `cx cases` | `cx-cases` | Covered |
+| `cx ai-center` | `cx-ai-center` | Covered (loads `ai-center-queries.md` + `dataprime-reference.md` + `spans-querying.md`) |
 | `cx slos` | `cx-slos` | Covered |
 | `cx parsing-rules` | `cx-data-pipeline` | Covered |
 | `cx enrichments` | `cx-data-pipeline` | Covered |

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -30,6 +30,10 @@
 /skills/telemetry-querying/            @coralogix/team-cxai
 /assets/                               @coralogix/team-cxai
 
+# === AI Center (GenAI applications, evaluations, policies, pricing) ===
+**/ai_center/                          @coralogix/team-cxai
+/skills/cx-ai-center/                  @coralogix/team-cxai
+
 # === config-surface (alerts, dashboards) ===
 **/alerts/                             @coralogix/team-cxai
 **/dashboards/                         @coralogix/team-cxai

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "coralogix-cli"
-version = "0.1.12"
+version = "0.1.13"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-cli"
-version = "0.1.12"
+version = "0.1.13"
 edition = "2021"
 description = "Coralogix CLI - the observability backbone for AI agents and engineering teams."
 repository = "https://github.com/coralogix/cx-cli"

--- a/scripts/sync-shared-references.sh
+++ b/scripts/sync-shared-references.sh
@@ -55,6 +55,11 @@ copy_refs "cx-telemetry-querying" \
     "rum-querying.md" \
     "rum-fields.md"
 
+# cx-ai-center: DataPrime + spans references for GenAI span analysis
+copy_refs "cx-ai-center" \
+    "dataprime-reference.md" \
+    "spans-querying.md"
+
 # cx-dashboards: query language and data-source references
 copy_refs "cx-dashboards" \
     "dataprime-reference.md" \

--- a/skills/cx-ai-center/SKILL.md
+++ b/skills/cx-ai-center/SKILL.md
@@ -31,7 +31,7 @@ answers questions about AI apps from two sources:
 
 A single question often spans both: e.g. *"which apps lack guardrails"* is config
 (`cx ai-center applications list`), while *"what are users asking my chatbot"* is telemetry
-(`cx spans '…'`, reading `gen_ai.input.messages`).
+(`cx spans '…'`, reading the conversation from the GenAI spans).
 
 ---
 
@@ -74,8 +74,10 @@ surface them.
 ## Golden rule
 
 For **content** questions (quality, hallucination, sentiment, topics) read the actual
-`gen_ai.input.messages` / `gen_ai.output.messages` and cite the `traceID` — don't rely on
-verdict tags alone. Full guidance + the query library:
+conversation and cite the `traceID` — don't rely on verdict tags alone. The transcript lives in
+one of two conventions (`gen_ai.input.messages`/`output.messages`, or the older indexed
+`gen_ai.prompt.<n>`/`completion.<n>` tags); read it with the **Reading conversations** queries in
+the library, which handle both and exclude the system prompt and tool traffic. Full guidance:
 [references/ai-center-queries.md](references/ai-center-queries.md).
 
 ---

--- a/skills/cx-ai-center/SKILL.md
+++ b/skills/cx-ai-center/SKILL.md
@@ -29,9 +29,11 @@ answers questions about AI apps from two sources:
   See [references/ai-center-queries.md](references/ai-center-queries.md) for the full,
   runnable query library, span schema, and playbooks.
 
-A single question often spans both: e.g. *"which apps lack guardrails"* is config
-(`cx ai-center applications list`), while *"what are users asking my chatbot"* is telemetry
-(`cx spans '…'`, reading the conversation from the GenAI spans).
+Match the source to the question: *"which apps lack guardrails"* → config
+(`cx ai-center applications list`); *"what are users asking my chatbot"* → telemetry
+(`cx spans '…'`, reading the conversation from the GenAI spans). Some questions need **both** —
+e.g. *"is my chatbot's PII policy actually catching PII?"* joins config (is the policy enabled)
+with telemetry (the PII verdicts + the messages).
 
 ---
 

--- a/skills/cx-ai-center/SKILL.md
+++ b/skills/cx-ai-center/SKILL.md
@@ -4,9 +4,8 @@ description: >
   Use this skill for any question or action about the user's AI/GenAI applications or agents —
   their behavior, prompts/responses, quality, hallucinations, guardrails, security, cost/tokens,
   errors, evaluations/policies, model pricing, or configuration — including comparing or tracking
-  agents over time. Invoke it even when the request doesn't say "AI"/"LLM"/"agent" explicitly
-  (e.g. "which of my agents…", "compare my agent to last week"). It covers both analyzing AI
-  telemetry (GenAI spans) and managing AI Center config via the `cx ai-center` commands.
+  agents over time. It covers both analyzing AI telemetry (GenAI spans) and managing AI Center
+  config via the `cx ai-center` commands.
 metadata:
   version: "0.1.0"
 ---

--- a/skills/cx-ai-center/SKILL.md
+++ b/skills/cx-ai-center/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: cx-ai-center
+description: >
+  Use this skill for any question or action about the user's AI/GenAI applications or agents —
+  their behavior, prompts/responses, quality, hallucinations, guardrails, security, cost/tokens,
+  errors, evaluations/policies, model pricing, or configuration — including comparing or tracking
+  agents over time. Invoke it even when the request doesn't say "AI"/"LLM"/"agent" explicitly
+  (e.g. "which of my agents…", "compare my agent to last week"). It covers both analyzing AI
+  telemetry (GenAI spans) and managing AI Center config via the `cx ai-center` commands.
+metadata:
+  version: "0.1.0"
+---
+
+# AI Center Skill
+
+**This is the tool for anything about AI/GenAI applications** — both **questions** about their
+behavior (prompts/responses, quality, hallucinations, guardrails, security, cost/tokens, errors,
+latency — everything AI apps expose through their GenAI spans/tags) and **actions** to manage them
+(applications, evaluations/policies, policy↔app links, model pricing). If a request touches an AI
+application or its GenAI telemetry, use this skill.
+
+Coralogix **AI Center** observes, evaluates, and guards GenAI/LLM applications. This skill
+answers questions about AI apps from two sources:
+
+- **Configuration** (this skill's `cx ai-center` commands): the AI application inventory,
+  configured evaluations/policies, coverage, custom evaluations, and model pricing — none of
+  which live in span telemetry.
+- **Telemetry** (GenAI spans): what users asked, how the model answered, cost, tokens,
+  latency, errors, tool calls, and eval/guardrail verdicts — queried with **`cx spans '<DataPrime>'`**.
+  See [references/ai-center-queries.md](references/ai-center-queries.md) for the full,
+  runnable query library, span schema, and playbooks.
+
+A single question often spans both: e.g. *"which apps lack guardrails"* is config
+(`cx ai-center applications list`), while *"what are users asking my chatbot"* is telemetry
+(`cx spans '…'`, reading `gen_ai.input.messages`).
+
+---
+
+## Destructive Operation Safety
+
+All write operations (`create`, `update`, `delete`, `add`, `remove`, `set`)
+require interactive confirmation. `ai-center` is a **risky** command, so writes are also
+gated by `allow_risky_commands` in `~/.cx/config.toml`. To skip the prompt in scripts, pass
+`--yes`.
+
+**IMPORTANT: NEVER pass `--yes` without explicit user approval.** Before executing any write:
+1. Describe the exact operation to the user (what will be created/modified/deleted/linked).
+2. Wait for the user to confirm.
+3. Only then execute with `--yes`.
+
+Read operations (`list`, `get`, `coverage`, `list-for-application`, `model-pricing get`) do
+not require confirmation and can be run freely.
+
+### Read-Only Mode
+Use `--read-only` (or `CX_READ_ONLY=1`) to block every write at the CLI level — safe for
+exploration.
+
+### Agent Mode
+When running inside an AI agent (Claude Code, Cursor, Codex, …), cx detects it and — instead of
+showing a confirmation prompt that would hang forever (no human is there to type y/n) — stops
+immediately with an error telling you to get the user's approval, then re-run with `--yes`.
+
+### No delete commands (by design)
+The CLI intentionally exposes **no delete** for custom-evaluation policies, AI applications, or
+model pricing — even though the AI v3 API has those delete endpoints, `cx ai-center` does not
+surface them.
+- **Custom-evaluation policy:** can't be deleted; to take it off an app, detach with
+  `custom-evaluations remove` (the policy object survives and can be re-attached).
+- **Model pricing:** no delete command. It's **team-wide** (not per-app), so to change or clear
+  it, run `model-pricing set` with a new map (an empty map `{}` clears all overrides) — `set`
+  replaces the whole set.
+
+---
+
+## Golden rule
+
+For **content** questions (quality, hallucination, sentiment, topics) read the actual
+`gen_ai.input.messages` / `gen_ai.output.messages` and cite the `traceID` — don't rely on
+verdict tags alone. Full guidance + the query library:
+[references/ai-center-queries.md](references/ai-center-queries.md).
+
+---
+
+## CLI Commands
+
+**Show names to the user; use UUIDs only internally.** When presenting results, refer to apps
+and evaluations by their human names (application/subsystem, evaluation name), not raw UUIDs.
+The UUID is only needed to *call* a by-id or write command — resolve it yourself from the
+matching `list` command (never guess or make the user paste a UUID).
+
+### Applications (inventory + guarded status)
+
+| Command | Purpose |
+|---------|---------|
+| `cx ai-center applications list` | List AI apps incl. `guardrailsIntegrated` (guarded) status |
+| `cx ai-center applications list --evaluation-type <TYPE>` | Filter to apps using an eval type (repeatable) |
+| `cx ai-center applications list --page-size <N> --page-offset <N>` | Paginate |
+| `cx ai-center applications get <application-id>` | One application by UUID |
+
+### Evaluations (configured policies on apps)
+
+| Command | Purpose |
+|---------|---------|
+| `cx ai-center evaluations list` | All configured evaluations |
+| `cx ai-center evaluations list --application <app> --subsystem <sub>` | Scope to one app (the pair) |
+| `cx ai-center evaluations list --evaluation-type <TYPE>` | Filter by type — `<TYPE>` is the API enum (e.g. `PII`, `TOXICITY`, `PROMPT_INJECTION`; the keys from `coverage`), **not** the lowercase form |
+| `cx ai-center evaluations get <evaluation-id>` | One evaluation by UUID |
+| `cx ai-center evaluations create --from-file eval.json` | Create/enable an evaluation *(write)* |
+| `cx ai-center evaluations update <evaluation-id> --from-file patch.json` | Partial update *(write)* |
+| `cx ai-center evaluations delete <evaluation-id>` | Remove an evaluation from its app *(write)* |
+
+### Custom evaluations (policies) & application links
+
+| Command | Purpose |
+|---------|---------|
+| `cx ai-center custom-evaluations list` | All custom evaluation policies |
+| `cx ai-center custom-evaluations list-for-application <application-id>` | Policies linked to one app |
+| `cx ai-center custom-evaluations create --from-file policy.json` | Create a custom policy *(write)* |
+| `cx ai-center custom-evaluations update <id> --from-file patch.json` | Partial update *(write)* |
+| `cx ai-center custom-evaluations add <evaluation-id> <application-id>` | Attach a policy to an app *(write)* |
+| `cx ai-center custom-evaluations remove <evaluation-id> <application-id>` | Detach (reversible) *(write)* |
+
+### Coverage & model pricing
+
+| Command | Purpose |
+|---------|---------|
+| `cx ai-center coverage` | Map of each evaluation type → number of apps using it (coverage / gap analysis) |
+| `cx ai-center model-pricing get` | Team's custom per-model pricing overrides |
+| `cx ai-center model-pricing set --from-file prices.json` | Set team pricing (team-wide, new data only) *(write)* |
+
+The `--from-file` bodies for `evaluations` and `custom-evaluations` match the AI v3 API
+shape verbatim; use `-` to read JSON from stdin. **Exception:** `model-pricing set` takes just
+the raw `model→price` map (e.g. `{"gpt-4o": { ... }}`) — cx wraps it as `{"prices": …}` for you,
+so do **not** include the outer `prices` envelope.
+
+---
+
+## Common workflows
+
+### Inventory & guardrail gaps
+```bash
+# Which apps are NOT guarded?
+cx ai-center applications list -o json | jq '[.[] | select(.guardrailsIntegrated==false)]'
+```
+
+### Enable a policy on an app (write — confirm first!)
+```bash
+# 1. Describe to the user; 2. get approval; 3. then:
+cx ai-center evaluations create --from-file eval.json --yes
+# eval.json: { "application": "...", "subsystem": "...", "config": { "<type>": {...} }, "isEnabled": true }
+```
+
+### Read the actual conversations (telemetry, not config)
+Use `cx spans` with the query library in
+[references/ai-center-queries.md](references/ai-center-queries.md) — reading messages, cost,
+latency, errors, tool calls, and per-user analysis.
+
+---
+
+## Key principles
+
+- **Config vs. telemetry:** inventory / evaluations / policies / coverage / pricing → `cx ai-center`;
+  content / cost / latency / errors / verdicts → GenAI spans via `cx spans`. Don't answer one
+  from the other.
+- **Confirm before writes.** Describe the operation, get approval, then run with `--yes`.
+
+---
+
+## Related Skills
+
+- `cx-telemetry-querying` — general logs/spans/metrics/DataPrime querying (the engine behind
+  the `cx spans` queries used here).
+- `cx-olly` — the conversational AI assistant (`cx olly ask`).

--- a/skills/cx-ai-center/SKILL.md
+++ b/skills/cx-ai-center/SKILL.md
@@ -129,8 +129,22 @@ matching `list` command (never guess or make the user paste a UUID).
 
 The `--from-file` bodies for `evaluations` and `custom-evaluations` match the AI v3 API
 shape verbatim; use `-` to read JSON from stdin. **Exception:** `model-pricing set` takes just
-the raw `model→price` map (e.g. `{"gpt-4o": { ... }}`) — cx wraps it as `{"prices": …}` for you,
-so do **not** include the outer `prices` envelope.
+the raw `model→price` map — cx wraps it as `{"prices": …}` for you, so do **not** include the
+outer `prices` envelope. Each model maps to a price object; all four fields are optional doubles
+(USD per **one million** tokens), omit the ones that don't apply:
+
+```json
+{
+  "gpt-4o": {
+    "inputPricePerMillionTokens": 2.5,
+    "outputPricePerMillionTokens": 10,
+    "cacheReadPricePerMillionTokens": 1.25,
+    "cacheWritePricePerMillionTokens": 3.75
+  }
+}
+```
+
+An empty map `{}` clears all overrides (set replaces the whole set — it's team-wide, new data only).
 
 ---
 

--- a/skills/cx-ai-center/SKILL.md
+++ b/skills/cx-ai-center/SKILL.md
@@ -76,8 +76,9 @@ surface them.
 For **content** questions (quality, hallucination, sentiment, topics) read the actual
 conversation and cite the `traceID` — don't rely on verdict tags alone. The transcript lives in
 one of two conventions (`gen_ai.input.messages`/`output.messages`, or the older indexed
-`gen_ai.prompt.<n>`/`completion.<n>` tags); read it with the **Reading conversations** queries in
-the library, which handle both and exclude the system prompt and tool traffic. Full guidance:
+`gen_ai.prompt.<n>`/`completion.<n>` tags); read it with the **Reading conversations (content
+questions)** queries in the library, which handle both and exclude the system prompt and tool
+traffic. Full guidance:
 [references/ai-center-queries.md](references/ai-center-queries.md).
 
 ---

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -105,10 +105,15 @@ for series); duration = `$m.duration` (µs).
 `tool` / `system`, part `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
 `blob`/`file`/`uri`.
 
-**What to read (both conventions):**
-- **User input** = `type:"text"` parts of `role:"user"` messages — read all of them.
-- **Model output** = `type:"text"` parts of the response.
-- **System prompt** = the `role:"system"` message's text.
+**What to read — the actual conversation, not tags.** For any question about *what was said*
+(quality, satisfaction, hallucination, whether the user repeated themselves, did the agent answer):
+read the **whole `input.messages` + `output.messages`** (or `prompt.<n>` + `completion.<n>`),
+**every turn except the system prompt**. Verdict/score tags are a summary, not the content.
+- Turns: `role:"user"` (the asks), `role:"assistant"` (answers + `tool_call`s), `role:"tool"`
+  (tool results). Message `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
+  `blob`/`file`/`uri`.
+- **Skip the system prompt** — the `role:"system"` message, or the separate
+  `gen_ai.system_instructions` tag. It's static and often large; not what the user said.
 
 **Two conventions:**
 - **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — one JSON blob per side, each
@@ -118,10 +123,18 @@ for series); duration = `$m.duration` (µs).
 
 Prefer `input.messages` / `output.messages`; when null, use the indexed tags.
 
-**Current convention — extract text.** Use the regex (not a raw fetch of `input.messages`): it
-returns only user + model text and never the system prompt, whether that prompt sits at index 0 of
-the array or in a separate tag. (`(?:[^"\\]|\\.)*` spans escaped quotes so long messages aren't
-truncated.)
+**Read the conversation** — fetch both sides and read every turn, ignoring the `role:"system"` one:
+```dataprime
+source spans
+| filter $d.traceID == '<trace-id>' && tags['gen_ai.input.messages'] != null
+| choose $d.spanID as span_id, tags['gen_ai.input.messages'] as input, tags['gen_ai.output.messages'] as output
+```
+Indexed: `| choose $d.spanID as span_id, $d.tags as tags` and read the `prompt.<n>` / `completion.<n>`
+keys, skipping `role:"system"`.
+
+**Extract one field at scale** — only when you need *just* the user or model text as a column to
+aggregate over many spans (e.g. count/group), not to read a conversation. Also skips the system
+prompt (`(?:[^"\\]|\\.)*` spans escaped quotes so long messages aren't truncated):
 ```dataprime
 | extract tags['gen_ai.input.messages']:string into u using regexp(e=/"role"\s*:\s*"user"[\s\S]*?"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
 | extract tags['gen_ai.output.messages']:string into a using regexp(e=/"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
@@ -134,16 +147,6 @@ All user turns — `multi_regexp` + `explode`:
 | extract turn into m using regexp(e=/"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
 | choose $d.traceID as trace_id, m.text as user_input
 ```
-
-**Indexed convention — same rule, flat tags:**
-```dataprime
-source spans
-| filter $d.traceID == '<trace-id>' && tags['gen_ai.prompt.0.role'] != null
-| choose $d.spanID as span_id, $d.tags as tags
-```
-- **User input** = each `prompt.<n>` with `.role == "user"` → `.content`.
-- **Model output** = `completion.<n>.content`.
-- **System prompt** = the `prompt.<n>` with `.role == "system"` → `.content`.
 
 **Span attributes (GenAI spans).** Span kind — `gen_ai.operation.name`: `chat` (also
 `generate_content`, `text_completion`), `embeddings`, `retrieval` (RAG), `create_agent`,

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -105,48 +105,81 @@ for series); duration = `$m.duration` (µs).
 `tool` / `system`, part `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
 `blob`/`file`/`uri`.
 
-**What to read — the actual conversation, not tags.** For any question about *what was said*
-(quality, satisfaction, hallucination, whether the user repeated themselves, did the agent answer):
-read the **whole `input.messages` + `output.messages`** (or `prompt.<n>` + `completion.<n>`),
-**every turn except the system prompt**. Verdict/score tags are a summary, not the content.
-- Turns: `role:"user"` (the asks), `role:"assistant"` (answers + `tool_call`s), `role:"tool"`
-  (tool results). Message `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
-  `blob`/`file`/`uri`.
-- **Skip the system prompt** — the `role:"system"` message, or the separate
-  `gen_ai.system_instructions` tag. It's static and often large; not what the user said.
+**Reading conversations (content questions).** For "are `<APP>`/`<SUB>` customers satisfied",
+"do users repeat themselves", quality, hallucination, "did the agent answer" — the answer is in
+the **user asks + model replies**, not verdict/score tags. Read the user's `type:"text"` messages
+and the model's `type:"text"` replies. **Build the query to exclude** the system prompt
+(`role:"system"` turn or the `gen_ai.system_instructions` tag) and tool traffic (`tool_call` /
+`tool_call_response`, `role:"tool"`) so they never enter the result — the system prompt especially
+would bloat context. (Read the system prompt only when the question is whether the agent followed
+its instructions.)
 
-**Two conventions:**
-- **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — one JSON blob per side, each
-  turn `{role, parts:[{type, content}]}`.
-- **Older indexed:** one tag per message — `gen_ai.prompt.<n>.{role,content}` (input),
-  `gen_ai.completion.<n>.{role,content}` (output), `n = 0,1,2,…`.
+**Flow:** (1) filter to the app — `$l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'`;
+(2) key each conversation — `firstNonNull(tags['gen_ai.conversation.id']:string, $d.traceID)`;
+(3) extract only user + model text (below); read each conversation's turns in order, judge from the
+user's side.
 
-Prefer `input.messages` / `output.messages`; when null, use the indexed tags.
+**Two conventions** — pick by which tags exist: use the **Current** query when
+`gen_ai.input.messages` is present; use the **Indexed** query when `gen_ai.prompt.0.role` is present.
+- **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — one JSON blob per side.
+- **Older indexed:** `gen_ai.prompt.<n>.{role,content}` / `gen_ai.completion.<n>.{role,content}`.
 
-**Read the conversation** — fetch both sides and read every turn, ignoring the `role:"system"` one:
+**Current convention — general conversation read.** Parse the messages JSON with `jsonobject()`,
+keep `user`/`assistant` roles (drops `system` + `tool`) and `type:"text"` parts (drops `tool_call`
+/ `tool_call_response`), and collect one transcript per span. Scope by adding
+`| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'` after `source spans`; a
+span's `input.messages` accumulates the prior turns, so the fullest span of a conversation holds the
+whole history:
 ```dataprime
 source spans
-| filter $d.traceID == '<trace-id>' && tags['gen_ai.input.messages'] != null
-| choose $d.spanID as span_id, tags['gen_ai.input.messages'] as input, tags['gen_ai.output.messages'] as output
+| filter $d.tags['gen_ai.input.messages'] != null || $d.tags['gen_ai.output.messages'] != null
+| create input_json from concat('{"messages":', firstNonNull($d.tags['gen_ai.input.messages'], '[]'), '}')
+| create output_json from concat('{"messages":', firstNonNull($d.tags['gen_ai.output.messages'], '[]'), '}')
+| extract $d.input_json into input_parsed using jsonobject()
+| extract $d.output_json into output_parsed using jsonobject()
+| create all_messages from arrayConcat($d.input_parsed.messages, $d.output_parsed.messages)
+| explode $d.all_messages into $d.message original preserve
+| filter ['user','assistant'].arrayContains($d.message.role)
+| explode $d.message.parts into $d.part original preserve
+| filter $d.part.type == 'text' && trim(firstNonNull($d.part.content, '')) != ''
+| create line from concat($d.message.role, ': ', $d.part.content)
+| groupby $d.traceID as trace_id, $d.spanID as span_id aggregate collect($d.line) as lines
+| create conversation_text from arrayJoin($d.lines, '\n')
+| choose trace_id, span_id, conversation_text
 ```
-Indexed: `| choose $d.spanID as span_id, $d.tags as tags` and read the `prompt.<n>` / `completion.<n>`
-keys, skipping `role:"system"`.
+This keeps `type:"text"` parts only. Some SDKs embed model reasoning (`<thinking>…</thinking>`) or
+serialize a tool call into a text part (e.g. `ResponseFunctionToolCall(…)`) — those are inside the
+content, so they can appear in the transcript; treat them as noise when judging.
 
-**Extract one field at scale** — only when you need *just* the user or model text as a column to
-aggregate over many spans (e.g. count/group), not to read a conversation. Also skips the system
-prompt (`(?:[^"\\]|\\.)*` spans escaped quotes so long messages aren't truncated):
+Aggregate instead of read (e.g. top user questions): keep only `$d.message.role == 'user'` before
+the parts explode, then `| groupby $d.part.content aggregate count() as times | orderby times desc`.
+
+**Indexed convention — general conversation read.** The messages are separate numbered tags
+(`gen_ai.prompt.<n>.*`), so there's no JSON string to parse and DataPrime can't enumerate the
+numbered keys directly. Instead serialize the whole span with `$d:string` and `multi_regexp` every
+`role`/`content` pair at once (any message count, no hardcoded range); group by index to re-pair
+role with content, then keep `user`/`assistant` with non-empty content (drops `system`, `role:"tool"`
+results, and tool-call turns which have no `.content`):
 ```dataprime
-| extract tags['gen_ai.input.messages']:string into u using regexp(e=/"role"\s*:\s*"user"[\s\S]*?"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
-| extract tags['gen_ai.output.messages']:string into a using regexp(e=/"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
-| choose $d.traceID as trace_id, u.text as user_input, a.text as model_output
+source spans
+| filter $d.tags['gen_ai.prompt.0.role'] != null
+| create doc_json from $d:string
+| extract doc_json into matches using multi_regexp(e=/"gen_ai\.(prompt|completion)\.(\d+)\.(role|content)":"((?:[^"\\]|\\.)*)"/)
+| explode matches into m original preserve
+| extract m into p using regexp(e=/"gen_ai\.(?<grp>prompt|completion)\.(?<idx>\d+)\.(?<kind>role|content)":"(?<value>(?:[^"\\]|\\.)*)"/)
+| groupby $d.traceID as trace_id, $d.spanID as span_id, p.grp:string as grp, p.idx:number as idx
+    aggregate any_value(if(p.kind == 'role', p.value:string, null)) as role,
+              any_value(if(p.kind == 'content', p.value:string, null)) as content
+| filter (role == 'user' || role == 'assistant') && content != null && trim(content) != ''
+| create line from concat(if(grp == 'prompt', '0', '1'), ':', padLeft(idx:string, 5, '0'), ':::', role, ': ', content)
+| groupby trace_id, span_id aggregate arrayJoin(arraySort(collect(line)), '\n') as conversation_text
+| redact conversation_text matching /[01]:\d{5}:::/ to ''
+| choose trace_id, span_id, conversation_text
 ```
-All user turns — `multi_regexp` + `explode`:
-```dataprime
-| extract tags['gen_ai.input.messages']:string into turns using multi_regexp(e=/"role"\s*:\s*"user"[\s\S]*?"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?:[^"\\]|\\.)*"/)
-| explode turns into turn original preserve
-| extract turn into m using regexp(e=/"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
-| choose $d.traceID as trace_id, m.text as user_input
-```
+The `grp`/`idx` sort prefix orders prompt-before-completion and ascending index (`collect` doesn't
+preserve order); `redact` strips it. Same content-level caveat as the current convention
+(`<thinking>…` / tool-call-as-text can appear). Scope with
+`| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'`.
 
 **Span attributes (GenAI spans).** Span kind — `gen_ai.operation.name`: `chat` (also
 `generate_content`, `text_completion`), `embeddings`, `retrieval` (RAG), `create_agent`,

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -24,44 +24,30 @@ policies, coverage, pricing) use the `cx ai-center` commands documented in the p
 
 ## Golden rule: read the interactions, not just the verdicts
 
-Each interaction's spans carry the **conversation** (`gen_ai.input.messages` = the full chat
-history sent to the model — system/user/assistant/tool turns — and `gen_ai.output.messages` =
-the model's response) plus model, tokens, cost, latency, errors, and tool calls. Evaluations,
-when configured, add **optional** verdict tags on the GenAI span; guardrails are **optional**
-too and live on **separate** guardrail spans (`otel.library.name == 'cx_guardrails.client'`),
-not on the GenAI span. **Match the data to the question:** for **content** questions
-(quality, hallucination, sentiment, frustration, satisfaction, topics) read the input/output
-messages and reason about them; for everything else use the relevant tags/aggregations. For
-plain dialogue read the **user**/**assistant** turns, but the `system`/`tool` turns matter too
-when you're debugging an agent or sub-agent (tool calls, the task it was given). Pull the system
-prompt for system-prompt questions (`gen_ai.system_instructions` and/or the `role:'system'`
-message, usually index 0 — check both).
+Each interaction's spans carry the **conversation** plus model, tokens, cost, latency, errors,
+and tool calls. Two conventions store the conversation: **current** — `gen_ai.input.messages` /
+`gen_ai.output.messages` (one JSON-array string per side); **older indexed** —
+`gen_ai.prompt.<n>.{role,content}` / `gen_ai.completion.<n>.{role,content}` (one tag per message).
+Evaluations, when configured, add **optional** verdict tags on the GenAI span; guardrails are
+**optional** too and live on **separate** guardrail spans
+(`otel.library.name == 'cx_guardrails.client'`), not on the GenAI span. **Match the data to the
+question:** for **content** questions (quality, hallucination, sentiment, frustration,
+satisfaction, topics) read the conversation and reason about it; for everything else use the
+relevant tags/aggregations. Pull the system prompt only for system-prompt questions
+(`gen_ai.system_instructions` and/or the `role:'system'` turn, usually index 0 — check both).
 
 Read the interactions the question needs, ordered by recency — don't add a manual `limit`.
 Report how many matched vs. how many you read (e.g. "312 matched; I read the 200 most
 recent") and offer to narrow. Cite the `traceID` of any interaction you reference.
 
 Use `cx ai-center applications list` to get the exact `applicationName`/`subsystemName` pairs.
-The app filter below is **optional**: keep it to scope to one app, **drop it** for org-wide
-questions, or **group by** `$l.applicationName, $l.subsystemName` to compare.
+The app filter in the queries below is **optional**: keep it to scope to one app, **drop it** for
+org-wide questions, or **group by** `$l.applicationName, $l.subsystemName` to compare.
 
-Example — reading a conversation (drop the app filter for a global question):
-```dataprime
-source spans
-| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
-| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
-| filter tags['gen_ai.input.messages']:string != null   // for spans that carry a conversation
-| choose $m.timestamp as ts, $d.traceID as trace_id,
-         $l.applicationName as application, $l.subsystemName as subsystem,
-         tags['gen_ai.conversation.id']:string as conversation,
-         tags['gen_ai.request.model']:string as model,
-         tags['gen_ai.input.messages']:string as input_messages,
-         tags['gen_ai.output.messages']:string as output_messages
-| orderby ts desc
-```
-This selects the raw messages blobs (all roles) for you to read. To pull out only the
-**user**/**assistant** turns in-query, use the regex extraction under **Extracting conversation
-text** below.
+**To read the actual user+assistant transcript** — both conventions, system prompt and tool
+traffic excluded — use the queries under **Reading conversations (content questions)** below.
+Don't hand-select the raw `input.messages` blob for content questions: it carries the system
+prompt and tool traffic and bloats context.
 
 ---
 
@@ -197,7 +183,7 @@ preserve order); `redact` strips it. Same content-level caveat as the current co
 | `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / cache token fields | Token usage |
 | `gen_ai.prompt_price` / `gen_ai.response_price` / `gen_ai.read_cache_price` / `gen_ai.write_cache_price` | Cost (USD) |
 | `gen_ai.response.finish_reasons` | Stop reason (`~ 'length'` = truncated, `~ 'tool_call'` = tool use) |
-| `gen_ai.input.messages` / `gen_ai.output.messages` | Conversation transcript (read these for content) |
+| `gen_ai.input.messages` / `gen_ai.output.messages` (current) or `gen_ai.prompt.<n>` / `gen_ai.completion.<n>` (indexed) | Conversation transcript — read via the **Reading conversations** queries, don't grep raw |
 | `gen_ai.tool.{name,call.arguments,call.result}` / `gen_ai.tool.definitions` | Tools executed / advertised |
 | `gen_ai.{target}.evaluations.{type}.{score,label}`, `…evaluations.custom.{0..9}.{…}`, `guardrails.triggered` | Eval/guardrail results (see below) |
 
@@ -341,8 +327,9 @@ source spans
 Calls-per-interaction: `groupby traceID aggregate count_if(is_tool) as n | groupby n aggregate count() as cnt`.
 Tool usage %: `aggregate distinct_count(traceID) as total, distinct_count_if(is_tool, traceID) as with_tools`.
 
-**Q11 — Read interactions / AI Explorer:** the "read a conversation" query at the top (select
-`gen_ai.input.messages` / `gen_ai.output.messages`, tokens, cost, user, duration).
+**Q11 — Read interactions / AI Explorer:** use the **Reading conversations (content questions)**
+queries (current-convention `jsonobject`, indexed-convention `$d:string` + `multi_regexp`) to get
+the clean user+assistant transcript; add tokens/cost/user/duration tags alongside if needed.
 
 **Q12 — Session walkthrough:** `filter traceID == '<traceID>'` then read ordered turns.
 
@@ -372,6 +359,9 @@ source spans
          tags['gen_ai.input.messages']:string as input_messages, tags['gen_ai.output.messages']:string as output_messages
 | orderby ts asc | limit 200
 ```
+This is a raw per-step dump (tools included) for debugging an agent run. For the clean
+user+assistant transcript — either convention, system prompt/tools excluded — use the
+**Reading conversations (content questions)** queries instead.
 
 **Q15 — Evaluation score distribution / trend** (score is a 0–1 float, separate from `p1`):
 ```dataprime
@@ -389,8 +379,10 @@ Trend: `groupby roundTime($m.timestamp, <interval>ms) as Time aggregate avg(tags
 
 **Method for sentiment / satisfaction / frustration:**
 1. Scope to recent interactions (order by recency; no manual `limit`). State matched-vs-read.
-2. **Read the conversations — don't keyword-search for emotion.** Group by session
-   (`gen_ai.conversation.id`, fall back to `traceID`) and read each session's turns in order.
+2. **Read the conversations — don't keyword-search for emotion.** Use the **Reading conversations
+   (content questions)** queries (current or indexed convention) to get clean user+assistant
+   transcripts, group by session (`gen_ai.conversation.id`, fall back to `traceID`), and read each
+   session's turns in order.
 3. **Judge from the USER's side.** Read user turns: satisfied (got their answer, "thanks",
    no re-asks) vs not (re-asks/rephrasing, rising turns, negative wording, excessive `?`/`!`/
    CAPS, "that's not what I asked", abandonment). Response quality / `finish_reason` / evals are
@@ -405,9 +397,10 @@ description of the agent's reply. Don't dump raw ID lists.
   keyword filters.
 - **Counting a specific term** ("how often do users mention RUM?") is narrower — decide if they
   want a count, list, or examples. Match **user turns** at the **word level** (a bare `~ 'rum'`
-  also hits *forum/premium*), and **never grep the whole `gen_ai.input.messages` blob** (it
-  contains the system prompt + tool definitions, so it matches nearly everything). Report counts
-  as a floor.
+  also hits *forum/premium*) — extract them first with the **Reading conversations** queries — and
+  **never grep the whole `gen_ai.input.messages` blob (or the indexed `prompt.<n>` tags)**: they
+  carry the system prompt + tool definitions, so they match nearly everything. Report counts as a
+  floor.
 - **Quality / hallucination:** optionally pre-filter `…evaluations.{name}.label=='p1'`, but
   confirm by reading the messages.
 - **Root cause:** `otel.status_code=='ERROR'` (+ `error.type`), then read messages + errored

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -30,7 +30,7 @@ errors, and tool calls. Two conventions store the conversation — current
 `gen_ai.completion.<n>`); see **Reading conversations (content questions)** for each one's exact
 shape and how to read it. Evaluations, when configured, add **optional** verdict tags on the GenAI
 span; guardrails are **optional** too and live on **separate** guardrail spans
-(`otel.library.name == 'cx_guardrails.client'`), not on the GenAI span. **Match the data to the
+(`otel.library.name == 'cx_guardrails.client'`). **Match the data to the
 question:** for **content** questions (quality, hallucination, sentiment, frustration,
 satisfaction, topics) read the conversation and reason about it; for everything else use the
 relevant tags/aggregations. For plain dialogue read the **`user`**/**`assistant`** turns (via the **Reading conversations

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -102,8 +102,9 @@ roles as flat per-message tags — `gen_ai.prompt.<n>.{role,content}` /
 **Two conventions carry the conversation — handle both** (pick by which tags exist: use the
 **Current** query when `gen_ai.input.messages` is present, the **Indexed** query when
 `gen_ai.prompt.0.role` is present):
-- **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — a **single JSON blob** per side
-  holding **all** turns as `{role, parts:[{type, content}]}` objects.
+- **Current:** `gen_ai.input.messages` and `gen_ai.output.messages` are each **one tag holding a
+  JSON array of `{role, parts:[{type, content}]}` messages** — `input.messages` = the full input
+  history (all prior turns), `output.messages` = the model's response turn(s).
 - **Older indexed:** **one tag per message**, numbered from 0 — `gen_ai.prompt.<n>.role` /
   `gen_ai.prompt.<n>.content` for each **input** message and `gen_ai.completion.<n>.role` /
   `gen_ai.completion.<n>.content` for the **output** message(s). `gen_ai.prompt.0` is the first

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -1,0 +1,420 @@
+# AI Center — GenAI span querying (DataPrime), schema & playbooks
+
+This is the telemetry half of the AI Center skill: how to read GenAI interactions and
+compute AI metrics from **spans**, using the cx CLI. Run every query with:
+
+```bash
+cx spans '<DataPrime query>' --start now-1d --end now
+```
+
+`cx spans` defaults to the last 1 hour when you don't pass `--start`; widen it (e.g.
+`--start now-1d`) when the question needs more history and the user hasn't specified a window.
+Use `-o json` for machine-readable output. For general DataPrime/spans syntax see the
+`cx-telemetry-querying` skill and [dataprime-reference.md](dataprime-reference.md) /
+[spans-querying.md](spans-querying.md). For **configuration** (inventory, evaluations,
+policies, coverage, pricing) use the `cx ai-center` commands documented in the parent
+`SKILL.md` — that data is not in spans.
+
+> **Shell quoting:** DataPrime uses single quotes for string literals, so wrap the whole
+> query in double quotes and escape the `$` sigils (`\$d`, `\$l`, `\$m`) so the shell doesn't
+> expand them — or put the query in a file and pipe it in. Examples below show the raw
+> DataPrime; quote as needed for your shell.
+
+---
+
+## Golden rule: read the interactions, not just the verdicts
+
+Each interaction's spans carry the **conversation** (`gen_ai.input.messages` = the full chat
+history sent to the model — system/user/assistant/tool turns — and `gen_ai.output.messages` =
+the model's response) plus model, tokens, cost, latency, errors, and tool calls. Evaluations,
+when configured, add **optional** verdict tags on the GenAI span; guardrails are **optional**
+too and live on **separate** guardrail spans (`otel.library.name == 'cx_guardrails.client'`),
+not on the GenAI span. **Match the data to the question:** for **content** questions
+(quality, hallucination, sentiment, frustration, satisfaction, topics) read the input/output
+messages and reason about them; for everything else use the relevant tags/aggregations. For
+plain dialogue read the **user**/**assistant** turns, but the `system`/`tool` turns matter too
+when you're debugging an agent or sub-agent (tool calls, the task it was given). Pull the system
+prompt for system-prompt questions (`gen_ai.system_instructions` and/or the `role:'system'`
+message, usually index 0 — check both).
+
+Read the interactions the question needs, ordered by recency — don't add a manual `limit`.
+Report how many matched vs. how many you read (e.g. "312 matched; I read the 200 most
+recent") and offer to narrow. Cite the `traceID` of any interaction you reference.
+
+You usually **won't know the exact `applicationName`/`subsystemName` up front** — run
+`cx ai-center applications list` first to get the exact pairs. The app filter below is
+**optional**: keep it to scope to one app, **drop it** for org-wide questions, or **group by**
+`$l.applicationName, $l.subsystemName` for comparative ones (e.g. "which Olly region is most
+active").
+
+Example — reading a conversation (drop the app filter for a global question):
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+| filter tags['gen_ai.input.messages']:string != null   // for spans that carry a conversation
+| choose $m.timestamp as ts, $d.traceID as trace_id,
+         $l.applicationName as application, $l.subsystemName as subsystem,
+         tags['gen_ai.conversation.id']:string as conversation,
+         tags['gen_ai.request.model']:string as model,
+         tags['gen_ai.input.messages']:string as input_messages,
+         tags['gen_ai.output.messages']:string as output_messages
+| orderby ts desc
+```
+This selects the raw messages blobs (all roles) for you to read. To pull out only the
+**user**/**assistant** turns in-query, use the regex extraction under **Extracting conversation
+text** below.
+
+---
+
+## How AI Center data is stored
+
+**Granularity.** An **AI span** = one AI operation (an LLM call, embeddings, retrieval/agent/
+tool/workflow step, or a Guardrails SDK invocation). An **interaction** = the multiple spans
+under one `traceID` — one exchange plus the surrounding spans and operations. Counts (AI spans,
+errors, guardrail actions) are **span-level**; the only trace-level rate is Issue Rate (Q9). For
+a deduplicated interaction count use `distinct_count(traceID)` and say so.
+
+**Find GenAI spans — the mandatory filter on every AI Center query.** `source spans` also
+holds ordinary APM traffic; omitting this filter computes AI metrics over non-AI data and
+returns wrong answers.
+```dataprime
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+```
+To also include guardrail spans (for AI-span counts and issue/guardrail rates),
+add `|| tags['otel.library.name']:string == 'cx_guardrails.client'`. Guardrail spans are marked
+by `tags['otel.library.name'] == 'cx_guardrails.client'`; from there, filter by whatever the
+question needs — `tags['guardrails.triggered'] == 'true'` for **fired** guardrails, `== 'false'`
+for ones that **passed**, or the per-policy `gen_ai.{prompt|response}.guardrails.{policy}.triggered`
+tags for a specific guardrail.
+
+> An **AI application** is a GenAI `($l.applicationName, $l.subsystemName)` **pair** — the apps
+> returned by `cx ai-center applications list`, not every `applicationName` in spans. **AI error
+> rate** = `otel.status_code == 'ERROR'` on GenAI spans (not generic HTTP 5xx). When unsure
+> which apps are AI apps, get them from `cx ai-center applications list`.
+
+**Scoping to an application.** A name may live in either `applicationName` or `subsystemName`;
+if a filter returns nothing, try the other field, or use `cx search-fields "<name>" --dataset spans`
+to find which field holds it. Time = `$m.timestamp` (`roundTime($m.timestamp, <interval>ms)`
+for series); duration = `$m.duration` (µs).
+
+**End-user identity:**
+```dataprime
+| create user from firstNonNull(tags['enduser.id'], tags['user.id'], tags['gen_ai.request.user'], tags['traceloop.association.properties.user_id'], tags['langsmith.metadata.user_id'])
+```
+
+**Message formats.** `gen_ai.input.messages` / `gen_ai.output.messages` are JSON arrays of
+`{role, parts:[{type, content}]}` (part `type` = `text`, `tool_call`, `tool_call_response`,
+`reasoning`, `blob`/`file`/`uri`). Roles: `user` = the end user's turn; `assistant` = the
+model's turn (may carry `tool_call` parts); `tool` = a tool's output fed back (`role:'tool'`,
+not `user`); `system` = the system prompt (usually index 0). To read what the user asked, take
+`text` parts of `role:'user'` messages.
+
+> **Two conventions carry the conversation — handle both.**
+> - **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — a **single** JSON blob
+>   holding **all** turns.
+> - **Older indexed:** **one tag per message**, numbered from 0 — `gen_ai.prompt.<n>.role` /
+>   `gen_ai.prompt.<n>.content` for each **input** message (`n = 0,1,2,…` in order) and
+>   `gen_ai.completion.<n>.role` / `gen_ai.completion.<n>.content` for the **output** message(s).
+>   So `gen_ai.prompt.0.content` is just the **first** message; the whole conversation is spread
+>   across `prompt.0, prompt.1, …` and `completion.0, …`.
+>
+> Different SDKs emit one convention or the other. **Prefer `input.messages` / `output.messages`;
+> when they are null, fall back to the indexed keys** — read `gen_ai.prompt.<n>` /
+> `gen_ai.completion.<n>` across all `n` (not just `.0`) to reconstruct the full conversation.
+> Apply this fallback everywhere you read prompt/response content below.
+
+**Extracting conversation text** (cheaper than parsing the whole blob). First-turn user ask +
+assistant reply — note the content capture `(?:[^"\\]|\\.)*` spans escaped quotes so messages
+aren't truncated:
+```dataprime
+| extract tags['gen_ai.input.messages']:string into u using regexp(e=/"role"\s*:\s*"user"[\s\S]*?"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
+| extract tags['gen_ai.output.messages']:string into a using regexp(e=/"role"\s*:\s*"assistant"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
+| choose $d.traceID as trace_id, u.text as user_text, a.text as assistant_text
+```
+Every turn (multi-turn): concat input history with the model's reply, match with
+`multi_regexp`, `explode`, re-extract:
+```dataprime
+| create convo from concat(tags['gen_ai.input.messages']:string, tags['gen_ai.output.messages']:string)
+| extract convo into turns using multi_regexp(e=/"role"\s*:\s*"(?:user|assistant)"[\s\S]*?"content"\s*:\s*"(?:[^"\\]|\\.)*"/)
+| explode turns into turn original preserve   // `original preserve` keeps the parent row's other columns (e.g. $d.traceID) on every exploded turn
+| extract turn into m using regexp(e=/"role"\s*:\s*"(?<role>\w+)"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
+| choose $d.traceID as trace_id, m.role, m.text
+```
+(`explode` normally drops the source row's other fields; `original preserve` keeps them, so each
+turn still carries its `traceID`.)
+
+**Span attributes (GenAI spans).** Span kind — `gen_ai.operation.name`: `chat` (also
+`generate_content`, `text_completion`), `embeddings`, `retrieval` (RAG), `create_agent`,
+`invoke_agent`, `invoke_workflow`, `execute_tool`.
+
+| Attribute | Meaning |
+| --- | --- |
+| `gen_ai.provider.name` (or deprecated `gen_ai.system`) | Provider |
+| `otel.status_code` (`ERROR`) / `error.type` | Failure status / error class |
+| `otel.library.name` | `cx_guardrails.client` marks a guardrail span |
+| `gen_ai.agent.{id,name,description,version}` / `gen_ai.workflow.name` | Agent / workflow identity |
+| `gen_ai.request.model` / `gen_ai.response.model` / `gen_ai.response.id` | Requested / actual model; completion id |
+| `gen_ai.conversation.id` | Conversation/session/thread id |
+| `enduser.id` / `user.id` (+ fallbacks above) | End user |
+| `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / cache token fields | Token usage |
+| `gen_ai.prompt_price` / `gen_ai.response_price` / `gen_ai.read_cache_price` / `gen_ai.write_cache_price` | Cost (USD) |
+| `gen_ai.response.finish_reasons` | Stop reason (`~ 'length'` = truncated, `~ 'tool_call'` = tool use) |
+| `gen_ai.input.messages` / `gen_ai.output.messages` | Conversation transcript (read these for content) |
+| `gen_ai.tool.{name,call.arguments,call.result}` / `gen_ai.tool.definitions` | Tools executed / advertised |
+| `gen_ai.{target}.evaluations.{type}.{score,label}`, `…evaluations.custom.{0..9}.{…}`, `guardrails.triggered` | Eval/guardrail results (see below) |
+
+**Cost (USD):** total = `firstNonNull(gen_ai.prompt_price,0)+firstNonNull(gen_ai.response_price,0)`;
+cache: `gen_ai.read_cache_price`/`gen_ai.write_cache_price`. Cache token accounting differs by
+provider: OpenAI-style `cache_read` ⊂ `input_tokens`; Anthropic-style input/cache_read/
+cache_creation are disjoint. Custom per-model pricing is team-wide, new data only — read it via
+`cx ai-center model-pricing get` (price tags already reflect it).
+
+---
+
+## Evaluations, Guardrails & Policies
+
+A **policy** is a configurable check. The same policy can act as an **evaluation** (post-hoc
+scoring/flagging) and/or a **guardrail** (real-time block). UI evaluation categories:
+Hallucinations, Security, Toxicity, Topics, User experience, Compliance, plus Custom (typed
+Quality or Security).
+
+**Evaluations** run on spans and write results back as tags. The target is **`prompt` or
+`response`** (the backend supports only these two — ignore the unused `conversation` enum value):
+- Built-in: `gen_ai.{prompt|response}.evaluations.{eval_type}.{score|label|version|details}`.
+  **`label == 'p1'` marks a flagged issue.**
+- Custom: `gen_ai.{target}.evaluations.custom.{0..9}.{name,target,category,triggered,score,label}`
+  (`triggered` is the string `"true"`/`"false"`).
+- Eval types — Hallucinations: `hallucination_context_adherence|context_relevance|completeness|correctness|task_adherence`, `sql_hallucination`;
+  Security: `prompt_injection`, `pii`, `sql_read_only|sql_load|sql_restricted_tables|sql_allowed_tables`;
+  Toxicity: `toxicity`, `sexism`; Topics: `restricted_topics`, `allowed_topics`, `competition`;
+  User experience: `language_mismatch`.
+- **Issue class:** Security = `prompt_injection`, `pii`, `sql_*`; everything else = Quality.
+
+**Guardrails** act in real time via the `cx-guardrails` SDK and **block** on violation. Each
+invocation is a span (`otel.library.name == 'cx_guardrails.client'`) with
+`tags['guardrails.triggered'] == 'true'` when it fired; `$l.operationName` starts with
+`guardrails.prompt`/`guardrails.response`. Prebuilt: Prompt Injection, PII, Toxicity — plus
+**custom** guardrails.
+
+**Configuration is not telemetry.** Which policies exist, which are enabled per app, the
+inventory, guarded status (`guardrailsIntegrated`), coverage, and the team's **custom model
+pricing** (`cx ai-center model-pricing get`) come from the backend — use the `cx ai-center`
+commands, not span queries.
+
+---
+
+## DataPrime query library (Q1–Q15, runnable)
+
+Q1–Q15 are the queries behind the AI Center UI widgets — here to **show the agent how each
+metric is computed, not as mandatory copy-paste**. If the user asks something the UI already
+answers, use the matching Q as-is; if it's close, take the relevant fields and adjust; if it's
+new, compose your own using these as reference. Keep the GenAI filter, set the time range, and
+scope to one app with `| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'`
+(drop for org-wide).
+
+**Q1 — Key insights (batched)** — Models Used, Time to Response, Token Usage, Estimated Cost,
+Errors, Guardrail Actions, AI Spans, Unique Users:
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter ((tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))) || tags['otel.library.name']:string == 'cx_guardrails.client'
+| create cost from firstNonNull(tags['gen_ai.prompt_price']:number,0) + firstNonNull(tags['gen_ai.response_price']:number,0)
+| create tokens from firstNonNull(tags['gen_ai.usage.input_tokens']:number,0) + firstNonNull(tags['gen_ai.usage.output_tokens']:number,0)
+| create user from firstNonNull(tags['enduser.id'], tags['user.id'], tags['gen_ai.request.user'], tags['traceloop.association.properties.user_id'], tags['langsmith.metadata.user_id'])
+| aggregate count() as ai_spans, avg(duration) as ttr_avg, sum(tokens) as token_usage,
+            sum(cost) as estimated_cost, count_if(tags['otel.status_code']:string == 'ERROR') as errors,
+            count_if(tags['guardrails.triggered']:string.toLowerCase() == 'true') as guardrail_actions,
+            distinct_count(user) as unique_users,
+            collect(firstNonNull(tags['gen_ai.request.model']:string, ''), distinct=true) as models_used
+```
+> Q1 is a **batched** query computing many metrics at once. When the user asks for **one**
+> metric, run a minimal query with only that aggregation (and the `create` lines it needs). TTR only → `… | aggregate avg(duration) as ttr_avg`
+> (or `percentile(0.95, duration)`; selector 0.5/0.75/0.9/0.95/0.99). Issue Rate = Q9.
+
+**Q2 — Response time (avg + percentiles):**
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+| aggregate avg(duration) as avg, percentile(0.75, duration) as p75, percentile(0.90, duration) as p90, percentile(0.95, duration) as p95, percentile(0.99, duration) as p99
+```
+For a response-time **trend over time**, add `| groupby roundTime($m.timestamp, <interval>ms) as Time` before the aggregate and `| orderby Time` after.
+
+**Q3 — Latency by model:** as Q2 but `groupby firstNonNull(tags['gen_ai.request.model']:string,'unknown') as model`, `orderby avg desc`.
+
+**Q4 — Top slowest apps/spans:** groupby `$l.applicationName, $l.subsystemName` (apps) or `$l.operationName` (spans), `aggregate avg(duration) as avg | orderby avg desc | limit 5`.
+
+**Q5 — Cost & tokens (totals):**
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+| create input_tokens from firstNonNull(tags['gen_ai.usage.input_tokens']:number,0)
+| create output_tokens from firstNonNull(tags['gen_ai.usage.output_tokens']:number,0)
+| create cache_read from firstNonNull(tags['gen_ai.usage.cache_read.input_tokens']:number, tags['gen_ai.usage.cache_read_input_tokens']:number, 0)
+| create cache_creation from firstNonNull(tags['gen_ai.usage.cache_creation.input_tokens']:number, tags['gen_ai.usage.cache_creation_input_tokens']:number, 0)
+| create cost from firstNonNull(tags['gen_ai.prompt_price']:number,0) + firstNonNull(tags['gen_ai.response_price']:number,0)
+| aggregate sum(cost) as cost, sum(input_tokens) as inputTokens, sum(output_tokens) as outputTokens, sum(cache_read) as cacheReadTokens, sum(cache_creation) as cacheCreationTokens
+```
+Cache Hit Rate = `sum(cacheReadTokens)/sum(inputTokens)`. For a cost/tokens **trend over time**, add `| groupby roundTime($m.timestamp, <interval>ms) as Time` before the aggregate and `| orderby Time` after.
+
+**Q6 — Cost by model:** as Q5 but `groupby firstNonNull(tags['gen_ai.request.model']:string,'unknown') as model | orderby cost desc`.
+
+**Q7 — Most expensive apps / high-spending users:** as Q5 but `groupby $l.applicationName,$l.subsystemName` (apps) or the `user` expr, `aggregate sum(cost) as cost, sum(input_tokens+output_tokens) as tokens | orderby cost desc | limit 5`.
+
+**Q8 — Errors (count) / top errored:**
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+| aggregate count() as total, count_if(tags['otel.status_code']:string == 'ERROR') as errors
+```
+For an errors **trend over time**, add `| groupby roundTime($m.timestamp, <interval>ms) as Time` before the aggregate and `| orderby Time` after. Top errored apps/spans: `groupby $l.applicationName,$l.subsystemName` (or `$l.operationName`) `aggregate count_if(tags['otel.status_code']:string=='ERROR') as errors | orderby errors desc | limit 5`.
+
+**Q9 — Issue rate (trace-level).** An issue on a target = any built-in eval `label == 'p1'`
+OR any custom eval `custom.{0..9}` with `triggered == 'true'` OR a guardrail that fired on
+that target. Repeat the `{eval}` term per enabled eval type and the `custom.{n}` term per
+configured index (for AI-SPM use only security types):
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter ((tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))) || tags['otel.library.name']:string == 'cx_guardrails.client'
+| create prompt_issue from (tags['gen_ai.prompt.evaluations.{eval}.label']:string == 'p1' || tags['gen_ai.prompt.evaluations.custom.0.triggered']:string.toLowerCase() == 'true' || ($l.operationName.startsWith('guardrails.prompt') && tags['guardrails.triggered']:string.toLowerCase() == 'true'))
+| create response_issue from (tags['gen_ai.response.evaluations.{eval}.label']:string == 'p1' || tags['gen_ai.response.evaluations.custom.0.triggered']:string.toLowerCase() == 'true' || ($l.operationName.startsWith('guardrails.response') && tags['guardrails.triggered']:string.toLowerCase() == 'true'))
+| groupby traceID aggregate max(if(prompt_issue,1,0)) as p, max(if(response_issue,1,0)) as r
+| aggregate count() as traces, sum(p) as prompt_issue_traces, sum(r) as response_issue_traces
+| create prompt_issue_rate from prompt_issue_traces*100.0/traces
+| create response_issue_rate from response_issue_traces*100.0/traces
+```
+Issue Distribution / Top Apps With Issues = the same detection grouped by eval **category**
+(Security = `prompt_injection`/`pii`/`sql_*`; else Quality) or by `$l.applicationName`.
+
+**Q10 — Tool calls:**
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+| create is_tool from (tags['gen_ai.operation.name']:string == 'execute_tool' || tags['gen_ai.response.finish_reasons']:string ~ 'tool_call')
+| filter is_tool
+| extract tags['gen_ai.output.messages']:string into msg_tool using regexp(e=/"type"\s*:\s*"tool_call".*?"name"\s*:\s*"(?<name>[^"]+)"/)
+| create tool from firstNonNull(tags['gen_ai.tool.name']:string, msg_tool.name, 'unknown')
+| groupby tool aggregate count() as uses | orderby uses desc
+```
+Calls-per-interaction: `groupby traceID aggregate count_if(is_tool) as n | groupby n aggregate count() as cnt`.
+Tool usage %: `aggregate distinct_count(traceID) as total, distinct_count_if(is_tool, traceID) as with_tools`.
+
+**Q11 — Read interactions / AI Explorer:** the "read a conversation" query at the top (select
+`gen_ai.input.messages` / `gen_ai.output.messages`, tokens, cost, user, duration).
+
+**Q12 — Session walkthrough:** `filter traceID == '<traceID>'` then read ordered turns.
+
+**Q13 — Who's using / sessions & user insights:**
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+| create user from firstNonNull(tags['enduser.id'], tags['user.id'], tags['gen_ai.request.user'], tags['traceloop.association.properties.user_id'], tags['langsmith.metadata.user_id'])
+| filter user != null
+| groupby user aggregate count() as interactions, distinct_count(tags['gen_ai.conversation.id']) as sessions,
+            sum(firstNonNull(tags['gen_ai.prompt_price']:number,0)+firstNonNull(tags['gen_ai.response_price']:number,0)) as cost
+| orderby interactions desc | limit 5
+```
+High-Activity = orderby interactions; High-Spend = orderby cost; Risky = add a security-eval
+`count_if(...label=='p1')` and orderby that.
+
+**Q14 — Agentic workflow walkthrough:**
+```dataprime
+source spans
+| filter traceID:string == '<traceID>'
+| filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
+| choose $m.timestamp as ts, tags['gen_ai.operation.name']:string as step,
+         tags['gen_ai.agent.name']:string as agent, tags['gen_ai.workflow.name']:string as workflow,
+         tags['gen_ai.tool.name']:string as tool, tags['gen_ai.tool.call.arguments']:string as tool_args,
+         tags['gen_ai.tool.call.result']:string as tool_result, tags['gen_ai.request.model']:string as model,
+         tags['gen_ai.input.messages']:string as input_messages, tags['gen_ai.output.messages']:string as output_messages
+| orderby ts asc | limit 200
+```
+
+**Q15 — Evaluation score distribution / trend** (score is a 0–1 float, separate from `p1`):
+```dataprime
+source spans
+| filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
+| filter tags['gen_ai.response.evaluations.{eval}.score']:number != null
+| create bucket from round(tags['gen_ai.response.evaluations.{eval}.score']:number, 1)
+| groupby bucket aggregate count() as n | orderby bucket
+```
+Trend: `groupby roundTime($m.timestamp, <interval>ms) as Time aggregate avg(tags['gen_ai.response.evaluations.{eval}.score']:number) as avg_score`. Swap `response`→`prompt` for the other target.
+
+---
+
+## Phase 1 — interaction intelligence (read the content)
+
+**Method for sentiment / satisfaction / frustration:**
+1. Scope to recent interactions (order by recency; no manual `limit`). State matched-vs-read.
+2. **Read the conversations — don't keyword-search for emotion.** Group by session
+   (`gen_ai.conversation.id`, fall back to `traceID`) and read each session's turns in order.
+3. **Judge from the USER's side.** Read user turns: satisfied (got their answer, "thanks",
+   no re-asks) vs not (re-asks/rephrasing, rising turns, negative wording, excessive `?`/`!`/
+   CAPS, "that's not what I asked", abandonment). Response quality / `finish_reason` / evals are
+   secondary — never the headline. Don't pivot a satisfaction question into "the app is broken".
+
+**Answer shape:** summarize the split, then back it with a few **verbatim user-message quotes +
+their `traceID`** (satisfied and dissatisfied) — an example is the user's own words, not a
+description of the agent's reply. Don't dump raw ID lists.
+
+- **Topic analysis** ("what do users ask about?") is an LLM-judgment task — read recent user
+  turns and cluster the asks yourself; report themes + how many you read. Don't bucket with
+  keyword filters.
+- **Counting a specific term** ("how often do users mention RUM?") is narrower — decide if they
+  want a count, list, or examples. Match **user turns** at the **word level** (a bare `~ 'rum'`
+  also hits *forum/premium*), and **never grep the whole `gen_ai.input.messages` blob** (it
+  contains the system prompt + tool definitions, so it matches nearly everything). Report counts
+  as a floor.
+- **Quality / hallucination:** optionally pre-filter `…evaluations.{name}.label=='p1'`, but
+  confirm by reading the messages.
+- **Root cause:** `otel.status_code=='ERROR'` (+ `error.type`), then read messages + errored
+  child spans; watch truncation, tool failures, retrieval misses. **Pull the whole trace
+  (`filter $d.traceID == '<id>'`), not just the GenAI spans** — the cause often lives in a
+  sibling **non-GenAI** span (a DB call, HTTP request, retrieval step).
+- **Agent behaving off-task / deviating from its instructions:** read the **system prompt**
+  (`gen_ai.system_instructions` and/or the `role:'system'` turn) alongside the user/assistant
+  turns, and judge whether the responses stayed within the task the system prompt defines.
+  Cite the `traceID`s where it drifted.
+
+---
+
+## Examples (question → approach)
+> When a question names an app/agent, **run `cx ai-center applications list` first** to resolve
+> the exact `applicationName`/`subsystemName` pair before scoping a query.
+
+- *"Which of my agents / LLM apps do I have?"* → `cx ai-center applications list`.
+- *"Average time to response for Financial Advisor last 24h?"* → list apps to get the exact
+  pair, then **Q1** (`ttr_avg`) scoped to it, `--start now-1d` (or **Q2** for the trend;
+  `percentile(0.95, duration)` for P95).
+- *"Token spend by model this week?"* → **Q6**, `--start now-7d`.
+- *"Which apps have the highest error rate?"* → **Q8** top variant, no app scope.
+- *"Which region / agent is the most active?"* → GenAI filter, no app scope, `groupby
+  $l.applicationName, $l.subsystemName aggregate count() as spans | orderby spans desc`.
+- *"Which agent deviates from its intended task?"* → read each agent's **system prompt** +
+  user/assistant turns and judge drift (see the agent-deviation playbook); cite traceIDs.
+- *"Compare agent X now vs a week ago"* / *"compare agent X to agent Y"* → run the relevant Q
+  twice with different `--start`/`--end` windows, or grouped by `$l.applicationName,$l.subsystemName`,
+  and diff the results (e.g. cost, error rate, latency, or the system prompt via a trace from each).
+- *"Are users frustrated in app X?"* → Phase 1 frustration playbook (**Q11** to read the
+  conversations; quote user turns + traceIDs).
+- *"Which apps lack guardrails?"* → `cx ai-center applications list -o json | jq '[.[]|select(.guardrailsIntegrated==false)]'` (config).
+- *"What policies are configured for app X?"* → `cx ai-center evaluations list --application <app> --subsystem <sub>`.
+
+## Troubleshooting
+- **No rows for an app** — the name may be in `subsystemName` not `applicationName`; try the
+  other field or `cx search-fields "<name>" --dataset spans`; widen the time range.
+- **Empty `gen_ai.*.messages`** — the app isn't capturing content (opt-in); say so.
+- **No eval/guardrail tags** — those policies aren't enabled; still answer content questions by
+  reading messages.
+- **Guarded status / configured policies / inventory / coverage** — configuration; use the
+  `cx ai-center` commands, not spans.
+- **AI Security Posture Score** — backend-computed; no CLI command or span query returns it.
+  Say so rather than trying to derive it.
+- **AI App Discovery** (GitHub repo scan) — not reachable from the CLI (the scan service only
+  accepts user-session auth). Explain it exists; don't attempt to fetch it.

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -99,15 +99,6 @@ roles as flat per-message tags — `gen_ai.prompt.<n>.{role,content}` /
 
 ### Reading conversations (content questions)
 
-For "are `<APP>`/`<SUB>` customers satisfied",
-"do users repeat themselves", quality, hallucination, "did the agent answer" — the answer is in
-the **user asks + model replies**, not verdict/score tags. Read the user's `type:"text"` messages
-and the model's `type:"text"` replies. **Build the query to exclude** the system prompt
-(`role:"system"` turn or the `gen_ai.system_instructions` tag) and tool traffic (`tool_call` /
-`tool_call_response`, `role:"tool"`) so they never enter the result — the system prompt especially
-would bloat context. (Read the system prompt only when the question is whether the agent followed
-its instructions.)
-
 **Two conventions carry the conversation — handle both** (pick by which tags exist: use the
 **Current** query when `gen_ai.input.messages` is present, the **Indexed** query when
 `gen_ai.prompt.0.role` is present):

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -362,9 +362,6 @@ source spans
          tags['gen_ai.input.messages']:string as input_messages, tags['gen_ai.output.messages']:string as output_messages
 | orderby ts asc | limit 200
 ```
-This is a raw per-step dump (tools included) for debugging an agent run. For the clean
-user+assistant transcript — either convention, system prompt/tools excluded — use the
-**Reading conversations (content questions)** queries instead.
 
 **Q15 — Evaluation score distribution / trend** (score is a 0–1 float, separate from `p1`):
 ```dataprime

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -118,8 +118,10 @@ for series); duration = `$m.duration` (µs).
 
 Prefer `input.messages` / `output.messages`; when null, use the indexed tags.
 
-**Current convention — extract text** (`(?:[^"\\]|\\.)*` spans escaped quotes so long messages
-aren't truncated):
+**Current convention — extract text.** Use the regex (not a raw fetch of `input.messages`): it
+returns only user + model text and never the system prompt, whether that prompt sits at index 0 of
+the array or in a separate tag. (`(?:[^"\\]|\\.)*` spans escaped quotes so long messages aren't
+truncated.)
 ```dataprime
 | extract tags['gen_ai.input.messages']:string into u using regexp(e=/"role"\s*:\s*"user"[\s\S]*?"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
 | extract tags['gen_ai.output.messages']:string into a using regexp(e=/"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -184,7 +184,7 @@ preserve order); `redact` strips it. Same content-level caveat as the current co
 | `enduser.id` / `user.id` (+ fallbacks above) | End user |
 | `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / cache token fields | Token usage |
 | `gen_ai.prompt_price` / `gen_ai.response_price` / `gen_ai.read_cache_price` / `gen_ai.write_cache_price` | Cost (USD) |
-| `gen_ai.response.finish_reasons` | Stop reason (`~ 'length'` = truncated, `~ 'tool_call'` = tool use) |
+| `gen_ai.response.finish_reasons` | Stop reason (`~ 'length'` = truncated; `~ 'tool_'` = tool call — values seen: `tool_call`/`tool_calls`/`tool_use`) |
 | `gen_ai.input.messages` / `gen_ai.output.messages` (current) or `gen_ai.prompt.<n>` / `gen_ai.completion.<n>` (indexed) | Conversation transcript — read via the **Reading conversations (content questions)** queries, don't grep raw |
 | `gen_ai.tool.{name,call.arguments,call.result}` / `gen_ai.tool.definitions` | Tools executed / advertised |
 | `gen_ai.{target}.evaluations.{type}.{score,label}`, `…evaluations.custom.{0..9}.{…}`, `guardrails.triggered` | Eval/guardrail results (see below) |
@@ -320,7 +320,7 @@ Issue Distribution / Top Apps With Issues = the same detection grouped by eval *
 source spans
 | filter $l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'
 | filter (tags['gen_ai.system']:string != null || tags['gen_ai.provider.name']:string != null || tags['gen_ai.operation.name']:string != null) && !(['cursor-agent','codex_cli_rs','codex-app-server','github-copilot','gemini-cli'].arrayContains($l.serviceName))
-| create is_tool from (tags['gen_ai.operation.name']:string == 'execute_tool' || tags['gen_ai.response.finish_reasons']:string ~ 'tool_call')
+| create is_tool from (tags['gen_ai.operation.name']:string == 'execute_tool' || tags['gen_ai.response.finish_reasons']:string ~ 'tool_')
 | filter is_tool
 | extract tags['gen_ai.output.messages']:string into msg_tool using regexp(e=/"type"\s*:\s*"tool_call".*?"name"\s*:\s*"(?<name>[^"]+)"/)
 | create tool from firstNonNull(tags['gen_ai.tool.name']:string, msg_tool.name, 'unknown')
@@ -429,7 +429,8 @@ description of the agent's reply. Don't dump raw ID lists.
 - *"Which region / agent is the most active?"* → GenAI filter, no app scope, `groupby
   $l.applicationName, $l.subsystemName aggregate count() as spans | orderby spans desc`.
 - *"Which agent deviates from its intended task?"* → read each agent's **system prompt** +
-  user/assistant turns and judge drift (see the agent-deviation playbook); cite traceIDs.
+  user/assistant turns and judge drift (see the *Agent behaving off-task* bullet in Phase 1);
+  cite traceIDs.
 - *"Compare agent X now vs a week ago"* / *"compare agent X to agent Y"* → run the relevant Q
   twice with different `--start`/`--end` windows, or grouped by `$l.applicationName,$l.subsystemName`,
   and diff the results (e.g. cost, error rate, latency, or the system prompt via a trace from each).

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -152,8 +152,12 @@ source spans
 | choose $d.traceID as trace_id, $d.tags as tags
 | limit 1
 ```
-- Key off `.role` (`system`/`user`/`assistant`/`tool`), not the index. Latest user ask = highest
-  `n` where `prompt.<n>.role == "user"`; read its `.content`. Reply = the `completion.<n>` turn(s).
+- **System prompt:** the `prompt.<n>` where `.role == "system"` → read its `.content`.
+- **User input (full history):** the highest `n` where `prompt.<n>.role == "user"` → its
+  `.content`. The last user turn carries the accumulated conversation, so it's the one to read.
+- **Model output:** the `completion.<n>` turn(s) → `.content` (or `…tool_calls.*` if it answered
+  with a tool call).
+- Key off `.role` (`system`/`user`/`assistant`/`tool`), **not the index**.
 - Tool-call turns (prompt or completion) have `…tool_calls.*` and **no `.content`** — that's why
   the filter uses `.role`, not `.content`.
 - A handoff span may have **no `user` turn** (the ask is on an earlier span).

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -105,12 +105,12 @@ for series); duration = `$m.duration` (µs).
 `tool` / `system`, part `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
 `blob`/`file`/`uri`.
 
-**What to read (both encodings):**
+**What to read (both conventions):**
 - **User input** = `type:"text"` parts of `role:"user"` messages — read all of them.
 - **Model output** = `type:"text"` parts of the response.
 - **System prompt** = the `role:"system"` message's text.
 
-**Two encodings:**
+**Two conventions:**
 - **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — one JSON blob per side, each
   turn `{role, parts:[{type, content}]}`.
 - **Older indexed:** one tag per message — `gen_ai.prompt.<n>.{role,content}` (input),

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -41,11 +41,9 @@ Read the interactions the question needs, ordered by recency — don't add a man
 Report how many matched vs. how many you read (e.g. "312 matched; I read the 200 most
 recent") and offer to narrow. Cite the `traceID` of any interaction you reference.
 
-You usually **won't know the exact `applicationName`/`subsystemName` up front** — run
-`cx ai-center applications list` first to get the exact pairs. The app filter below is
-**optional**: keep it to scope to one app, **drop it** for org-wide questions, or **group by**
-`$l.applicationName, $l.subsystemName` for comparative ones (e.g. "which Olly region is most
-active").
+Use `cx ai-center applications list` to get the exact `applicationName`/`subsystemName` pairs.
+The app filter below is **optional**: keep it to scope to one app, **drop it** for org-wide
+questions, or **group by** `$l.applicationName, $l.subsystemName` to compare.
 
 Example — reading a conversation (drop the app filter for a global question):
 ```dataprime

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -101,66 +101,47 @@ for series); duration = `$m.duration` (µs).
 | create user from firstNonNull(tags['enduser.id'], tags['user.id'], tags['gen_ai.request.user'], tags['traceloop.association.properties.user_id'], tags['langsmith.metadata.user_id'])
 ```
 
-**Message formats.** `gen_ai.input.messages` / `gen_ai.output.messages` are JSON arrays of
-`{role, parts:[{type, content}]}` (part `type` = `text`, `tool_call`, `tool_call_response`,
-`reasoning`, `blob`/`file`/`uri`). Roles: `user` = the end user's turn; `assistant` = the
-model's turn (may carry `tool_call` parts); `tool` = a tool's output fed back (`role:'tool'`,
-not `user`); `system` = the system prompt (usually index 0). To read what the user asked, take
-`text` parts of `role:'user'` messages.
+**Message formats.** Messages are `{role, parts:[{type, content}]}`; roles `user` / `assistant` /
+`tool` / `system`, part `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
+`blob`/`file`/`uri`.
 
-> **Two conventions carry the conversation — handle both.**
-> - **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — a **single** JSON blob
->   holding **all** turns.
-> - **Older indexed:** **one tag per message**, numbered from 0 — `gen_ai.prompt.<n>.role` /
->   `gen_ai.prompt.<n>.content` for each **input** message (`n = 0,1,2,…` in order) and
->   `gen_ai.completion.<n>.role` / `gen_ai.completion.<n>.content` for the **output** message(s).
->   Tool-call turns (prompt **or** completion) carry `…tool_calls.*` instead of a `.content`.
->   So `gen_ai.prompt.0.content` is just the **first** message; the whole conversation is spread
->   across `prompt.0, prompt.1, …` and `completion.0, …`.
->
-> Different SDKs emit one convention or the other. **Prefer `input.messages` / `output.messages`;
-> when they are null, fall back to the indexed keys** — read `gen_ai.prompt.<n>` /
-> `gen_ai.completion.<n>` across all `n` (not just `.0`) to reconstruct the full conversation.
-> Apply this fallback everywhere you read prompt/response content below.
+**What to read (both encodings):**
+- **User input** = `type:"text"` parts of `role:"user"` messages — read all of them.
+- **Model output** = `type:"text"` parts of the response.
+- **System prompt** = the `role:"system"` message's text.
 
-**Extracting conversation text** (cheaper than parsing the whole blob). First-turn user ask +
-assistant reply — note the content capture `(?:[^"\\]|\\.)*` spans escaped quotes so messages
-aren't truncated:
+**Two encodings:**
+- **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — one JSON blob per side, each
+  turn `{role, parts:[{type, content}]}`.
+- **Older indexed:** one tag per message — `gen_ai.prompt.<n>.{role,content}` (input),
+  `gen_ai.completion.<n>.{role,content}` (output), `n = 0,1,2,…`.
+
+Prefer `input.messages` / `output.messages`; when null, use the indexed tags.
+
+**Current convention — extract text** (`(?:[^"\\]|\\.)*` spans escaped quotes so long messages
+aren't truncated):
 ```dataprime
 | extract tags['gen_ai.input.messages']:string into u using regexp(e=/"role"\s*:\s*"user"[\s\S]*?"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
-| extract tags['gen_ai.output.messages']:string into a using regexp(e=/"role"\s*:\s*"assistant"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
-| choose $d.traceID as trace_id, u.text as user_text, a.text as assistant_text
+| extract tags['gen_ai.output.messages']:string into a using regexp(e=/"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
+| choose $d.traceID as trace_id, u.text as user_input, a.text as model_output
 ```
-Every turn (multi-turn): concat input history with the model's reply, match with
-`multi_regexp`, `explode`, re-extract:
+All user turns — `multi_regexp` + `explode`:
 ```dataprime
-| create convo from concat(tags['gen_ai.input.messages']:string, tags['gen_ai.output.messages']:string)
-| extract convo into turns using multi_regexp(e=/"role"\s*:\s*"(?:user|assistant)"[\s\S]*?"content"\s*:\s*"(?:[^"\\]|\\.)*"/)
-| explode turns into turn original preserve   // `original preserve` keeps the parent row's other columns (e.g. $d.traceID) on every exploded turn
-| extract turn into m using regexp(e=/"role"\s*:\s*"(?<role>\w+)"[\s\S]*?"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
-| choose $d.traceID as trace_id, m.role, m.text
+| extract tags['gen_ai.input.messages']:string into turns using multi_regexp(e=/"role"\s*:\s*"user"[\s\S]*?"type"\s*:\s*"text"[\s\S]*?"content"\s*:\s*"(?:[^"\\]|\\.)*"/)
+| explode turns into turn original preserve
+| extract turn into m using regexp(e=/"content"\s*:\s*"(?<text>(?:[^"\\]|\\.)*)"/)
+| choose $d.traceID as trace_id, m.text as user_input
 ```
-(`explode` normally drops the source row's other fields; `original preserve` keeps them, so each
-turn still carries its `traceID`.)
 
-**Indexed convention** (`gen_ai.prompt.<n>` / `gen_ai.completion.<n>`, `n = 0,1,2,…`) — when
-`input.messages` / `output.messages` are absent. One numbered tag per message. Fetch the whole map
-and pick from the JSON (DataPrime can't iterate numbered keys):
+**Indexed convention — same rule, flat tags:**
 ```dataprime
 source spans
-| filter tags['gen_ai.prompt.0.role'] != null
-| choose $d.traceID as trace_id, $d.tags as tags
-| limit 1
+| filter $d.traceID == '<trace-id>' && tags['gen_ai.prompt.0.role'] != null
+| choose $d.spanID as span_id, $d.tags as tags
 ```
-- **System prompt:** the `prompt.<n>` where `.role == "system"` → read its `.content`.
-- **User input (full history):** the highest `n` where `prompt.<n>.role == "user"` → its
-  `.content`. The last user turn carries the accumulated conversation, so it's the one to read.
-- **Model output:** the `completion.<n>` turn(s) → `.content` (or `…tool_calls.*` if it answered
-  with a tool call).
-- Key off `.role` (`system`/`user`/`assistant`/`tool`), **not the index**.
-- Tool-call turns (prompt or completion) have `…tool_calls.*` and **no `.content`** — that's why
-  the filter uses `.role`, not `.content`.
-- A handoff span may have **no `user` turn** (the ask is on an earlier span).
+- **User input** = each `prompt.<n>` with `.role == "user"` → `.content`.
+- **Model output** = `completion.<n>.content`.
+- **System prompt** = the `prompt.<n>` with `.role == "system"` → `.content`.
 
 **Span attributes (GenAI spans).** Span kind — `gen_ai.operation.name`: `chat` (also
 `generate_content`, `text_completion`), `embeddings`, `retrieval` (RAG), `create_agent`,

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -82,7 +82,7 @@ returns wrong answers.
 To also include guardrail spans (for AI-span counts and issue/guardrail rates),
 add `|| tags['otel.library.name']:string == 'cx_guardrails.client'`. Guardrail spans are marked
 by `tags['otel.library.name'] == 'cx_guardrails.client'`; from there, filter by whatever the
-question needs — `tags['guardrails.triggered'] == 'true'` for **fired** guardrails, `== 'false'`
+question needs — `tags['guardrails.triggered'] == 'true'` for **triggered** guardrails, `== 'false'`
 for ones that **passed**, or the per-policy `gen_ai.{prompt|response}.guardrails.{policy}.triggered`
 tags for a specific guardrail.
 
@@ -114,6 +114,7 @@ not `user`); `system` = the system prompt (usually index 0). To read what the us
 > - **Older indexed:** **one tag per message**, numbered from 0 — `gen_ai.prompt.<n>.role` /
 >   `gen_ai.prompt.<n>.content` for each **input** message (`n = 0,1,2,…` in order) and
 >   `gen_ai.completion.<n>.role` / `gen_ai.completion.<n>.content` for the **output** message(s).
+>   Tool-call turns (prompt **or** completion) carry `…tool_calls.*` instead of a `.content`.
 >   So `gen_ai.prompt.0.content` is just the **first** message; the whole conversation is spread
 >   across `prompt.0, prompt.1, …` and `completion.0, …`.
 >
@@ -141,6 +142,37 @@ Every turn (multi-turn): concat input history with the model's reply, match with
 ```
 (`explode` normally drops the source row's other fields; `original preserve` keeps them, so each
 turn still carries its `traceID`.)
+
+**Indexed convention** (`gen_ai.prompt.<n>` / `gen_ai.completion.<n>`) — when `input.messages` /
+`output.messages` are absent. Here each message is **its own numbered tag**
+(`gen_ai.prompt.<n>.role` / `.content`, `gen_ai.completion.<n>.role` / `.content`; `n = 0,1,2,…`).
+DataPrime has no way to iterate an unknown set of numbered keys (there's no `tags.keys()`), so
+**don't** try to reconstruct it inside the query. Instead fetch the whole tag map for the one span
+that carries the prompt tags and read the numbered keys off the returned object:
+```dataprime
+source spans
+| filter tags['gen_ai.prompt.0.role'] != null   // the LLM span holding the indexed prompt tags
+| choose $d.traceID as trace_id, $d.tags as tags
+| limit 1
+```
+The returned `tags` object contains every `gen_ai.prompt.<n>.*` and `gen_ai.completion.<n>.*`;
+read them in index order — **the picking happens on the JSON you got back, not in DataPrime.** To
+get the latest user ask, scan the `prompt.<n>.role` entries and take the **highest `n` whose
+`.role == "user"`**, then read that `prompt.<n>.content`; the reply is the `completion.<n>`
+turn(s). (There's no in-query way to compute this — DataPrime can't iterate the numbered keys, so
+the agent does it on the returned object.) Notes from real spans:
+- **Filter on `.role`, not `.content`** — every message has a `.role`, but tool-call turns
+  (prompt **or** completion) carry `…tool_calls.*` and **no `.content`**, so a `.content` filter
+  can miss the span.
+- **Key off `.role`, not the index.** The system prompt is the turn whose `.role == "system"`
+  (its `.content` is the system prompt) — typically `.0`, but identify it by role, not position.
+  The user's ask, when present, is the next `role:"user"` turn (e.g. `prompt.1`). Roles are
+  `system` / `user` / `assistant` / `tool`. A multi-agent/handoff span may have **no `user` turn
+  at all** (the ask lives on an earlier agent's span) — so read the roles, don't assume the ask is
+  here.
+- Indices run as high as the history is long (a real weather-agent span used
+  `gen_ai.prompt.0`…`.11`), which is exactly why this "grab the map, pick from the JSON" approach
+  beats any fixed index ladder — no hard-coded ceiling.
 
 **Span attributes (GenAI spans).** Span kind — `gen_ai.operation.name`: `chat` (also
 `generate_content`, `text_completion`), `embeddings`, `retrieval` (RAG), `create_agent`,
@@ -191,7 +223,7 @@ Quality or Security).
 
 **Guardrails** act in real time via the `cx-guardrails` SDK and **block** on violation. Each
 invocation is a span (`otel.library.name == 'cx_guardrails.client'`) with
-`tags['guardrails.triggered'] == 'true'` when it fired; `$l.operationName` starts with
+`tags['guardrails.triggered'] == 'true'` when it triggered; `$l.operationName` starts with
 `guardrails.prompt`/`guardrails.response`. Prebuilt: Prompt Injection, PII, Toxicity — plus
 **custom** guardrails.
 
@@ -271,7 +303,7 @@ source spans
 For an errors **trend over time**, add `| groupby roundTime($m.timestamp, <interval>ms) as Time` before the aggregate and `| orderby Time` after. Top errored apps/spans: `groupby $l.applicationName,$l.subsystemName` (or `$l.operationName`) `aggregate count_if(tags['otel.status_code']:string=='ERROR') as errors | orderby errors desc | limit 5`.
 
 **Q9 — Issue rate (trace-level).** An issue on a target = any built-in eval `label == 'p1'`
-OR any custom eval `custom.{0..9}` with `triggered == 'true'` OR a guardrail that fired on
+OR any custom eval `custom.{0..9}` with `triggered == 'true'` OR a guardrail that triggered on
 that target. Repeat the `{eval}` term per enabled eval type and the `custom.{n}` term per
 configured index (for AI-SPM use only security types):
 ```dataprime

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -24,17 +24,21 @@ policies, coverage, pricing) use the `cx ai-center` commands documented in the p
 
 ## Golden rule: read the interactions, not just the verdicts
 
-Each interaction's spans carry the **conversation** plus model, tokens, cost, latency, errors,
-and tool calls. Two conventions store the conversation: **current** — `gen_ai.input.messages` /
-`gen_ai.output.messages` (one JSON-array string per side); **older indexed** —
-`gen_ai.prompt.<n>.{role,content}` / `gen_ai.completion.<n>.{role,content}` (one tag per message).
-Evaluations, when configured, add **optional** verdict tags on the GenAI span; guardrails are
-**optional** too and live on **separate** guardrail spans
+Each interaction's **GenAI spans** carry the **conversation** plus model, tokens, cost, latency,
+errors, and tool calls. Two conventions store the conversation — current
+(`gen_ai.input.messages` / `gen_ai.output.messages`) and older indexed (`gen_ai.prompt.<n>` /
+`gen_ai.completion.<n>`); see **Reading conversations (content questions)** for each one's exact
+shape and how to read it. Evaluations, when configured, add **optional** verdict tags on the GenAI
+span; guardrails are **optional** too and live on **separate** guardrail spans
 (`otel.library.name == 'cx_guardrails.client'`), not on the GenAI span. **Match the data to the
 question:** for **content** questions (quality, hallucination, sentiment, frustration,
 satisfaction, topics) read the conversation and reason about it; for everything else use the
-relevant tags/aggregations. Pull the system prompt only for system-prompt questions
-(`gen_ai.system_instructions` and/or the `role:'system'` turn, usually index 0 — check both).
+relevant tags/aggregations. For plain dialogue read the **`user`**/**`assistant`** turns (via the **Reading conversations
+(content questions)** queries below), but the **`system`**/**`tool`** turns matter too when you're
+debugging an agent or sub-agent (the tool calls it made and the task it was given). Pull the system prompt only for system-prompt questions —
+it lives in the `gen_ai.system_instructions` tag **or** the `role:"system"` turn: the first
+`role:"system"` message inside `gen_ai.input.messages` (current) / `gen_ai.prompt.0.content` when
+`gen_ai.prompt.0.role == "system"` (indexed). Check both places.
 
 Read the interactions the question needs, ordered by recency — don't add a manual `limit`.
 Report how many matched vs. how many you read (e.g. "312 matched; I read the 200 most
@@ -87,9 +91,11 @@ for series); duration = `$m.duration` (µs).
 | create user from firstNonNull(tags['enduser.id'], tags['user.id'], tags['gen_ai.request.user'], tags['traceloop.association.properties.user_id'], tags['langsmith.metadata.user_id'])
 ```
 
-**Message formats.** Messages are `{role, parts:[{type, content}]}`; roles `user` / `assistant` /
-`tool` / `system`, part `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
-`blob`/`file`/`uri`.
+**Message formats.** `gen_ai.input.messages` / `gen_ai.output.messages` are JSON arrays of
+`{role, parts:[{type, content}]}` (part `type` = `text`, `tool_call`, `tool_call_response`,
+`reasoning`, `blob`/`file`/`uri`). (The older indexed convention stores the same
+roles as flat per-message tags — `gen_ai.prompt.<n>.{role,content}` /
+`gen_ai.completion.<n>.{role,content}`, no `parts` array — see Reading conversations below.)
 
 ### Reading conversations (content questions)
 
@@ -102,15 +108,18 @@ and the model's `type:"text"` replies. **Build the query to exclude** the system
 would bloat context. (Read the system prompt only when the question is whether the agent followed
 its instructions.)
 
-**Flow:** (1) filter to the app — `$l.applicationName == '<APP>' && $l.subsystemName == '<SUB>'`;
-(2) key each conversation — `firstNonNull(tags['gen_ai.conversation.id']:string, $d.traceID)`;
-(3) extract only user + model text (below); read each conversation's turns in order, judge from the
-user's side.
-
-**Two conventions** — pick by which tags exist: use the **Current** query when
-`gen_ai.input.messages` is present; use the **Indexed** query when `gen_ai.prompt.0.role` is present.
-- **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — one JSON blob per side.
-- **Older indexed:** `gen_ai.prompt.<n>.{role,content}` / `gen_ai.completion.<n>.{role,content}`.
+**Two conventions carry the conversation — handle both** (pick by which tags exist: use the
+**Current** query when `gen_ai.input.messages` is present, the **Indexed** query when
+`gen_ai.prompt.0.role` is present):
+- **Current:** `gen_ai.input.messages` / `gen_ai.output.messages` — a **single JSON blob** per side
+  holding **all** turns as `{role, parts:[{type, content}]}` objects.
+- **Older indexed:** **one tag per message**, numbered from 0 — `gen_ai.prompt.<n>.role` /
+  `gen_ai.prompt.<n>.content` for each **input** message and `gen_ai.completion.<n>.role` /
+  `gen_ai.completion.<n>.content` for the **output** message(s). `gen_ai.prompt.0` is the first
+  message (usually the system prompt); the conversation is spread across `prompt.0, prompt.1, …`
+  and `completion.0, …`. An assistant turn that calls tools carries
+  `gen_ai.prompt.<n>.tool_calls.*` (function name/arguments/id) and **no** `.content`; a tool
+  **result** comes back as `role:"tool"` with its output in `.content`.
 
 **Current convention — general conversation read.** Parse the messages JSON with `jsonobject()`,
 keep `user`/`assistant` roles (drops `system` + `tool`) and `type:"text"` parts (drops `tool_call`

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -91,7 +91,9 @@ for series); duration = `$m.duration` (µs).
 `tool` / `system`, part `type` ∈ `text`, `tool_call`, `tool_call_response`, `reasoning`,
 `blob`/`file`/`uri`.
 
-**Reading conversations (content questions).** For "are `<APP>`/`<SUB>` customers satisfied",
+### Reading conversations (content questions)
+
+For "are `<APP>`/`<SUB>` customers satisfied",
 "do users repeat themselves", quality, hallucination, "did the agent answer" — the answer is in
 the **user asks + model replies**, not verdict/score tags. Read the user's `type:"text"` messages
 and the model's `type:"text"` replies. **Build the query to exclude** the system prompt
@@ -183,7 +185,7 @@ preserve order); `redact` strips it. Same content-level caveat as the current co
 | `gen_ai.usage.input_tokens` / `gen_ai.usage.output_tokens` / cache token fields | Token usage |
 | `gen_ai.prompt_price` / `gen_ai.response_price` / `gen_ai.read_cache_price` / `gen_ai.write_cache_price` | Cost (USD) |
 | `gen_ai.response.finish_reasons` | Stop reason (`~ 'length'` = truncated, `~ 'tool_call'` = tool use) |
-| `gen_ai.input.messages` / `gen_ai.output.messages` (current) or `gen_ai.prompt.<n>` / `gen_ai.completion.<n>` (indexed) | Conversation transcript — read via the **Reading conversations** queries, don't grep raw |
+| `gen_ai.input.messages` / `gen_ai.output.messages` (current) or `gen_ai.prompt.<n>` / `gen_ai.completion.<n>` (indexed) | Conversation transcript — read via the **Reading conversations (content questions)** queries, don't grep raw |
 | `gen_ai.tool.{name,call.arguments,call.result}` / `gen_ai.tool.definitions` | Tools executed / advertised |
 | `gen_ai.{target}.evaluations.{type}.{score,label}`, `…evaluations.custom.{0..9}.{…}`, `guardrails.triggered` | Eval/guardrail results (see below) |
 
@@ -397,7 +399,7 @@ description of the agent's reply. Don't dump raw ID lists.
   keyword filters.
 - **Counting a specific term** ("how often do users mention RUM?") is narrower — decide if they
   want a count, list, or examples. Match **user turns** at the **word level** (a bare `~ 'rum'`
-  also hits *forum/premium*) — extract them first with the **Reading conversations** queries — and
+  also hits *forum/premium*) — extract them first with the **Reading conversations (content questions)** queries — and
   **never grep the whole `gen_ai.input.messages` blob (or the indexed `prompt.<n>` tags)**: they
   carry the system prompt + tool definitions, so they match nearly everything. Report counts as a
   floor.

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -35,8 +35,8 @@ question:** for **content** questions (quality, hallucination, sentiment, frustr
 satisfaction, topics) read the conversation and reason about it; for everything else use the
 relevant tags/aggregations. For plain dialogue read the **`user`**/**`assistant`** turns (via the **Reading conversations
 (content questions)** queries below), but the **`system`**/**`tool`** turns matter too when you're
-debugging an agent or sub-agent (the tool calls it made and the task it was given). Pull the system prompt only for system-prompt questions —
-it lives in the `gen_ai.system_instructions` tag **or** the `role:"system"` turn: the first
+debugging an agent or sub-agent (the tool calls it made and the task it was given). The system
+prompt lives in the `gen_ai.system_instructions` tag **or** the `role:"system"` turn: the first
 `role:"system"` message inside `gen_ai.input.messages` (current) / `gen_ai.prompt.0.content` when
 `gen_ai.prompt.0.role == "system"` (indexed). Check both places.
 

--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -143,36 +143,20 @@ Every turn (multi-turn): concat input history with the model's reply, match with
 (`explode` normally drops the source row's other fields; `original preserve` keeps them, so each
 turn still carries its `traceID`.)
 
-**Indexed convention** (`gen_ai.prompt.<n>` / `gen_ai.completion.<n>`) — when `input.messages` /
-`output.messages` are absent. Here each message is **its own numbered tag**
-(`gen_ai.prompt.<n>.role` / `.content`, `gen_ai.completion.<n>.role` / `.content`; `n = 0,1,2,…`).
-DataPrime has no way to iterate an unknown set of numbered keys (there's no `tags.keys()`), so
-**don't** try to reconstruct it inside the query. Instead fetch the whole tag map for the one span
-that carries the prompt tags and read the numbered keys off the returned object:
+**Indexed convention** (`gen_ai.prompt.<n>` / `gen_ai.completion.<n>`, `n = 0,1,2,…`) — when
+`input.messages` / `output.messages` are absent. One numbered tag per message. Fetch the whole map
+and pick from the JSON (DataPrime can't iterate numbered keys):
 ```dataprime
 source spans
-| filter tags['gen_ai.prompt.0.role'] != null   // the LLM span holding the indexed prompt tags
+| filter tags['gen_ai.prompt.0.role'] != null
 | choose $d.traceID as trace_id, $d.tags as tags
 | limit 1
 ```
-The returned `tags` object contains every `gen_ai.prompt.<n>.*` and `gen_ai.completion.<n>.*`;
-read them in index order — **the picking happens on the JSON you got back, not in DataPrime.** To
-get the latest user ask, scan the `prompt.<n>.role` entries and take the **highest `n` whose
-`.role == "user"`**, then read that `prompt.<n>.content`; the reply is the `completion.<n>`
-turn(s). (There's no in-query way to compute this — DataPrime can't iterate the numbered keys, so
-the agent does it on the returned object.) Notes from real spans:
-- **Filter on `.role`, not `.content`** — every message has a `.role`, but tool-call turns
-  (prompt **or** completion) carry `…tool_calls.*` and **no `.content`**, so a `.content` filter
-  can miss the span.
-- **Key off `.role`, not the index.** The system prompt is the turn whose `.role == "system"`
-  (its `.content` is the system prompt) — typically `.0`, but identify it by role, not position.
-  The user's ask, when present, is the next `role:"user"` turn (e.g. `prompt.1`). Roles are
-  `system` / `user` / `assistant` / `tool`. A multi-agent/handoff span may have **no `user` turn
-  at all** (the ask lives on an earlier agent's span) — so read the roles, don't assume the ask is
-  here.
-- Indices run as high as the history is long (a real weather-agent span used
-  `gen_ai.prompt.0`…`.11`), which is exactly why this "grab the map, pick from the JSON" approach
-  beats any fixed index ladder — no hard-coded ceiling.
+- Key off `.role` (`system`/`user`/`assistant`/`tool`), not the index. Latest user ask = highest
+  `n` where `prompt.<n>.role == "user"`; read its `.content`. Reply = the `completion.<n>` turn(s).
+- Tool-call turns (prompt or completion) have `…tool_calls.*` and **no `.content`** — that's why
+  the filter uses `.role`, not `.content`.
+- A handoff span may have **no `user` turn** (the ask is on an earlier span).
 
 **Span attributes (GenAI spans).** Span kind — `gen_ai.operation.name`: `chat` (also
 `generate_content`, `text_completion`), `embeddings`, `retrieval` (RAG), `create_agent`,

--- a/skills/cx-ai-center/references/dataprime-reference.md
+++ b/skills/cx-ai-center/references/dataprime-reference.md
@@ -1,0 +1,254 @@
+# DataPrime Query Language Reference
+
+## Query Structure
+
+A DataPrime query is a pipeline of commands separated by `|`. Each command transforms the output of the previous one:
+
+```dataprime
+filter $m.severity == ERROR | groupby $l.subsystemname aggregate count() as errors
+```
+
+### Source Handling
+
+Every query targets a **source** (`logs`, `spans`, etc.). The source is set by whichever `cx` command you use. A full query with an explicit source looks like:
+
+```dataprime
+source <logs|spans> | filter ... | groupby ...
+```
+
+When running via a source-specific command (e.g. `cx logs`, `cx spans`), the source is injected automatically - omit it from the query. When running via `cx dataprime query`, use the `--source` flag or include `source` in the query itself.
+
+The examples below focus on the DataPrime query language and omit the source and CLI command prefix.
+
+### Comments
+
+Comments are supported with `#` or `//`:
+
+```dataprime
+filter $m.severity == ERROR  # only errors
+| limit 10                   // cap results
+```
+
+## Data Prefixes
+
+All fields are accessed through three namespaces:
+
+| Prefix | Description | Examples |
+|--------|-------------|----------|
+| `$m` | Metadata (system-managed) | `$m.timestamp`, `$m.severity`, `$m.duration` |
+| `$l` | Labels (indexed key-value pairs) | `$l.applicationname`, `$l.subsystemname`, `$l.serviceName` |
+| `$d` | User data (application payload) | `$d.message`, `$d.user_id`, `$d.traceID` |
+
+`$d` is the default prefix and can sometimes be omitted, but being explicit avoids ambiguity.
+
+## Data Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `string` | Text, enclosed in **single quotes** | `'some_text'` |
+| `number` | Numeric value | `123`, `3.14` |
+| `boolean` | True or false | `true`, `false` |
+| `timestamp` | Date and time (nanoseconds since epoch) | `1714636800000000000` |
+| `interval` | Time duration | `1h`, `1d`, `1w` |
+| `array` | List of values | `[1, 2, 3]` |
+| `object` | Key-value pairs | `{"name": "John"}` |
+| `null` | Missing value or key | `null` |
+
+## Commands
+
+### Filtering and Selection
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `filter` | Keep rows matching a condition | `filter $m.severity == ERROR` |
+| `choose` | Select specific fields | `choose $m.timestamp, $d.message` |
+| `limit` | Cap the number of results | `limit 10` |
+| `wildfind` | Search all fields for a string (see note below) | `wildfind 'connection refused'` |
+| `lucene` | Filter using Lucene syntax | `lucene 'key:field:"value"'` |
+
+> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
+
+### Aggregation
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `groupby` | Group rows and apply aggregations | `groupby $l.subsystemname aggregate count() as n` |
+| `multigroupby` | Group by multiple field sets | `multigroupby a, b aggregate count()` |
+| `count` | Count all rows | `count` |
+| `countby` | Count rows grouped by a field | `countby $l.applicationname` |
+| `distinct` | Return unique values of a field | `distinct $l.subsystemname` |
+
+### Transformation
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `create` | Add a computed field | `create latency_ms from $m.duration / 1000` |
+| `orderby` | Sort results | `orderby $d.timestamp desc` |
+| `extract` | Parse fields with regex or JSON | See [Text Extraction](#text-extraction) |
+| `dedupeby` | Remove duplicates by a field | `dedupeby $m.templateid` |
+
+## Operators
+
+| Operator | Description | Example |
+|----------|-------------|---------|
+| `==` | Equals | `filter $m.severity == ERROR` |
+| `!=` | Not equals | `filter $l.subsystemname != 'test'` |
+| `>`, `<`, `>=`, `<=` | Comparison | `filter $d.response_time > 1000` |
+| `~` | Contains (substring match) | `filter $d.message ~ 'timeout'` |
+| `&&` | AND | `filter $m.severity == ERROR && $l.applicationname == 'api'` |
+| `\|\|` | OR | `filter $m.severity == ERROR \|\| $m.severity == CRITICAL` |
+| `!= null` | Field exists | `filter $d.some_field != null` |
+
+## Type Conversions
+
+Cast fields inline with `:type`:
+
+```dataprime
+filter $d.http_error_code:number == 500
+```
+
+Supported types: `bool`, `number`, `string`, `timestamp`, `interval`, `array`, `object`
+
+## Field Access
+
+```dataprime
+# Chained field names (dot notation)
+filter $d.tags.user_context.email == 'test@example.com'
+
+# Special characters require brackets
+filter $d.http['status/code'] == 500
+```
+
+## Aggregation Functions
+
+| Function | Description |
+|----------|-------------|
+| `count()` | Count rows |
+| `sum($field)` | Sum values |
+| `avg($field)` | Average |
+| `min($field)` | Minimum |
+| `max($field)` | Maximum |
+| `percentile(0.95, $field)` | Percentile |
+| `median($field)` | Median value |
+| `stddev($field)` | Standard deviation |
+| `variance($field)` | Variance |
+| `distinct_count($field)` | Count unique values |
+| `any_value($field)` | Random sample value |
+| `collect($field)` | Collect values into an array |
+
+Example - full CLI invocation:
+```bash
+cx dataprime query --source logs 'groupby $l.subsystemname aggregate count() as error_count, avg($d.response_time) as avg_response | orderby error_count desc'
+```
+
+## Utility Functions
+
+### firstNonNull - Field Coalescing
+
+Return the first non-null value from a list of fields. Useful when the same data may appear in different fields across log sources:
+
+```dataprime
+# Merge fields
+create message from firstNonNull($d.error_message, $d.msg, $d.body)
+
+# Use inside groupby
+groupby firstNonNull($d.error_message, $d.msg) as message aggregate count() as n
+```
+
+### Template Sampling
+
+Find top error patterns with a sample message for each:
+
+```dataprime
+filter $m.severity == ERROR | groupby $m.templateid aggregate any_value($d) as sample, count() as total | orderby total desc | limit 5
+```
+
+## Time-Based Grouping
+
+Use `roundTime()` to bucket timestamps:
+
+```dataprime
+# Group by hour
+groupby roundTime($m.timestamp, 1h) as hour aggregate count() as count
+
+# Error rate over 15-minute intervals
+filter $m.severity == ERROR | groupby roundTime($m.timestamp, 15m) as interval aggregate count() as errors
+```
+
+## Multi-Value Matching
+
+Use `arrayContains` to match against a set of values:
+
+```dataprime
+# Match multiple subsystems
+filter ['api', 'web', 'worker'].arrayContains($l.subsystemname)
+
+# Match multiple severity levels
+filter [ERROR, CRITICAL].arrayContains($m.severity)
+```
+
+## Text Extraction
+
+### Regex Extraction
+
+```dataprime
+# Extract with unnamed capture group
+extract $d.email into domain using regexp(e=/@(.*)/) | distinct $d.domain._0
+
+# Named capture groups
+extract $d.email into extracted using regexp(e=/(?<username>[a-zA-Z0-9._%+-]+)@(?<domain>.*)/) | choose $d.extracted.username, $d.extracted.domain
+```
+
+### JSON String Parsing
+
+```dataprime
+# Parse a JSON string field into an object for further querying
+extract $d.json_payload into parsed using jsonobject() | filter $d.parsed.status == 'failed'
+```
+
+## Deduplication
+
+```dataprime
+# Remove duplicates by log template
+dedupeby $m.templateid
+
+# Dedupe by a custom field
+dedupeby $d.request_id
+```
+
+## Built-In Documentation
+
+For the full list of commands and functions with detailed syntax:
+
+```bash
+cx dataprime list                              # List all commands and functions
+cx dataprime list --filter commands             # Commands only
+cx dataprime list --filter functions --name time # Search functions by name
+cx dataprime show filter                        # Detailed help for a specific command
+cx dataprime show groupby
+```
+
+## Validating a DataPrime query
+
+A query that looks right can still fail on a typoed field path, an invented function, or a malformed pipeline stage. Validate before trusting the output — a short-window run through the CLI is cheap and catches almost all of these:
+
+```bash
+cx logs  '<pipeline>' --start now-15m --end now --limit 1
+cx spans '<pipeline>' --start now-15m --end now --limit 1
+```
+
+`now-15m` is a good default; widen it only if 15 minutes is unlikely to exercise the pipeline. Per "Source Handling" above, omit any leading `source logs` / `source spans` — `cx logs` and `cx spans` inject the source themselves.
+
+Check both the exit code and the output — some errors surface only in the output.
+
+**Pass** = exit 0 and the output is rows or `[]` with no error or warning lines.
+
+**Hard fail** — query is broken, fix it:
+- non-zero exit
+- `error from profile '...': API request failed` — HTTP error from the API
+- `Compilation errors:` — parse error, unknown function, malformed expression
+
+**Soft fail** (needs investigation):
+- `keypath does not exist` — the query parsed, but no record in the window had the referenced field. This is ambiguous: the field name might be a typo, or it might be real but absent from records in this 15-minute slice. Confirm with `cx search-fields "<field hint>" --dataset logs` (or `--dataset spans`). If the field is real, the query is fine — try a wider window or accept the empty result. If it isn't, fix the field name.
+
+On fail: re-discover fields with `cx search-fields`, look up command syntax with `cx dataprime show <command>`, fix, re-run.

--- a/skills/cx-ai-center/references/spans-querying.md
+++ b/skills/cx-ai-center/references/spans-querying.md
@@ -1,0 +1,298 @@
+# Span Querying Reference
+
+Query and analyze distributed tracing data using the `cx spans` command with DataPrime syntax.
+
+> **DataPrime syntax:** See `dataprime-reference.md` for the full query language reference.
+
+## Understanding Spans in Coralogix
+
+Spans are the fundamental unit of tracing data. **Traces are not stored as single entities** - they are logical groupings of spans that share the same `traceID`. To analyze a trace, you query its constituent spans.
+
+This means:
+- **Metadata (`$m.*`)** and **labels (`$l.*`)** are predictable - you can always filter on timestamp, duration, service name, and operation name without discovery.
+- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentSpanID`) and application-specific tags/attributes that vary by service. Always verify custom `$d` fields before assuming they exist.
+
+---
+
+## CLI Command
+
+```bash
+cx spans '<dataprime_query>'
+```
+
+The `source spans` is automatically injected - do not include it in the query.
+
+### Options
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--start` | `now-1h` | Start time (ISO 8601 or relative, e.g. `now-6h`) |
+| `--end` | `now` | End time |
+| `--limit` | `200` | Maximum number of results |
+| `--tier` | `frequent` | Storage tier: `frequent` (hot/recent) or `archive` (cold/historical) |
+| `-o, --output` | `text` | Output format: `text`, `json`, or `agents` |
+
+---
+
+## Span Data Model
+
+### Standard Fields (Always Available)
+
+| Field | Description |
+|-------|-------------|
+| `$m.timestamp` | Span start timestamp |
+| `$m.duration` | Span duration in **microseconds** (see [Duration Units](#duration-units)) |
+| `$l.applicationName` | Application name - highest-level label. Meaning varies by customer (environment, team, region) but it always exists. |
+| `$l.subsystemName` | Subsystem name - second-level label. Typically maps to a component. |
+| `$l.serviceName` | Service name - the logical service unit emitting the span. |
+| `$l.operationName` | Operation name - the span title (e.g. "POST /checkout", "db.query"). |
+| `$d.traceID` | Trace ID - groups spans into a single trace. |
+| `$d.spanID` | Unique span identifier. |
+| `$d.parentSpanID` | Parent span ID (empty string for root spans). |
+| `$d.*` | Application-specific tags and attributes (see [Field Discovery](#field-discovery)). |
+
+> **Note on label fields:** The meaning of `$l.applicationName` and `$l.subsystemName` varies by customer - they may represent environments, teams, regions, or something else entirely. Don't assume what they map to. Use `cx search-fields` or sample queries to verify actual values.
+
+### Duration Units
+
+`$m.duration` is in **microseconds**:
+- 500ms = `500000`
+- 1s = `1000000`
+- 1min = `60000000`
+
+When presenting duration values, always convert to human-readable units (milliseconds, seconds, or minutes) and include the unit. Never display raw microsecond values or the "µs" symbol.
+
+```dataprime
+# Computed field for milliseconds
+create latency_ms from $m.duration / 1000
+```
+
+### Error Detection
+
+Spans do not have a `$m.severity` field like logs. Errors are typically indicated by:
+- `$d.tags.error == true` - the most common convention (OpenTelemetry/Jaeger)
+- Status codes in custom fields (e.g. `$d.http.status_code`, `$d.grpc.status_code`)
+- Other application-specific error tags
+
+The exact field depends on the instrumentation library used. If `$d.tags.error` returns no results, inspect sample spans with `-o json` to discover how errors are tagged:
+
+```bash
+cx spans "filter \$l.serviceName == 'api'" --limit 5 -o json
+```
+
+---
+
+## Essential Query Examples
+
+```bash
+# Get all spans for a trace
+cx spans "filter \$d.traceID == '4f6a8f3c2e8a1b97'"
+
+# Find spans for a service
+cx spans "filter \$l.serviceName == 'checkout-service'"
+
+# Find slow spans (> 1 second)
+cx spans "filter \$m.duration > 1000000"
+
+# Find error spans
+cx spans "filter \$d.tags.error == true"
+
+# Aggregate latency by operation
+cx spans "groupby \$l.operationName aggregate avg(\$m.duration) as avg_latency | orderby avg_latency desc"
+
+# Wider time range
+cx spans "filter \$l.serviceName == 'api'" --start now-6h
+```
+
+### Wildfind Policy
+
+**Avoid `wildfind` by default.** It scans all fields and is expensive.
+
+The **one exception**: when the user provides a specific string and you don't know which field contains it:
+
+```bash
+cx spans "wildfind 'connection refused'"
+```
+
+> **Tip:** `wildfind` can also serve as a last-resort field discovery method - when `cx search-fields` doesn't find what you need, run `wildfind` with a known value, then inspect the matching spans to see which fields contain it.
+
+---
+
+## Field Discovery
+
+**Skip discovery when:**
+- The query only uses standard fields (`$m.duration`, `$l.serviceName`, `$l.operationName`, `$d.traceID`)
+- The user explicitly names the fields they want
+- The fields have already been discovered earlier in the conversation
+
+### 1. Infer from Source Code (Preferred)
+
+If you have access to the application's source code, examine OpenTelemetry instrumentation, span attribute definitions, and tracing middleware to identify field names directly.
+
+### 2. Semantic Search
+
+```bash
+cx search-fields "customer identifier" --dataset spans
+cx search-fields "order ID" --dataset spans
+cx search-fields "http response code" --dataset spans
+```
+
+Note: `cx search-fields` only has access to the most common fields. If it doesn't find what you need, fall back to sample query inspection.
+
+### 3. Sample Query Inspection
+
+```bash
+cx spans "filter \$l.serviceName == 'api'" --limit 5 -o json
+```
+
+Inspect the JSON output to see all available fields. Especially useful for discovering fields in unstructured or deeply nested data.
+
+---
+
+## Investigation Workflow
+
+### 1. Understand the Request
+
+Identify:
+- Whether you have a trace ID, service name, or error description
+- Time frame of interest
+- Whether the question is about latency, errors, or request flow
+
+### 2. Start with Known Information
+
+**If you have a trace ID** - go straight to it:
+```bash
+cx spans "filter \$d.traceID == '<trace_id>'"
+```
+
+**If you have a service name** - query its spans:
+```bash
+cx spans "filter \$l.serviceName == '<service>'" --limit 50
+```
+
+**If you have neither** - start broad to find entry points:
+```bash
+# Find recent error spans
+cx spans "filter \$d.tags.error == true" --limit 20
+
+# Find the slowest spans in the last hour
+cx spans "groupby \$l.serviceName, \$l.operationName aggregate avg(\$m.duration) as avg_latency | orderby avg_latency desc | limit 10"
+
+# Then extract trace IDs from interesting spans
+cx spans "filter \$l.serviceName == '<service>' && \$m.duration > 1000000 | distinct \$d.traceID"
+```
+
+### 3. Troubleshooting
+
+If a query returns no results, change **one thing at a time**:
+
+1. **Extend the time range**: `--start now-6h` or `--start now-24h`
+2. **Relax filters**: remove the most restrictive condition
+3. **Check field availability**: the field you're filtering by may only exist in a subset of spans
+4. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+5. **Check service names**: service names are case-sensitive
+6. **Try archive tier**: `--tier archive --start now-30d` for older data
+
+---
+
+## Common Query Patterns
+
+### Trace Reconstruction
+
+```bash
+# All spans for a trace
+cx spans "filter \$d.traceID == '4f6a8f3c2e8a1b97'"
+
+# Find root spans only (no parent)
+cx spans "filter \$l.serviceName == 'api-gateway' | filter \$d.parentId == null"
+
+# Find trace IDs for a service
+cx spans "filter \$l.serviceName == 'payment-service' | distinct \$d.traceID"
+```
+
+### Latency Analysis
+
+```bash
+# Spans slower than 1 second
+cx spans "filter \$m.duration > 1000000"
+
+# Top 10 slowest operations by average duration
+cx spans "groupby \$l.operationName aggregate avg(\$m.duration) as avg_latency | orderby avg_latency desc | limit 10"
+
+# Average latency by service
+cx spans "groupby \$l.serviceName aggregate avg(\$m.duration) as avg_latency"
+
+# P95 latency by operation
+cx spans "groupby \$l.operationName aggregate percentile(0.95, \$m.duration) as p95_latency"
+```
+
+### Latency Spike Detection
+
+```bash
+# Average latency per 15-minute window
+cx spans "filter \$l.serviceName == 'api' | groupby roundTime(\$m.timestamp, 15m) as interval aggregate avg(\$m.duration) as avg_latency | orderby interval"
+
+# Find the time windows with highest latency
+cx spans "filter \$l.serviceName == 'api' | groupby roundTime(\$m.timestamp, 5m) as interval aggregate avg(\$m.duration) as avg_latency | orderby avg_latency desc | limit 10"
+```
+
+### Error Investigation
+
+```bash
+# All error spans
+cx spans "filter \$d.tags.error == true"
+
+# Error spans for a specific service
+cx spans "filter \$l.serviceName == 'checkout' | filter \$d.tags.error == true"
+
+# Error rate by service
+cx spans "filter \$d.tags.error == true | groupby \$l.serviceName aggregate count() as errors | orderby errors desc"
+
+# Error rate over time
+cx spans "filter \$d.tags.error == true | groupby roundTime(\$m.timestamp, 15m) as interval aggregate count() as errors"
+```
+
+### Sampling Error Types
+
+```bash
+# Group errors by operation with a sample
+cx spans "filter \$d.tags.error == true | groupby \$l.operationName aggregate any_value(\$d) as sample, count() as total | orderby total desc | limit 5"
+
+# Group by service and operation to see where errors concentrate
+cx spans "filter \$d.tags.error == true | groupby \$l.serviceName, \$l.operationName aggregate count() as errors | orderby errors desc | limit 10"
+```
+
+### Finding Unique Values
+
+```bash
+# List all services with spans
+cx spans "distinct \$l.serviceName"
+
+# List all operations for a service
+cx spans "filter \$l.serviceName == 'api' | distinct \$l.operationName"
+
+# Find unique trace IDs for error spans
+cx spans "filter \$d.tags.error == true | distinct \$d.traceID"
+```
+
+### Correlating by Trace ID
+
+```bash
+# Find spans across services for the same trace
+cx spans "filter \$d.traceID == 'abc123' | groupby \$l.serviceName aggregate count() as span_count, avg(\$m.duration) as avg_latency"
+```
+
+---
+
+## Performance Tips
+
+- Use `--limit` for exploratory queries
+- Use `groupby` with aggregations instead of fetching raw spans when possible
+- Filter by time first when dealing with large datasets
+- Use specific filters (service name, operation) to reduce scan scope
+- Don't rely solely on aggregations - retrieve sample spans to find information you didn't anticipate
+- For large result sets, use `--output agents` which spills automatically:
+
+```bash
+cx spans "filter \$l.serviceName == 'api'" --start now-24h --limit 1000 -o agents
+```

--- a/src/commands/ai_center/api.rs
+++ b/src/commands/ai_center/api.rs
@@ -1,0 +1,278 @@
+//! REST client for the Coralogix AI Center (AI v3) configuration APIs.
+//!
+//! The proto (`com/coralogixapis/ai/v3`) annotates paths like `/ai/applications/v3`,
+//! but openapi-facade serves them under the management gateway mount `/mgmt/openapi/5`
+//! (the mount every management command uses) — hence the [`AI_BASE`] prefix. There is
+//! deliberately no delete for custom-evaluation policies, applications, or pricing.
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::api_client::CxClient;
+use crate::error::Result;
+
+/// openapi-facade management gateway mount that fronts the AI v3 proto routes.
+const AI_BASE: &str = "/mgmt/openapi/5/ai";
+
+// --- Response types ---
+//
+// All three list routes return their rows as raw `Value`s so JSON/agents output
+// preserves every field the API sends; the text renderers read the columns they
+// need off the raw object. Each wrapper just names the array key the route uses.
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ApplicationItems {
+    #[serde(default)]
+    ai_applications: Vec<Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct EvaluationItems {
+    #[serde(default)]
+    ai_evaluations: Vec<Value>,
+}
+
+/// Best-effort evaluation-type label from an evaluation item's `config` oneof
+/// (the variant key names the type); "-" when absent.
+pub fn eval_config_type(item: &Value) -> String {
+    item.get("config")
+        .and_then(Value::as_object)
+        .and_then(|m| m.keys().next())
+        .cloned()
+        .unwrap_or_else(|| "-".to_string())
+}
+
+/// Wrapper for the two custom-evaluation list routes, which both return `{ "items": [...] }`.
+/// Items are kept as raw `Value` so JSON/agents output preserves every policy field
+/// (config, instructions, examples, policyType, …); the text table reads what it needs.
+#[derive(Debug, Default, Deserialize)]
+struct CustomEvaluationItems {
+    #[serde(default)]
+    items: Vec<Value>,
+}
+
+// --- API ---
+
+pub struct AiCenterApi<'a> {
+    client: &'a CxClient,
+}
+
+impl<'a> AiCenterApi<'a> {
+    pub fn new(client: &'a CxClient) -> Self {
+        Self { client }
+    }
+
+    // ── Reads ────────────────────────────────────────────────────────
+
+    /// GET /ai/applications/v3 — list AI applications (raw items).
+    pub async fn list_applications(&self, params: &[(&str, &str)]) -> Result<Vec<Value>> {
+        let resp: ApplicationItems = self
+            .client
+            .get(&format!("{AI_BASE}/applications/v3"), params)
+            .await?;
+        Ok(resp.ai_applications)
+    }
+
+    /// GET /ai/applications/v3/{id}.
+    pub async fn get_application(&self, id: &str) -> Result<Value> {
+        self.client
+            .get(&format!("{AI_BASE}/applications/v3/{id}"), &[])
+            .await
+    }
+
+    /// GET /ai/evaluations/v3 — configured evaluations/policies (raw items; optionally per app).
+    pub async fn list_evaluations(&self, params: &[(&str, &str)]) -> Result<Vec<Value>> {
+        let resp: EvaluationItems = self
+            .client
+            .get(&format!("{AI_BASE}/evaluations/v3"), params)
+            .await?;
+        Ok(resp.ai_evaluations)
+    }
+
+    /// GET /ai/evaluations/v3/{id}.
+    pub async fn get_evaluation(&self, id: &str) -> Result<Value> {
+        self.client
+            .get(&format!("{AI_BASE}/evaluations/v3/{id}"), &[])
+            .await
+    }
+
+    /// GET /ai/evaluation-counts/v3/per-type — app count per evaluation type (coverage).
+    pub async fn count_apps_per_eval_type(&self) -> Result<Value> {
+        self.client
+            .get(&format!("{AI_BASE}/evaluation-counts/v3/per-type"), &[])
+            .await
+    }
+
+    /// GET /ai/custom-evaluations/v3 — all custom evaluations (raw items).
+    pub async fn list_custom_evaluations(&self) -> Result<Vec<Value>> {
+        let resp: CustomEvaluationItems = self
+            .client
+            .get(&format!("{AI_BASE}/custom-evaluations/v3"), &[])
+            .await?;
+        Ok(resp.items)
+    }
+
+    /// GET /ai/custom-evaluations/v3/by-application/{application_id} (raw items).
+    pub async fn list_custom_evaluations_for_application(
+        &self,
+        application_id: &str,
+    ) -> Result<Vec<Value>> {
+        let resp: CustomEvaluationItems = self
+            .client
+            .get(
+                &format!("{AI_BASE}/custom-evaluations/v3/by-application/{application_id}"),
+                &[],
+            )
+            .await?;
+        Ok(resp.items)
+    }
+
+    /// GET /ai/model-pricing/v3 — the team's custom model pricing overrides.
+    pub async fn get_model_pricing(&self) -> Result<Value> {
+        self.client
+            .get(&format!("{AI_BASE}/model-pricing/v3"), &[])
+            .await
+    }
+
+    // ── Writes ───────────────────────────────────────────────────────
+
+    /// POST /ai/evaluations/v3 — create (enable) an evaluation on an application.
+    pub async fn create_evaluation(&self, body: &Value) -> Result<Value> {
+        self.client
+            .post(&format!("{AI_BASE}/evaluations/v3"), body)
+            .await
+    }
+
+    /// PATCH /ai/evaluations/v3/{id}.
+    pub async fn update_evaluation(&self, id: &str, body: &Value) -> Result<Value> {
+        self.client
+            .patch(&format!("{AI_BASE}/evaluations/v3/{id}"), body)
+            .await
+    }
+
+    /// DELETE /ai/evaluations/v3/{id} — remove an evaluation from its application.
+    pub async fn delete_evaluation(&self, id: &str) -> Result<Value> {
+        self.client
+            .delete(&format!("{AI_BASE}/evaluations/v3/{id}"))
+            .await
+    }
+
+    /// POST /ai/custom-evaluations/v3 — create a custom evaluation (policy).
+    pub async fn create_custom_evaluation(&self, body: &Value) -> Result<Value> {
+        self.client
+            .post(&format!("{AI_BASE}/custom-evaluations/v3"), body)
+            .await
+    }
+
+    /// PATCH /ai/custom-evaluations/v3/{id}.
+    pub async fn update_custom_evaluation(&self, id: &str, body: &Value) -> Result<Value> {
+        self.client
+            .patch(&format!("{AI_BASE}/custom-evaluations/v3/{id}"), body)
+            .await
+    }
+
+    /// POST /ai/custom-evaluations/v3/{id}/applications/{application_id} — attach a
+    /// custom evaluation (policy) to an application (the LinkCustomEvaluation RPC).
+    pub async fn add_policy_to_application(
+        &self,
+        evaluation_id: &str,
+        application_id: &str,
+    ) -> Result<Value> {
+        self.client
+            .post_empty(
+                &format!(
+                    "{AI_BASE}/custom-evaluations/v3/{evaluation_id}/applications/{application_id}"
+                ),
+                &[],
+            )
+            .await
+    }
+
+    /// DELETE /ai/custom-evaluations/v3/{id}/applications/{application_id} — detach a
+    /// custom evaluation (policy) from an application (reversible; the policy survives).
+    pub async fn remove_policy_from_application(
+        &self,
+        evaluation_id: &str,
+        application_id: &str,
+    ) -> Result<Value> {
+        self.client
+            .delete(&format!(
+                "{AI_BASE}/custom-evaluations/v3/{evaluation_id}/applications/{application_id}"
+            ))
+            .await
+    }
+
+    /// PUT /ai/model-pricing/v3 — set the team's per-model pricing overrides.
+    /// `prices` is the model→price map; it is wrapped as `{"prices": …}` for the API.
+    pub async fn set_model_pricing(&self, prices: &Value) -> Result<Value> {
+        let body = json!({ "prices": prices });
+        self.client
+            .put(&format!("{AI_BASE}/model-pricing/v3"), &body)
+            .await
+    }
+}
+
+// --- Tests ---
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn application_items_preserve_full_object() {
+        // Raw items keep every field (incl. createdAt/companyId) for JSON/agents.
+        let body = json!({
+            "aiApplications": [
+                { "id": "a-1", "application": "Production", "subsystem": "Advisor",
+                  "guardrailsIntegrated": true, "companyId": "42", "createdAt": "2026-01-01" }
+            ]
+        });
+        let resp: ApplicationItems = serde_json::from_value(body).unwrap();
+        assert_eq!(resp.ai_applications.len(), 1);
+        assert_eq!(resp.ai_applications[0]["id"], "a-1");
+        assert_eq!(resp.ai_applications[0]["guardrailsIntegrated"], true);
+        assert_eq!(resp.ai_applications[0]["companyId"], "42");
+    }
+
+    #[test]
+    fn empty_application_items() {
+        let resp: ApplicationItems = serde_json::from_value(json!({})).unwrap();
+        assert!(resp.ai_applications.is_empty());
+    }
+
+    #[test]
+    fn evaluation_items_and_config_type() {
+        let body = json!({
+            "aiEvaluations": [
+                { "id": "e-1", "application": "Prod", "subsystem": "Sub", "isEnabled": true,
+                  "target": "RESPONSE", "threshold": 0.8, "config": { "toxicity": {} } },
+                { "id": "e-2", "application": "Prod", "subsystem": "Sub" }
+            ]
+        });
+        let resp: EvaluationItems = serde_json::from_value(body).unwrap();
+        assert_eq!(resp.ai_evaluations.len(), 2);
+        assert_eq!(eval_config_type(&resp.ai_evaluations[0]), "toxicity");
+        assert_eq!(resp.ai_evaluations[0]["isEnabled"], true);
+        assert_eq!(eval_config_type(&resp.ai_evaluations[1]), "-");
+    }
+
+    #[test]
+    fn custom_evaluation_items_preserve_full_object() {
+        // Items are raw Values, so every policy field (incl. config/instructions)
+        // survives for JSON/agents output, not just the columns the table reads.
+        let body = json!({
+            "items": [
+                { "id": "c-1", "name": "No PII", "description": "block pii",
+                  "applicationIds": ["a-1", "a-2"],
+                  "config": { "instructions": "reject PII", "policyType": "SECURITY" } }
+            ]
+        });
+        let resp: CustomEvaluationItems = serde_json::from_value(body).unwrap();
+        assert_eq!(resp.items.len(), 1);
+        assert_eq!(resp.items[0]["name"], "No PII");
+        assert_eq!(resp.items[0]["config"]["policyType"], "SECURITY");
+    }
+}

--- a/src/commands/ai_center/mod.rs
+++ b/src/commands/ai_center/mod.rs
@@ -1,0 +1,641 @@
+//! `cx ai-center` — Coralogix AI Center (AI v3) configuration commands.
+//!
+//! Read/write access to the AI application inventory, configured evaluations/policies,
+//! coverage, custom evaluations, and model pricing — the configuration that is *not*
+//! in span telemetry. Telemetry (GenAI spans) is queried separately via `cx spans`.
+//! See the `cx-ai-center` skill.
+
+pub mod api;
+
+use std::sync::Arc;
+
+use anyhow::Result;
+use colored::Colorize;
+use serde_json::Value;
+use toon_format::encode_default as toon_encode;
+
+use crate::config::OutputFormat;
+use crate::execution::{fan_out, ExecutionTarget};
+use crate::render;
+use api::AiCenterApi;
+
+// ── Shared helpers ──────────────────────────────────────────────────
+
+fn read_from_file(path: &str) -> Result<Value> {
+    let raw = if path == "-" {
+        eprintln!("{}", "Reading JSON definition from stdin...".dimmed());
+        use std::io::Read;
+        let mut buf = String::new();
+        std::io::stdin().read_to_string(&mut buf)?;
+        buf
+    } else {
+        eprintln!(
+            "{}",
+            format!("Reading JSON definition from {path}...").dimmed()
+        );
+        std::fs::read_to_string(path)?
+    };
+    Ok(serde_json::from_str(&raw)?)
+}
+
+fn to_param_refs(params: &[(String, String)]) -> Vec<(&str, &str)> {
+    params
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect()
+}
+
+/// Render a list of JSON rows + a text table across the three output formats.
+fn emit_table(
+    all_json: &[Value],
+    rows: Vec<Vec<String>>,
+    headers: &[&str],
+    include_profile: bool,
+    output: OutputFormat,
+    empty_msg: &str,
+) -> Result<()> {
+    match output {
+        OutputFormat::Json => render::render_json(all_json)?,
+        OutputFormat::Agents => {
+            let toon =
+                toon_encode(&all_json).map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
+            println!("{toon}");
+        }
+        OutputFormat::Text => {
+            if rows.is_empty() {
+                render::print_no_results(empty_msg);
+                return Ok(());
+            }
+            render::render_table(headers, rows, include_profile);
+        }
+    }
+    Ok(())
+}
+
+/// Render one JSON object per profile (get / coverage / pricing / write results).
+fn emit_objects(
+    all: &[Value],
+    include_profile: bool,
+    output: OutputFormat,
+    empty_msg: &str,
+) -> Result<()> {
+    match output {
+        OutputFormat::Json => render::render_json_auto(all)?,
+        OutputFormat::Agents => {
+            let toon =
+                toon_encode(&all).map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
+            println!("{toon}");
+        }
+        OutputFormat::Text => {
+            render::render_get_text(all, include_profile, empty_msg, None::<&dyn Fn(&Value)>)?;
+        }
+    }
+    Ok(())
+}
+
+/// Read a string field off a raw item for a text-table column ("" if absent).
+fn col<'a>(item: &'a Value, key: &str) -> &'a str {
+    item.get(key).and_then(Value::as_str).unwrap_or_default()
+}
+
+/// Tag a raw item with its profile (multi-profile mode) and return it.
+fn tag_item(mut item: Value, include_profile: bool, profile: &str) -> Value {
+    if include_profile {
+        if let Some(obj) = item.as_object_mut() {
+            obj.insert("profile".into(), Value::String(profile.to_string()));
+        }
+    }
+    item
+}
+
+/// Collect per-profile `Value` results, printing per-profile errors to stderr and
+/// tagging each object with its profile in multi-profile mode.
+fn collect_objects(per_profile: Vec<(String, Result<Value>)>, include_profile: bool) -> Vec<Value> {
+    let mut all: Vec<Value> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            Ok(mut val) => {
+                if include_profile {
+                    render::tag_get_result(&mut val, &profile);
+                }
+                all.push(val);
+            }
+            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+        }
+    }
+    all
+}
+
+// ── Applications ────────────────────────────────────────────────────
+
+pub async fn run_applications_list(
+    targets: &[Arc<ExecutionTarget>],
+    page_size: Option<u32>,
+    page_offset: Option<u32>,
+    evaluation_types: &[String],
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", "Fetching AI applications...".dimmed());
+    let include_profile = targets.len() > 1;
+
+    let mut params: Vec<(String, String)> = Vec::new();
+    if let Some(n) = page_size {
+        params.push(("pageSize".into(), n.to_string()));
+    }
+    if let Some(n) = page_offset {
+        params.push(("pageOffset".into(), n.to_string()));
+    }
+    for t in evaluation_types {
+        params.push(("evaluationTypes".into(), t.clone()));
+    }
+
+    let per_profile = fan_out(targets, |t| {
+        let params = params.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.list_applications(&to_param_refs(&params)).await?)
+        }
+    })
+    .await;
+
+    let mut all_json: Vec<Value> = Vec::new();
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            Ok(items) => {
+                for item in items {
+                    rows.push(vec![
+                        profile.clone(),
+                        col(&item, "id").to_string(),
+                        col(&item, "application").to_string(),
+                        col(&item, "subsystem").to_string(),
+                        render::bool_display(
+                            item.get("guardrailsIntegrated").and_then(Value::as_bool),
+                        ),
+                    ]);
+                    all_json.push(tag_item(item, include_profile, &profile));
+                }
+            }
+            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+        }
+    }
+
+    emit_table(
+        &all_json,
+        rows,
+        &["ID", "Application", "Subsystem", "Guarded"],
+        include_profile,
+        output,
+        "No AI applications found.",
+    )
+}
+
+pub async fn run_applications_get(
+    targets: &[Arc<ExecutionTarget>],
+    id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", format!("Fetching AI application {id}...").dimmed());
+    let include_profile = targets.len() > 1;
+    let id = id.to_string();
+
+    let per_profile = fan_out(targets, |t| {
+        let id = id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.get_application(&id).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    emit_objects(&all, include_profile, output, "AI application not found.")
+}
+
+// ── Evaluations ─────────────────────────────────────────────────────
+
+#[allow(clippy::too_many_arguments)]
+pub async fn run_evaluations_list(
+    targets: &[Arc<ExecutionTarget>],
+    application: Option<&str>,
+    subsystem: Option<&str>,
+    evaluation_type: Option<&str>,
+    page_size: Option<u32>,
+    page_offset: Option<u32>,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", "Fetching AI evaluations...".dimmed());
+    let include_profile = targets.len() > 1;
+
+    let mut params: Vec<(String, String)> = Vec::new();
+    if let Some(v) = application {
+        params.push(("application".into(), v.to_string()));
+    }
+    if let Some(v) = subsystem {
+        params.push(("subsystem".into(), v.to_string()));
+    }
+    if let Some(v) = evaluation_type {
+        params.push(("evaluationType".into(), v.to_string()));
+    }
+    if let Some(n) = page_size {
+        params.push(("pageSize".into(), n.to_string()));
+    }
+    if let Some(n) = page_offset {
+        params.push(("pageOffset".into(), n.to_string()));
+    }
+
+    let per_profile = fan_out(targets, |t| {
+        let params = params.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.list_evaluations(&to_param_refs(&params)).await?)
+        }
+    })
+    .await;
+
+    let mut all_json: Vec<Value> = Vec::new();
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            Ok(items) => {
+                for item in items {
+                    rows.push(vec![
+                        profile.clone(),
+                        col(&item, "id").to_string(),
+                        col(&item, "application").to_string(),
+                        col(&item, "subsystem").to_string(),
+                        api::eval_config_type(&item),
+                        col(&item, "target").to_string(),
+                        render::bool_display(item.get("isEnabled").and_then(Value::as_bool)),
+                        item.get("threshold")
+                            .and_then(Value::as_f64)
+                            .map(|t| t.to_string())
+                            .unwrap_or_default(),
+                    ]);
+                    all_json.push(tag_item(item, include_profile, &profile));
+                }
+            }
+            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+        }
+    }
+
+    emit_table(
+        &all_json,
+        rows,
+        &[
+            "ID",
+            "Application",
+            "Subsystem",
+            "Type",
+            "Target",
+            "Enabled",
+            "Threshold",
+        ],
+        include_profile,
+        output,
+        "No AI evaluations found.",
+    )
+}
+
+pub async fn run_evaluations_get(
+    targets: &[Arc<ExecutionTarget>],
+    id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", format!("Fetching AI evaluation {id}...").dimmed());
+    let include_profile = targets.len() > 1;
+    let id = id.to_string();
+
+    let per_profile = fan_out(targets, |t| {
+        let id = id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.get_evaluation(&id).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    emit_objects(&all, include_profile, output, "AI evaluation not found.")
+}
+
+pub async fn run_evaluations_create(
+    targets: &[Arc<ExecutionTarget>],
+    from_file: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let body = read_from_file(from_file)?;
+    eprintln!("{}", "Creating AI evaluation...".dimmed());
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |t| {
+        let body = body.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.create_evaluation(&body).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Created AI evaluation.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}
+
+pub async fn run_evaluations_update(
+    targets: &[Arc<ExecutionTarget>],
+    id: &str,
+    from_file: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let body = read_from_file(from_file)?;
+    eprintln!("{}", format!("Updating AI evaluation {id}...").dimmed());
+    let include_profile = targets.len() > 1;
+    let id = id.to_string();
+
+    let per_profile = fan_out(targets, |t| {
+        let body = body.clone();
+        let id = id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.update_evaluation(&id, &body).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Updated AI evaluation.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}
+
+pub async fn run_evaluations_delete(
+    targets: &[Arc<ExecutionTarget>],
+    id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", format!("Deleting AI evaluation {id}...").dimmed());
+    let include_profile = targets.len() > 1;
+    let id = id.to_string();
+
+    let per_profile = fan_out(targets, |t| {
+        let id = id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.delete_evaluation(&id).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Deleted AI evaluation.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}
+
+// ── Coverage (apps per evaluation type) ─────────────────────────────
+
+pub async fn run_coverage(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> Result<()> {
+    eprintln!("{}", "Fetching AI evaluation coverage...".dimmed());
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |t| async move {
+        let api = AiCenterApi::new(&t.client);
+        Ok(api.count_apps_per_eval_type().await?)
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    emit_objects(&all, include_profile, output, "No coverage data.")
+}
+
+// ── Custom evaluations ──────────────────────────────────────────────
+
+pub async fn run_custom_evaluations_list(
+    targets: &[Arc<ExecutionTarget>],
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", "Fetching custom evaluations...".dimmed());
+    run_custom_evaluations_table(targets, None, output).await
+}
+
+pub async fn run_custom_evaluations_for_application(
+    targets: &[Arc<ExecutionTarget>],
+    application_id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!(
+        "{}",
+        format!("Fetching custom evaluations for application {application_id}...").dimmed()
+    );
+    run_custom_evaluations_table(targets, Some(application_id.to_string()), output).await
+}
+
+/// Shared list/table path for both custom-evaluation list variants.
+async fn run_custom_evaluations_table(
+    targets: &[Arc<ExecutionTarget>],
+    application_id: Option<String>,
+    output: OutputFormat,
+) -> Result<()> {
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |t| {
+        let application_id = application_id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            let resp = match application_id {
+                Some(app_id) => api.list_custom_evaluations_for_application(&app_id).await?,
+                None => api.list_custom_evaluations().await?,
+            };
+            Ok(resp)
+        }
+    })
+    .await;
+
+    let mut all_json: Vec<Value> = Vec::new();
+    let mut rows: Vec<Vec<String>> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            // Items are raw API objects: the text table reads a few columns, but
+            // JSON/agents output keeps the full policy (config, instructions, etc.).
+            Ok(items) => {
+                for item in items {
+                    let app_count = item
+                        .get("applicationIds")
+                        .and_then(Value::as_array)
+                        .map(|a| a.len())
+                        .unwrap_or(0);
+                    rows.push(vec![
+                        profile.clone(),
+                        col(&item, "id").to_string(),
+                        col(&item, "name").to_string(),
+                        app_count.to_string(),
+                        col(&item, "description").chars().take(60).collect(),
+                    ]);
+                    all_json.push(tag_item(item, include_profile, &profile));
+                }
+            }
+            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+        }
+    }
+
+    emit_table(
+        &all_json,
+        rows,
+        &["ID", "Name", "Apps", "Description"],
+        include_profile,
+        output,
+        "No custom evaluations found.",
+    )
+}
+
+pub async fn run_custom_evaluations_create(
+    targets: &[Arc<ExecutionTarget>],
+    from_file: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let body = read_from_file(from_file)?;
+    eprintln!("{}", "Creating custom evaluation...".dimmed());
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |t| {
+        let body = body.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.create_custom_evaluation(&body).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Created custom evaluation.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}
+
+pub async fn run_custom_evaluations_update(
+    targets: &[Arc<ExecutionTarget>],
+    id: &str,
+    from_file: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let body = read_from_file(from_file)?;
+    eprintln!("{}", format!("Updating custom evaluation {id}...").dimmed());
+    let include_profile = targets.len() > 1;
+    let id = id.to_string();
+
+    let per_profile = fan_out(targets, |t| {
+        let body = body.clone();
+        let id = id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.update_custom_evaluation(&id, &body).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Updated custom evaluation.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}
+
+pub async fn run_add_policy(
+    targets: &[Arc<ExecutionTarget>],
+    evaluation_id: &str,
+    application_id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!(
+        "{}",
+        format!("Attaching policy {evaluation_id} to application {application_id}...").dimmed()
+    );
+    let include_profile = targets.len() > 1;
+    let evaluation_id = evaluation_id.to_string();
+    let application_id = application_id.to_string();
+
+    let per_profile = fan_out(targets, |t| {
+        let evaluation_id = evaluation_id.clone();
+        let application_id = application_id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api
+                .add_policy_to_application(&evaluation_id, &application_id)
+                .await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Attached policy to application.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}
+
+pub async fn run_remove_policy(
+    targets: &[Arc<ExecutionTarget>],
+    evaluation_id: &str,
+    application_id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!(
+        "{}",
+        format!("Detaching policy {evaluation_id} from application {application_id}...").dimmed()
+    );
+    let include_profile = targets.len() > 1;
+    let evaluation_id = evaluation_id.to_string();
+    let application_id = application_id.to_string();
+
+    let per_profile = fan_out(targets, |t| {
+        let evaluation_id = evaluation_id.clone();
+        let application_id = application_id.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api
+                .remove_policy_from_application(&evaluation_id, &application_id)
+                .await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Detached policy from application.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}
+
+// ── Model pricing ───────────────────────────────────────────────────
+
+pub async fn run_model_pricing_get(
+    targets: &[Arc<ExecutionTarget>],
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", "Fetching model pricing...".dimmed());
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |t| async move {
+        let api = AiCenterApi::new(&t.client);
+        Ok(api.get_model_pricing().await?)
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    emit_objects(&all, include_profile, output, "No model pricing overrides.")
+}
+
+pub async fn run_model_pricing_set(
+    targets: &[Arc<ExecutionTarget>],
+    from_file: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let prices = read_from_file(from_file)?;
+    eprintln!("{}", "Setting model pricing...".dimmed());
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |t| {
+        let prices = prices.clone();
+        async move {
+            let api = AiCenterApi::new(&t.client);
+            Ok(api.set_model_pricing(&prices).await?)
+        }
+    })
+    .await;
+
+    let all = collect_objects(per_profile, include_profile);
+    eprintln!("{}", "Set model pricing.".green());
+    emit_objects(&all, include_profile, output, "No result.")
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod actions;
+pub mod ai_center;
 pub mod alerts;
 pub mod api_keys;
 pub mod cases;

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,9 @@ pub enum SearchByValueDataset {
   \x1b[1mviews\x1b[0m              Manage saved views and view folders
   \x1b[1mslos\x1b[0m               Manage SLO definitions
 
+\x1b[1m\x1b[4mAI:\x1b[0m
+  \x1b[1mai-center\x1b[0m (risky)  Manage AI Center applications, evaluations, policies, and pricing
+
 \x1b[1m\x1b[4mDetect & Respond:\x1b[0m
   \x1b[1malerts\x1b[0m             Manage alert definitions and suppression rules
   \x1b[1mcases\x1b[0m               Manage and triage cases
@@ -493,6 +496,22 @@ Examples:
         cmd: DataArchiveCmd,
     },
 
+    /// Manage AI Center (GenAI) applications, evaluations, policies, and pricing.
+    #[command(
+        name = "ai-center",
+        after_help = "\
+Examples:
+  cx ai-center applications list
+  cx ai-center evaluations list --application <app> --subsystem <sub>
+  cx ai-center coverage
+  cx ai-center custom-evaluations list
+  cx ai-center model-pricing get"
+    )]
+    AiCenter {
+        #[command(subcommand)]
+        cmd: AiCenterCmd,
+    },
+
     /// Manage SLO definitions.
     #[command(after_help = "\
 Examples:
@@ -564,7 +583,10 @@ Examples:
 
 impl Commands {
     fn is_risky(&self) -> bool {
-        matches!(self, Self::Iam { .. } | Self::DataArchive { .. })
+        matches!(
+            self,
+            Self::Iam { .. } | Self::DataArchive { .. } | Self::AiCenter { .. }
+        )
     }
 
     fn is_olly(&self) -> bool {
@@ -1878,6 +1900,174 @@ enum ViewFoldersCmd {
     Delete {
         /// Folder ID.
         id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum AiCenterCmd {
+    /// Manage AI applications (inventory + guarded status).
+    #[command(after_help = "\
+Examples:
+  cx ai-center applications list
+  cx ai-center applications get <application-id>")]
+    Applications {
+        #[command(subcommand)]
+        cmd: ApplicationsCmd,
+    },
+    /// Manage configured evaluations/policies on applications.
+    #[command(after_help = "\
+Examples:
+  cx ai-center evaluations list --application <app> --subsystem <sub>
+  cx ai-center evaluations get <evaluation-id>
+  cx ai-center evaluations create --from-file eval.json
+  cx ai-center evaluations update <evaluation-id> --from-file eval.json
+  cx ai-center evaluations delete <evaluation-id>")]
+    Evaluations {
+        #[command(subcommand)]
+        cmd: EvaluationsCmd,
+    },
+    /// Manage custom evaluation policies and their application links.
+    #[command(after_help = "\
+Examples:
+  cx ai-center custom-evaluations list
+  cx ai-center custom-evaluations list-for-application <application-id>
+  cx ai-center custom-evaluations create --from-file policy.json
+  cx ai-center custom-evaluations add <evaluation-id> <application-id>
+  cx ai-center custom-evaluations remove <evaluation-id> <application-id>")]
+    CustomEvaluations {
+        #[command(subcommand)]
+        cmd: CustomEvaluationsCmd,
+    },
+    /// Show evaluation coverage — AI applications per evaluation type.
+    Coverage,
+    /// View and set the team's custom model-pricing overrides.
+    #[command(after_help = "\
+Examples:
+  cx ai-center model-pricing get
+  cx ai-center model-pricing set --from-file pricing.json")]
+    ModelPricing {
+        #[command(subcommand)]
+        cmd: ModelPricingCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum ApplicationsCmd {
+    /// List AI applications (incl. guarded status).
+    List {
+        /// Maximum number of applications to return.
+        #[arg(long)]
+        page_size: Option<u32>,
+        /// Number of applications to skip for pagination.
+        #[arg(long)]
+        page_offset: Option<u32>,
+        /// Filter to apps using this evaluation type, as the API enum (e.g. PII,
+        /// TOXICITY, PROMPT_INJECTION — the keys from `coverage`). Repeatable.
+        #[arg(long = "evaluation-type")]
+        evaluation_type: Vec<String>,
+    },
+    /// Get one AI application by UUID.
+    Get {
+        /// Application UUID.
+        id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum EvaluationsCmd {
+    /// List configured evaluations (optionally scoped to one app).
+    List {
+        /// Scope to one application (pair with --subsystem).
+        #[arg(long)]
+        application: Option<String>,
+        /// Scope to one subsystem (pair with --application).
+        #[arg(long)]
+        subsystem: Option<String>,
+        /// Filter by evaluation type, as the API enum (e.g. PII, TOXICITY,
+        /// PROMPT_INJECTION — the keys returned by `coverage`).
+        #[arg(long = "evaluation-type")]
+        evaluation_type: Option<String>,
+        /// Maximum number of evaluations to return.
+        #[arg(long)]
+        page_size: Option<u32>,
+        /// Number of evaluations to skip for pagination.
+        #[arg(long)]
+        page_offset: Option<u32>,
+    },
+    /// Get one configured evaluation by UUID.
+    Get {
+        /// Evaluation UUID.
+        id: String,
+    },
+    /// Create (enable) an evaluation on an application from a JSON file [requires --yes].
+    Create {
+        /// Path to JSON file with the evaluation body. Use '-' for stdin.
+        #[arg(long, default_value = "-")]
+        from_file: String,
+    },
+    /// Update a configured evaluation by UUID from a JSON file [requires --yes].
+    Update {
+        /// Path to JSON file with the partial update. Use '-' for stdin.
+        #[arg(long, default_value = "-")]
+        from_file: String,
+        /// Evaluation UUID.
+        id: String,
+    },
+    /// Delete a configured evaluation by UUID [requires --yes].
+    Delete {
+        /// Evaluation UUID.
+        id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum CustomEvaluationsCmd {
+    /// List all custom evaluation policies.
+    List,
+    /// List custom evaluations linked to an application (by UUID).
+    ListForApplication {
+        /// Application UUID.
+        application_id: String,
+    },
+    /// Create a custom evaluation policy from a JSON file [requires --yes].
+    Create {
+        /// Path to JSON file with the custom evaluation body. Use '-' for stdin.
+        #[arg(long, default_value = "-")]
+        from_file: String,
+    },
+    /// Update a custom evaluation policy by UUID from a JSON file [requires --yes].
+    Update {
+        /// Path to JSON file with the partial update. Use '-' for stdin.
+        #[arg(long, default_value = "-")]
+        from_file: String,
+        /// Custom evaluation UUID.
+        id: String,
+    },
+    /// Attach a custom evaluation (policy) to an application [requires --yes].
+    Add {
+        /// Custom evaluation UUID.
+        evaluation_id: String,
+        /// Application UUID.
+        application_id: String,
+    },
+    /// Detach a custom evaluation (policy) from an application [requires --yes].
+    Remove {
+        /// Custom evaluation UUID.
+        evaluation_id: String,
+        /// Application UUID.
+        application_id: String,
+    },
+}
+
+#[derive(Subcommand)]
+enum ModelPricingCmd {
+    /// Get the team's custom per-model pricing overrides.
+    Get,
+    /// Set the team's per-model pricing overrides from a JSON file [requires --yes].
+    Set {
+        /// Path to JSON file with the model→price map. Use '-' for stdin.
+        #[arg(long, default_value = "-")]
+        from_file: String,
     },
 }
 
@@ -3445,6 +3635,156 @@ async fn main() -> Result<()> {
                 },
             },
 
+            Commands::AiCenter { cmd } => match cmd {
+                AiCenterCmd::Applications { cmd } => match cmd {
+                    ApplicationsCmd::List {
+                        page_size,
+                        page_offset,
+                        evaluation_type,
+                    } => {
+                        commands::ai_center::run_applications_list(
+                            &targets,
+                            page_size,
+                            page_offset,
+                            &evaluation_type,
+                            output,
+                        )
+                        .await?;
+                    }
+                    ApplicationsCmd::Get { id } => {
+                        commands::ai_center::run_applications_get(&targets, &id, output).await?;
+                    }
+                },
+                AiCenterCmd::Evaluations { cmd } => match cmd {
+                    EvaluationsCmd::List {
+                        application,
+                        subsystem,
+                        evaluation_type,
+                        page_size,
+                        page_offset,
+                    } => {
+                        commands::ai_center::run_evaluations_list(
+                            &targets,
+                            application.as_deref(),
+                            subsystem.as_deref(),
+                            evaluation_type.as_deref(),
+                            page_size,
+                            page_offset,
+                            output,
+                        )
+                        .await?;
+                    }
+                    EvaluationsCmd::Get { id } => {
+                        commands::ai_center::run_evaluations_get(&targets, &id, output).await?;
+                    }
+                    EvaluationsCmd::Create { from_file } => {
+                        confirm_destructive("Create a new AI evaluation?", yes, agent_mode)?;
+                        commands::ai_center::run_evaluations_create(&targets, &from_file, output)
+                            .await?;
+                    }
+                    EvaluationsCmd::Update { from_file, id } => {
+                        confirm_destructive(
+                            &format!("Update AI evaluation '{id}'?"),
+                            yes,
+                            agent_mode,
+                        )?;
+                        commands::ai_center::run_evaluations_update(
+                            &targets, &id, &from_file, output,
+                        )
+                        .await?;
+                    }
+                    EvaluationsCmd::Delete { id } => {
+                        confirm_destructive(
+                            &format!("Delete AI evaluation '{id}'?"),
+                            yes,
+                            agent_mode,
+                        )?;
+                        commands::ai_center::run_evaluations_delete(&targets, &id, output).await?;
+                    }
+                },
+                AiCenterCmd::CustomEvaluations { cmd } => match cmd {
+                    CustomEvaluationsCmd::List => {
+                        commands::ai_center::run_custom_evaluations_list(&targets, output).await?;
+                    }
+                    CustomEvaluationsCmd::ListForApplication { application_id } => {
+                        commands::ai_center::run_custom_evaluations_for_application(
+                            &targets,
+                            &application_id,
+                            output,
+                        )
+                        .await?;
+                    }
+                    CustomEvaluationsCmd::Create { from_file } => {
+                        confirm_destructive("Create a new custom evaluation?", yes, agent_mode)?;
+                        commands::ai_center::run_custom_evaluations_create(
+                            &targets, &from_file, output,
+                        )
+                        .await?;
+                    }
+                    CustomEvaluationsCmd::Update { from_file, id } => {
+                        confirm_destructive(
+                            &format!("Update custom evaluation '{id}'?"),
+                            yes,
+                            agent_mode,
+                        )?;
+                        commands::ai_center::run_custom_evaluations_update(
+                            &targets, &id, &from_file, output,
+                        )
+                        .await?;
+                    }
+                    CustomEvaluationsCmd::Add {
+                        evaluation_id,
+                        application_id,
+                    } => {
+                        confirm_destructive(
+                            &format!(
+                                "Attach policy '{evaluation_id}' to application '{application_id}'?"
+                            ),
+                            yes,
+                            agent_mode,
+                        )?;
+                        commands::ai_center::run_add_policy(
+                            &targets,
+                            &evaluation_id,
+                            &application_id,
+                            output,
+                        )
+                        .await?;
+                    }
+                    CustomEvaluationsCmd::Remove {
+                        evaluation_id,
+                        application_id,
+                    } => {
+                        confirm_destructive(
+                            &format!(
+                                "Detach policy '{evaluation_id}' from application '{application_id}'?"
+                            ),
+                            yes,
+                            agent_mode,
+                        )?;
+                        commands::ai_center::run_remove_policy(
+                            &targets,
+                            &evaluation_id,
+                            &application_id,
+                            output,
+                        )
+                        .await?;
+                    }
+                },
+                AiCenterCmd::Coverage => {
+                    commands::ai_center::run_coverage(&targets, output).await?;
+                }
+                AiCenterCmd::ModelPricing { cmd } => match cmd {
+                    ModelPricingCmd::Get => {
+                        commands::ai_center::run_model_pricing_get(&targets, output).await?;
+                    }
+                    ModelPricingCmd::Set { from_file } => {
+                        confirm_destructive("Set team model pricing?", yes, agent_mode)?;
+                        commands::ai_center::run_model_pricing_set(&targets, &from_file, output)
+                            .await?;
+                    }
+                },
+            },
             Commands::Iam { cmd } => match cmd {
                 IamCmd::ApiKeys { cmd } => match cmd {
                     ApiKeysCmd::List => {

--- a/tests/ai_center/main.rs
+++ b/tests/ai_center/main.rs
@@ -1,0 +1,220 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{body_json, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use coralogix_cli::commands::ai_center::{
+    run_add_policy, run_applications_get, run_applications_list, run_coverage,
+    run_custom_evaluations_for_application, run_custom_evaluations_list, run_evaluations_delete,
+    run_evaluations_list, run_model_pricing_get, run_model_pricing_set, run_remove_policy,
+};
+use coralogix_cli::config::OutputFormat;
+
+const AI: &str = "/mgmt/openapi/5/ai";
+
+#[tokio::test]
+async fn applications_list_hits_endpoint() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{AI}/applications/v3")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "aiApplications": [
+                { "id": "a-1", "application": "Prod", "subsystem": "Advisor", "guardrailsIntegrated": true }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_applications_list(&targets, None, None, &[], OutputFormat::Json)
+        .await
+        .expect("applications list should succeed");
+}
+
+#[tokio::test]
+async fn applications_list_empty_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{AI}/applications/v3")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_applications_list(&targets, None, None, &[], OutputFormat::Text)
+        .await
+        .expect("empty applications list should succeed");
+}
+
+#[tokio::test]
+async fn applications_get_hits_id_path() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{AI}/applications/v3/app-123")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "id": "app-123" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_applications_get(&targets, "app-123", OutputFormat::Json)
+        .await
+        .expect("applications get should succeed");
+}
+
+#[tokio::test]
+async fn evaluations_list_forwards_scope_params() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{AI}/evaluations/v3")))
+        .and(query_param("application", "Prod"))
+        .and(query_param("subsystem", "Advisor"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "aiEvaluations": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_evaluations_list(
+        &targets,
+        Some("Prod"),
+        Some("Advisor"),
+        None,
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("evaluations list should succeed");
+}
+
+#[tokio::test]
+async fn coverage_hits_per_type_endpoint() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{AI}/evaluation-counts/v3/per-type")))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({ "counts": { "toxicity": 3 } })),
+        )
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_coverage(&targets, OutputFormat::Json)
+        .await
+        .expect("coverage should succeed");
+}
+
+#[tokio::test]
+async fn custom_evaluations_list_and_for_application() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{AI}/custom-evaluations/v3")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "items": [ { "id": "c-1", "name": "No PII", "applicationIds": ["a-1"] } ]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "{AI}/custom-evaluations/v3/by-application/app-9"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "items": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_custom_evaluations_list(&targets, OutputFormat::Json)
+        .await
+        .expect("custom-evaluations list should succeed");
+    run_custom_evaluations_for_application(&targets, "app-9", OutputFormat::Json)
+        .await
+        .expect("custom-evaluations for-application should succeed");
+}
+
+#[tokio::test]
+async fn model_pricing_get_and_set() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(format!("{AI}/model-pricing/v3")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "prices": {} })))
+        .mount(&server)
+        .await;
+    // `set` reads the model→price map from stdin and must wrap it as {"prices": …}.
+    Mock::given(method("PUT"))
+        .and(path(format!("{AI}/model-pricing/v3")))
+        .and(body_json(
+            json!({ "prices": { "gpt-4o": { "inputPricePerMillionTokens": 2.5 } } }),
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_model_pricing_get(&targets, OutputFormat::Json)
+        .await
+        .expect("model-pricing get should succeed");
+
+    let dir = std::env::temp_dir();
+    let file = dir.join("cx_ai_center_pricing_test.json");
+    std::fs::write(
+        &file,
+        json!({ "gpt-4o": { "inputPricePerMillionTokens": 2.5 } }).to_string(),
+    )
+    .unwrap();
+    run_model_pricing_set(&targets, file.to_str().unwrap(), OutputFormat::Json)
+        .await
+        .expect("model-pricing set should succeed");
+    let _ = std::fs::remove_file(&file);
+}
+
+#[tokio::test]
+async fn evaluations_delete_uses_delete_verb() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(format!("{AI}/evaluations/v3/e-1")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_evaluations_delete(&targets, "e-1", OutputFormat::Json)
+        .await
+        .expect("evaluations delete should succeed");
+}
+
+#[tokio::test]
+async fn add_and_remove_policy_use_link_routes() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "{AI}/custom-evaluations/v3/c-1/applications/a-1"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path(format!(
+            "{AI}/custom-evaluations/v3/c-1/applications/a-1"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    run_add_policy(&targets, "c-1", "a-1", OutputFormat::Json)
+        .await
+        .expect("add-policy should succeed");
+    run_remove_policy(&targets, "c-1", "a-1", OutputFormat::Json)
+        .await
+        .expect("remove-policy should succeed");
+}

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -16,6 +16,8 @@ mod harness;
 
 #[path = "e2e/actions.rs"]
 mod actions;
+#[path = "e2e/ai_center/mod.rs"]
+mod ai_center;
 #[path = "e2e/alerts/mod.rs"]
 mod alerts;
 #[path = "e2e/api_keys.rs"]

--- a/tests/e2e/ai_center/mod.rs
+++ b/tests/e2e/ai_center/mod.rs
@@ -1,0 +1,81 @@
+use std::sync::OnceLock;
+
+use crate::harness;
+
+#[test]
+#[ignore]
+fn ai_center_applications_list() {
+    if harness::require_creds("ai_center_applications_list").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&["ai-center", "applications", "list", "-o", "json"]);
+    harness::assert_array(&v);
+}
+
+#[test]
+#[ignore]
+fn ai_center_applications_get() {
+    if harness::require_creds("ai_center_applications_get").is_none() {
+        return;
+    }
+    let Some(id) = discover_application_id() else {
+        eprintln!("[e2e] skipping ai_center_applications_get: no AI applications on test team");
+        return;
+    };
+    harness::run_ok_json(&["ai-center", "applications", "get", &id, "-o", "json"]);
+}
+
+#[test]
+#[ignore]
+fn ai_center_evaluations_list() {
+    if harness::require_creds("ai_center_evaluations_list").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&["ai-center", "evaluations", "list", "-o", "json"]);
+    harness::assert_array(&v);
+}
+
+#[test]
+#[ignore]
+fn ai_center_coverage() {
+    if harness::require_creds("ai_center_coverage").is_none() {
+        return;
+    }
+    harness::run_ok_json(&["ai-center", "coverage", "-o", "json"]);
+}
+
+#[test]
+#[ignore]
+fn ai_center_custom_evaluations_list() {
+    if harness::require_creds("ai_center_custom_evaluations_list").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&["ai-center", "custom-evaluations", "list", "-o", "json"]);
+    harness::assert_array(&v);
+}
+
+#[test]
+#[ignore]
+fn ai_center_model_pricing_get() {
+    if harness::require_creds("ai_center_model_pricing_get").is_none() {
+        return;
+    }
+    harness::run_ok_json(&["ai-center", "model-pricing", "get", "-o", "json"]);
+}
+
+/// Discover an application id from `applications list -o json`. Cached so multiple
+/// tests don't each pay for the list call; returns `None` when the team has no AI apps.
+fn discover_application_id() -> Option<String> {
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let stdout = harness::run_ok(&["ai-center", "applications", "list", "-o", "json"]);
+            let v = harness::parse_json(&stdout)?;
+            v.as_array()?
+                .iter()
+                .filter_map(|item| item.get("id").and_then(|x| x.as_str()))
+                .next()
+                .map(String::from)
+        })
+        .clone()
+}

--- a/tests/schema/main.rs
+++ b/tests/schema/main.rs
@@ -21,7 +21,7 @@ fn schema_outputs_valid_json_with_expected_commands() {
     let commands = schema["commands"]
         .as_array()
         .expect("commands should be an array");
-    assert_eq!(commands.len(), 28, "expected 28 top-level commands");
+    assert_eq!(commands.len(), 29, "expected 29 top-level commands");
 
     let names: Vec<&str> = commands
         .iter()
@@ -43,6 +43,7 @@ fn schema_outputs_valid_json_with_expected_commands() {
     assert!(names.contains(&"schema"), "missing schema");
     assert!(names.contains(&"docs"), "missing docs");
     assert!(names.contains(&"olly"), "missing olly");
+    assert!(names.contains(&"ai-center"), "missing ai-center");
 
     // Verify old commands are gone
     assert!(


### PR DESCRIPTION
Re-opens the work from #159 (that PR was closed and its branch force-pushed to purge accidentally-committed `graphify-out/` local files, which blocks GitHub from reopening it — so this is a fresh PR with identical, cleaned content).

## What
`cx ai-center` — AI Center (GenAI) configuration commands over the AI v3 REST API (`/mgmt/openapi/5/ai/...`): `applications`, `evaluations`, `custom-evaluations`, `coverage`, `model-pricing` — mirroring the `ws-ai-mcp` AI Center tool surface — plus the `cx-ai-center` skill (config commands + the GenAI-span DataPrime query library).

## History
- All review feedback from #159 (bot + Yoav) is already applied; see #159 for the full discussion/resolved threads.
- Validated end-to-end against real eu2 AI Center data; unit + wiremock + `#[ignore]`d e2e tests; `verify-skills` green.
- Branch history was re-baselined on master to fully purge the `graphify-out/` files (now gitignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pj6ieK81Qdk1YfcJwqNraV