### PR TITLE
fix(presets): align notification preset endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "coralogix-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-cli"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Coralogix CLI - the observability backbone for AI agents and engineering teams."
 repository = "https://github.com/coralogix/cx-cli"

--- a/src/commands/presets/api.rs
+++ b/src/commands/presets/api.rs
@@ -17,6 +17,7 @@ pub struct Preset {
     pub connector_type: Option<String>,
     pub is_default: Option<bool>,
     pub is_custom: Option<bool>,
+    pub preset_type: Option<String>,
 }
 
 impl Preset {
@@ -30,12 +31,20 @@ impl Preset {
             .map(|s| s.strip_prefix("CONNECTOR_TYPE_").unwrap_or(s).to_string())
             .unwrap_or_else(|| "-".to_string())
     }
+
+    pub fn display_is_custom(&self) -> Option<bool> {
+        self.is_custom.or_else(|| {
+            self.preset_type
+                .as_deref()
+                .map(|preset_type| preset_type == "CUSTOM")
+        })
+    }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListPresetsResponse {
-    #[serde(default)]
+    #[serde(default, alias = "presetSummaries")]
     pub presets: Vec<Preset>,
 }
 
@@ -71,7 +80,7 @@ impl<'a> PresetsApi<'a> {
     }
 
     pub async fn list(&self) -> Result<ListPresetsResponse> {
-        let path = format!("{PRESETS_BASE}/summaries");
+        let path = format!("{PRESETS_BASE}:summariesList");
         self.client.get(&path, &[]).await
     }
 
@@ -81,12 +90,12 @@ impl<'a> PresetsApi<'a> {
     }
 
     pub async fn create(&self, body: &Value) -> Result<CreatePresetResponse> {
-        let path = format!("{PRESETS_BASE}/custom");
+        let path = format!("{PRESETS_BASE}:createCustom");
         self.client.post(&path, body).await
     }
 
     pub async fn replace(&self, body: &Value) -> Result<Value> {
-        let path = format!("{PRESETS_BASE}/custom");
+        let path = format!("{PRESETS_BASE}:replaceCustom");
         self.client.put(&path, body).await
     }
 
@@ -96,7 +105,7 @@ impl<'a> PresetsApi<'a> {
     }
 
     pub async fn set_default(&self, id: &str) -> Result<SetDefaultPresetResponse> {
-        let path = format!("{PRESETS_BASE}/{id}/default");
+        let path = format!("{PRESETS_BASE}/{id}/default/apply");
         self.client.post(&path, &serde_json::json!({})).await
     }
 }
@@ -111,20 +120,18 @@ mod tests {
     #[test]
     fn deserialize_list_response() {
         let json = json!({
-            "presets": [
+            "presetSummaries": [
                 {
                     "id": "preset-001",
                     "name": "Default Slack",
-                    "connectorType": "CONNECTOR_TYPE_SLACK",
-                    "isDefault": true,
-                    "isCustom": false
+                    "connectorType": "SLACK",
+                    "presetType": "SYSTEM"
                 },
                 {
                     "id": "preset-002",
                     "name": "Custom PD",
-                    "connectorType": "CONNECTOR_TYPE_PAGERDUTY",
-                    "isDefault": false,
-                    "isCustom": true
+                    "connectorType": "PAGERDUTY",
+                    "presetType": "CUSTOM"
                 }
             ]
         });
@@ -133,7 +140,8 @@ mod tests {
         assert_eq!(resp.presets.len(), 2);
         assert_eq!(resp.presets[0].display_name(), "Default Slack");
         assert_eq!(resp.presets[0].display_connector_type(), "SLACK");
-        assert_eq!(resp.presets[0].is_default, Some(true));
+        assert_eq!(resp.presets[0].display_is_custom(), Some(false));
+        assert_eq!(resp.presets[1].display_is_custom(), Some(true));
     }
 
     #[test]
@@ -157,6 +165,7 @@ mod tests {
             connector_type: None,
             is_default: None,
             is_custom: None,
+            preset_type: None,
         };
         assert_eq!(preset.display_name(), "-");
         assert_eq!(preset.display_connector_type(), "-");

--- a/src/commands/presets/mod.rs
+++ b/src/commands/presets/mod.rs
@@ -18,7 +18,7 @@ fn preset_to_json(preset: &Preset, include_profile: bool, profile: &str) -> Valu
         "name": preset.display_name(),
         "connector_type": preset.display_connector_type(),
         "is_default": preset.is_default,
-        "is_custom": preset.is_custom,
+        "is_custom": preset.display_is_custom(),
     });
     if include_profile {
         if let Value::Object(ref mut m) = v {
@@ -43,6 +43,13 @@ fn read_from_file(path: &str) -> Result<Value> {
         std::fs::read_to_string(path)?
     };
     Ok(serde_json::from_str(&raw)?)
+}
+
+fn custom_preset_request_body(body: Value) -> Value {
+    match body {
+        Value::Object(ref map) if map.contains_key("preset") => body,
+        _ => json!({ "preset": body }),
+    }
 }
 
 pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> Result<()> {
@@ -90,7 +97,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                         preset.display_name().to_string(),
                         preset.display_connector_type(),
                         render::bool_display(preset.is_default),
-                        render::bool_display(preset.is_custom),
+                        render::bool_display(preset.display_is_custom()),
                     ]
                 })
                 .collect();
@@ -156,7 +163,7 @@ pub async fn run_create(
     from_file: &str,
     output: OutputFormat,
 ) -> Result<()> {
-    let body = read_from_file(from_file)?;
+    let body = custom_preset_request_body(read_from_file(from_file)?);
     eprintln!("{}", "Creating preset...".dimmed());
     let include_profile = targets.len() > 1;
     let per_profile = fan_out(targets, |t| {
@@ -203,7 +210,7 @@ pub async fn run_update(
     from_file: &str,
     output: OutputFormat,
 ) -> Result<()> {
-    let body = read_from_file(from_file)?;
+    let body = custom_preset_request_body(read_from_file(from_file)?);
     eprintln!("{}", "Updating preset...".dimmed());
     let per_profile = fan_out(targets, |t| {
         let body = body.clone();

--- a/tests/presets/main.rs
+++ b/tests/presets/main.rs
@@ -2,10 +2,10 @@
 mod common;
 
 use serde_json::json;
-use wiremock::matchers::{method, path};
+use wiremock::matchers::{body_json, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
-use coralogix_cli::commands::presets::run_list;
+use coralogix_cli::commands::presets::{run_create, run_list, run_set_default, run_update};
 use coralogix_cli::config::OutputFormat;
 
 #[tokio::test]
@@ -13,14 +13,14 @@ async fn list_presets_from_mock() {
     let server = MockServer::start().await;
 
     let body = json!({
-        "presets": [
-            { "id": "preset-001", "name": "Default Slack", "connectorType": "CONNECTOR_TYPE_SLACK", "isDefault": true, "isCustom": false }
+        "presetSummaries": [
+            { "id": "preset-001", "name": "Default Slack", "connectorType": "SLACK", "presetType": "SYSTEM" }
         ]
     });
 
     Mock::given(method("GET"))
         .and(path(
-            "/mgmt/openapi/5/notifications/notification-center/v1/presets/summaries",
+            "/mgmt/openapi/5/notifications/notification-center/v1/presets:summariesList",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
@@ -31,4 +31,119 @@ async fn list_presets_from_mock() {
     run_list(&[target], OutputFormat::Json)
         .await
         .expect("run_list should succeed");
+}
+
+#[tokio::test]
+async fn create_preset_from_mock() {
+    let server = MockServer::start().await;
+
+    let input_body = json!({
+        "name": "Custom Slack",
+        "parentId": "preset_system_slack_alerts_basic",
+        "description": "Custom preset for alerts",
+        "attachmentConfig": {},
+        "configOverrides": []
+    });
+    let expected_request = json!({ "preset": input_body.clone() });
+    let response_body = json!({
+        "preset": {
+            "id": "preset-custom-001",
+            "name": "Custom Slack",
+            "parentId": "preset_system_slack_alerts_basic",
+            "description": "Custom preset for alerts",
+            "attachmentConfig": {},
+            "configOverrides": []
+        }
+    });
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/mgmt/openapi/5/notifications/notification-center/v1/presets:createCustom",
+        ))
+        .and(body_json(expected_request))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let path = std::env::temp_dir().join(format!(
+        "cx-preset-create-{}-{}.json",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::write(&path, input_body.to_string()).expect("write preset fixture");
+
+    let target = common::test_target("test-profile", &server.uri());
+    let result = run_create(&[target], path.to_str().unwrap(), OutputFormat::Json).await;
+
+    std::fs::remove_file(path).expect("remove preset fixture");
+    result.expect("run_create should succeed");
+}
+
+#[tokio::test]
+async fn update_preset_from_mock() {
+    let server = MockServer::start().await;
+
+    let input_body = json!({
+        "id": "preset-custom-001",
+        "name": "Custom Slack Updated",
+        "parentId": "preset_system_slack_alerts_basic",
+        "description": "Updated custom preset for alerts",
+        "attachmentConfig": {},
+        "configOverrides": []
+    });
+    let expected_request = json!({ "preset": input_body.clone() });
+    let response_body = json!({
+        "preset": {
+            "id": "preset-custom-001",
+            "name": "Custom Slack Updated",
+            "parentId": "preset_system_slack_alerts_basic",
+            "description": "Updated custom preset for alerts",
+            "attachmentConfig": {},
+            "configOverrides": []
+        }
+    });
+
+    Mock::given(method("PUT"))
+        .and(path(
+            "/mgmt/openapi/5/notifications/notification-center/v1/presets:replaceCustom",
+        ))
+        .and(body_json(expected_request))
+        .respond_with(ResponseTemplate::new(200).set_body_json(&response_body))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let path = std::env::temp_dir().join(format!(
+        "cx-preset-update-{}-{}.json",
+        std::process::id(),
+        line!()
+    ));
+    std::fs::write(&path, input_body.to_string()).expect("write preset fixture");
+
+    let target = common::test_target("test-profile", &server.uri());
+    let result = run_update(&[target], path.to_str().unwrap(), OutputFormat::Json).await;
+
+    std::fs::remove_file(path).expect("remove preset fixture");
+    result.expect("run_update should succeed");
+}
+
+#[tokio::test]
+async fn set_default_preset_from_mock() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(
+            "/mgmt/openapi/5/notifications/notification-center/v1/presets/preset-system-001/default/apply",
+        ))
+        .and(body_json(json!({})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    run_set_default(&[target], "preset-system-001")
+        .await
+        .expect("run_set_default should succeed");
 }


### PR DESCRIPTION
## Context
The notification preset commands were still using older endpoint paths and response shapes, which caused staging requests to return 404/501 errors for list, create, update, and set-default flows. This fixes the preset command surface for FORGE-364 and bumps the CLI version for the endpoint correction.

## Linked Issues
FORGE-364 — inferred from branch name `yonatanbeker/forge-364-cli-bug-notifcations-center-501-unimplemented`.

## Design
The preset API client now maps each CLI operation to the current OpenAPI v5 Presets service paths. `run_list` consumes the documented `presetSummaries` response shape, create/update pass through a shared wrapper normalizer that accepts either a bare preset document or the documented `{ "preset": ... }` envelope, and output rendering derives the custom flag from `presetType` when older `isCustom` fields are absent. The command layer remains responsible for file/stdin parsing and presentation, while `src/commands/presets/api.rs` owns the transport paths.

## Key Decisions
The create/update commands accept both bare preset JSON and the documented wrapped request body to preserve the existing `--from-file` ergonomics while sending the API shape Coralogix expects. `presetType` is converted into the existing `is_custom` output field instead of changing the CLI output contract, limiting downstream impact for scripts that already read `is_custom`.

## Changes
- Corrected preset list, create, replace/update, and set-default endpoint paths to match the OpenAPI v5 Presets service.
- Updated list response parsing from `presets` to the documented `presetSummaries` shape while keeping a backward-compatible alias.
- Added request-body normalization for custom preset create/update so bare preset JSON is wrapped as `{ "preset": ... }`.
- Derived custom/system display behavior from `presetType` when the API does not return `isCustom`.
- Added WireMock coverage for list, create, update, and set-default preset command paths and request bodies.
- Bumped `coralogix-cli` from `0.1.11` to `0.1.12`.

## Testing
- `cargo check`
- `cargo test --test presets`
- `cargo test --lib presets`
- `cargo fmt --check`
- `cargo clippy --locked -- -D warnings`
- `cargo run -- notifications presets list -p stg --output json`
- `cargo run -- notifications presets get preset_system_slack_alerts_basic -p stg --output json`
- `cargo run -- notifications presets create --from-file /private/tmp/cx-preset-stg-create.json -p stg --output json --yes`
- `cargo run -- notifications presets delete ab7ec3ea-284c-45d5-aa79-11a743f03f9a -p stg --yes`
- `cargo run -- notifications presets get ab7ec3ea-284c-45d5-aa79-11a743f03f9a -p stg --output json` verified the deleted test preset returned 404.
- `cargo run -- notifications presets set-default preset_system_slack_alerts_basic -p stg --yes`

## Risks & Rollout
This changes live management API paths for notification presets, so the blast radius is limited to `cx notifications presets` commands. The request-body wrapper is backward-compatible for bare preset files and already accepts the documented envelope. Rollback is reverting this commit and releasing the previous endpoint mappings, though that would reintroduce the staging failures.

## Out of Scope / Follow-ups
N/A — all known broken `cx notifications presets` subcommands were aligned and covered in this PR.