### PR TITLE
docs(skills): correct DataPrime reference docs and performance wording

### DIFF
--- a/skills/cx-ai-center/references/ai-center-queries.md
+++ b/skills/cx-ai-center/references/ai-center-queries.md
@@ -61,7 +61,9 @@ prompt and tool traffic and bloats context.
 tool/workflow step, or a Guardrails SDK invocation). An **interaction** = the multiple spans
 under one `traceID` — one exchange plus the surrounding spans and operations. Counts (AI spans,
 errors, guardrail actions) are **span-level**; the only trace-level rate is Issue Rate (Q9). For
-a deduplicated interaction count use `distinct_count(traceID)` and say so.
+a deduplicated interaction count use `distinct_count(traceID)` and say so. For very
+high-cardinality counts, use `approx_count_distinct(traceID)` to avoid memory blowups when an
+exact number isn't needed.
 
 **Find GenAI spans — the mandatory filter on every AI Center query.** `source spans` also
 holds ordinary APM traffic; omitting this filter computes AI metrics over non-AI data and

--- a/skills/cx-ai-center/references/dataprime-reference.md
+++ b/skills/cx-ai-center/references/dataprime-reference.md
@@ -66,7 +66,7 @@ All fields are accessed through three namespaces:
 | `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
 | `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
-> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
+> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage. `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
 
 ### Aggregation
 

--- a/skills/cx-ai-center/references/dataprime-reference.md
+++ b/skills/cx-ai-center/references/dataprime-reference.md
@@ -63,8 +63,8 @@ All fields are accessed through three namespaces:
 | `filter` | Keep rows matching a condition | `filter $m.severity == ERROR` |
 | `choose` | Select specific fields | `choose $m.timestamp, $d.message` |
 | `limit` | Cap the number of results | `limit 10` |
-| `wildfind` | Search all fields for a string (see note below) | `wildfind 'connection refused'` |
-| `lucene` | Filter using Lucene syntax | `lucene 'key:field:"value"'` |
+| `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
+| `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
 > **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
 
@@ -85,7 +85,7 @@ All fields are accessed through three namespaces:
 | `create` | Add a computed field | `create latency_ms from $m.duration / 1000` |
 | `orderby` | Sort results | `orderby $d.timestamp desc` |
 | `extract` | Parse fields with regex or JSON | See [Text Extraction](#text-extraction) |
-| `dedupeby` | Remove duplicates by a field | `dedupeby $m.templateid` |
+| `dedupeby` | Remove duplicates by a field (cost grows with number of distinct keys) | `dedupeby $m.templateid` |
 
 ## Operators
 
@@ -94,10 +94,12 @@ All fields are accessed through three namespaces:
 | `==` | Equals | `filter $m.severity == ERROR` |
 | `!=` | Not equals | `filter $l.subsystemname != 'test'` |
 | `>`, `<`, `>=`, `<=` | Comparison | `filter $d.response_time > 1000` |
-| `~` | Contains (substring match) | `filter $d.message ~ 'timeout'` |
+| `~` | Case-insensitive token match (matches whole tokens, not arbitrary substrings) | `filter $d.message ~ 'timeout'` |
 | `&&` | AND | `filter $m.severity == ERROR && $l.applicationname == 'api'` |
 | `\|\|` | OR | `filter $m.severity == ERROR \|\| $m.severity == CRITICAL` |
 | `!= null` | Field exists | `filter $d.some_field != null` |
+
+> **`~` vs `contains()`:** `~` is a **case-insensitive, token-based** match — it matches whole tokens (words), so `~ 'timeout'` also matches `TIMEOUT` and `Timeout`. `contains()` is a **case-sensitive raw substring** match — `contains('time')` matches inside `timeout`, but only in that exact case. Use `~` for word/term search; use `contains()` when you need an exact-case partial-string match.
 
 ## Type Conversions
 
@@ -132,9 +134,12 @@ filter $d.http['status/code'] == 500
 | `median($field)` | Median value |
 | `stddev($field)` | Standard deviation |
 | `variance($field)` | Variance |
-| `distinct_count($field)` | Count unique values |
+| `distinct_count($field)` | Count unique values (exact) |
+| `approx_count_distinct($field)` | Approximate count of unique values |
 | `any_value($field)` | Random sample value |
 | `collect($field)` | Collect values into an array |
+
+> **`distinct_count` vs `approx_count_distinct`:** Exact `distinct_count` can be slow or run out of memory on high-cardinality fields. When an exact count isn't required, use `approx_count_distinct` instead.
 
 Example - full CLI invocation:
 ```bash
@@ -212,9 +217,11 @@ extract $d.json_payload into parsed using jsonobject() | filter $d.parsed.status
 # Remove duplicates by log template
 dedupeby $m.templateid
 
-# Dedupe by a custom field
-dedupeby $d.request_id
+# Keep one row per key (cost grows with the number of distinct keys)
+dedupeby $d.session_id
 ```
+
+> **Performance:** `dedupeby` cost scales with the number of **distinct keys** it tracks, so it gets slow and memory-heavy on high-cardinality or near-unique keys (e.g. a request id). Cardinality depends on your data and time window — a key like session or trace id can still be large. Keep `dedupeby` when you genuinely need one representative row per key; to cut cost, narrow the input first (tighter `filter`, smaller time window) rather than swapping in `filter`/`limit` (which does **not** keep one row per key) or an aggregation (which changes the row shape) unless that different output is acceptable. The `dedupeby <key> orderby ...` form (keep the latest row per key) is heavier still.
 
 ## Built-In Documentation
 

--- a/skills/cx-ai-center/references/spans-querying.md
+++ b/skills/cx-ai-center/references/spans-querying.md
@@ -110,6 +110,8 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-ai-center/references/spans-querying.md
+++ b/skills/cx-ai-center/references/spans-querying.md
@@ -10,7 +10,7 @@ Spans are the fundamental unit of tracing data. **Traces are not stored as singl
 
 This means:
 - **Metadata (`$m.*`)** and **labels (`$l.*`)** are predictable - you can always filter on timestamp, duration, service name, and operation name without discovery.
-- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentSpanID`) and application-specific tags/attributes that vary by service. Always verify custom `$d` fields before assuming they exist.
+- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentId`) and application-specific tags/attributes that vary by service. Exact attribute names depend on the instrumentation and can differ across tenants, so verify `$d` fields with a sample query before assuming they exist.
 
 ---
 
@@ -48,7 +48,7 @@ The `source spans` is automatically injected - do not include it in the query.
 | `$l.operationName` | Operation name - the span title (e.g. "POST /checkout", "db.query"). |
 | `$d.traceID` | Trace ID - groups spans into a single trace. |
 | `$d.spanID` | Unique span identifier. |
-| `$d.parentSpanID` | Parent span ID (empty string for root spans). |
+| `$d.parentId` | Parent span ID. Root spans have `parentId == null` (not an empty string). |
 | `$d.*` | Application-specific tags and attributes (see [Field Discovery](#field-discovery)). |
 
 > **Note on label fields:** The meaning of `$l.applicationName` and `$l.subsystemName` varies by customer - they may represent environments, teams, regions, or something else entirely. Don't assume what they map to. Use `cx search-fields` or sample queries to verify actual values.
@@ -106,7 +106,9 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and is expensive.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
@@ -184,14 +186,14 @@ cx spans "filter \$l.serviceName == '<service>' && \$m.duration > 1000000 | dist
 
 ### 3. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Check field availability**: the field you're filtering by may only exist in a subset of spans
-4. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-5. **Check service names**: service names are case-sensitive
-6. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Check field availability**: the field you're filtering by may only exist in a subset of spans
+3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+4. **Check service names**: service names are case-sensitive
+5. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+6. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-alerts/references/dataprime-reference.md
+++ b/skills/cx-alerts/references/dataprime-reference.md
@@ -66,7 +66,7 @@ All fields are accessed through three namespaces:
 | `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
 | `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
-> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
+> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage. `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
 
 ### Aggregation
 

--- a/skills/cx-alerts/references/dataprime-reference.md
+++ b/skills/cx-alerts/references/dataprime-reference.md
@@ -63,8 +63,8 @@ All fields are accessed through three namespaces:
 | `filter` | Keep rows matching a condition | `filter $m.severity == ERROR` |
 | `choose` | Select specific fields | `choose $m.timestamp, $d.message` |
 | `limit` | Cap the number of results | `limit 10` |
-| `wildfind` | Search all fields for a string (see note below) | `wildfind 'connection refused'` |
-| `lucene` | Filter using Lucene syntax | `lucene 'key:field:"value"'` |
+| `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
+| `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
 > **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
 
@@ -85,7 +85,7 @@ All fields are accessed through three namespaces:
 | `create` | Add a computed field | `create latency_ms from $m.duration / 1000` |
 | `orderby` | Sort results | `orderby $d.timestamp desc` |
 | `extract` | Parse fields with regex or JSON | See [Text Extraction](#text-extraction) |
-| `dedupeby` | Remove duplicates by a field | `dedupeby $m.templateid` |
+| `dedupeby` | Remove duplicates by a field (cost grows with number of distinct keys) | `dedupeby $m.templateid` |
 
 ## Operators
 
@@ -94,10 +94,12 @@ All fields are accessed through three namespaces:
 | `==` | Equals | `filter $m.severity == ERROR` |
 | `!=` | Not equals | `filter $l.subsystemname != 'test'` |
 | `>`, `<`, `>=`, `<=` | Comparison | `filter $d.response_time > 1000` |
-| `~` | Contains (substring match) | `filter $d.message ~ 'timeout'` |
+| `~` | Case-insensitive token match (matches whole tokens, not arbitrary substrings) | `filter $d.message ~ 'timeout'` |
 | `&&` | AND | `filter $m.severity == ERROR && $l.applicationname == 'api'` |
 | `\|\|` | OR | `filter $m.severity == ERROR \|\| $m.severity == CRITICAL` |
 | `!= null` | Field exists | `filter $d.some_field != null` |
+
+> **`~` vs `contains()`:** `~` is a **case-insensitive, token-based** match — it matches whole tokens (words), so `~ 'timeout'` also matches `TIMEOUT` and `Timeout`. `contains()` is a **case-sensitive raw substring** match — `contains('time')` matches inside `timeout`, but only in that exact case. Use `~` for word/term search; use `contains()` when you need an exact-case partial-string match.
 
 ## Type Conversions
 
@@ -132,9 +134,12 @@ filter $d.http['status/code'] == 500
 | `median($field)` | Median value |
 | `stddev($field)` | Standard deviation |
 | `variance($field)` | Variance |
-| `distinct_count($field)` | Count unique values |
+| `distinct_count($field)` | Count unique values (exact) |
+| `approx_count_distinct($field)` | Approximate count of unique values |
 | `any_value($field)` | Random sample value |
 | `collect($field)` | Collect values into an array |
+
+> **`distinct_count` vs `approx_count_distinct`:** Exact `distinct_count` can be slow or run out of memory on high-cardinality fields. When an exact count isn't required, use `approx_count_distinct` instead.
 
 Example - full CLI invocation:
 ```bash
@@ -212,9 +217,11 @@ extract $d.json_payload into parsed using jsonobject() | filter $d.parsed.status
 # Remove duplicates by log template
 dedupeby $m.templateid
 
-# Dedupe by a custom field
-dedupeby $d.request_id
+# Keep one row per key (cost grows with the number of distinct keys)
+dedupeby $d.session_id
 ```
+
+> **Performance:** `dedupeby` cost scales with the number of **distinct keys** it tracks, so it gets slow and memory-heavy on high-cardinality or near-unique keys (e.g. a request id). Cardinality depends on your data and time window — a key like session or trace id can still be large. Keep `dedupeby` when you genuinely need one representative row per key; to cut cost, narrow the input first (tighter `filter`, smaller time window) rather than swapping in `filter`/`limit` (which does **not** keep one row per key) or an aggregation (which changes the row shape) unless that different output is acceptable. The `dedupeby <key> orderby ...` form (keep the latest row per key) is heavier still.
 
 ## Built-In Documentation
 

--- a/skills/cx-alerts/references/logs-querying.md
+++ b/skills/cx-alerts/references/logs-querying.md
@@ -51,7 +51,7 @@ The `source logs` prefix is automatically injected if the query doesn't already 
 
 Severity keywords are used **without quotes** in DataPrime:
 
-`DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
+`VERBOSE` | `DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
 
 ```bash
 cx logs 'filter $m.severity == ERROR'
@@ -79,9 +79,13 @@ cx logs 'filter $m.severity == ERROR | groupby $l.subsystemname aggregate count(
 cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 ```
 
+> **`~` (text match):** `~` is a **case-insensitive, token-based** match — `~ 'timeout'` also matches `TIMEOUT`/`Timeout`, and it matches whole tokens (words), not arbitrary substrings. For a **case-sensitive raw substring** match, use `contains()` instead. See the operator table in `dataprime-reference.md`.
+
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and returns noisy results, especially for generic terms.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
@@ -174,12 +178,12 @@ cx logs "filter \$l.subsystemname == 'checkout' && \$m.severity == ERROR | group
 
 ### 4. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-4. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+3. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+4. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-alerts/references/logs-querying.md
+++ b/skills/cx-alerts/references/logs-querying.md
@@ -87,6 +87,8 @@ cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-alerts/references/spans-querying.md
+++ b/skills/cx-alerts/references/spans-querying.md
@@ -110,6 +110,8 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-alerts/references/spans-querying.md
+++ b/skills/cx-alerts/references/spans-querying.md
@@ -10,7 +10,7 @@ Spans are the fundamental unit of tracing data. **Traces are not stored as singl
 
 This means:
 - **Metadata (`$m.*`)** and **labels (`$l.*`)** are predictable - you can always filter on timestamp, duration, service name, and operation name without discovery.
-- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentSpanID`) and application-specific tags/attributes that vary by service. Always verify custom `$d` fields before assuming they exist.
+- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentId`) and application-specific tags/attributes that vary by service. Exact attribute names depend on the instrumentation and can differ across tenants, so verify `$d` fields with a sample query before assuming they exist.
 
 ---
 
@@ -48,7 +48,7 @@ The `source spans` is automatically injected - do not include it in the query.
 | `$l.operationName` | Operation name - the span title (e.g. "POST /checkout", "db.query"). |
 | `$d.traceID` | Trace ID - groups spans into a single trace. |
 | `$d.spanID` | Unique span identifier. |
-| `$d.parentSpanID` | Parent span ID (empty string for root spans). |
+| `$d.parentId` | Parent span ID. Root spans have `parentId == null` (not an empty string). |
 | `$d.*` | Application-specific tags and attributes (see [Field Discovery](#field-discovery)). |
 
 > **Note on label fields:** The meaning of `$l.applicationName` and `$l.subsystemName` varies by customer - they may represent environments, teams, regions, or something else entirely. Don't assume what they map to. Use `cx search-fields` or sample queries to verify actual values.
@@ -106,7 +106,9 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and is expensive.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
@@ -184,14 +186,14 @@ cx spans "filter \$l.serviceName == '<service>' && \$m.duration > 1000000 | dist
 
 ### 3. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Check field availability**: the field you're filtering by may only exist in a subset of spans
-4. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-5. **Check service names**: service names are case-sensitive
-6. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Check field availability**: the field you're filtering by may only exist in a subset of spans
+3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+4. **Check service names**: service names are case-sensitive
+5. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+6. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-coding-agents/references/dataprime-reference.md
+++ b/skills/cx-coding-agents/references/dataprime-reference.md
@@ -66,7 +66,7 @@ All fields are accessed through three namespaces:
 | `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
 | `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
-> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
+> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage. `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
 
 ### Aggregation
 

--- a/skills/cx-coding-agents/references/dataprime-reference.md
+++ b/skills/cx-coding-agents/references/dataprime-reference.md
@@ -63,8 +63,8 @@ All fields are accessed through three namespaces:
 | `filter` | Keep rows matching a condition | `filter $m.severity == ERROR` |
 | `choose` | Select specific fields | `choose $m.timestamp, $d.message` |
 | `limit` | Cap the number of results | `limit 10` |
-| `wildfind` | Search all fields for a string (see note below) | `wildfind 'connection refused'` |
-| `lucene` | Filter using Lucene syntax | `lucene 'key:field:"value"'` |
+| `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
+| `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
 > **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
 
@@ -85,7 +85,7 @@ All fields are accessed through three namespaces:
 | `create` | Add a computed field | `create latency_ms from $m.duration / 1000` |
 | `orderby` | Sort results | `orderby $d.timestamp desc` |
 | `extract` | Parse fields with regex or JSON | See [Text Extraction](#text-extraction) |
-| `dedupeby` | Remove duplicates by a field | `dedupeby $m.templateid` |
+| `dedupeby` | Remove duplicates by a field (cost grows with number of distinct keys) | `dedupeby $m.templateid` |
 
 ## Operators
 
@@ -94,10 +94,12 @@ All fields are accessed through three namespaces:
 | `==` | Equals | `filter $m.severity == ERROR` |
 | `!=` | Not equals | `filter $l.subsystemname != 'test'` |
 | `>`, `<`, `>=`, `<=` | Comparison | `filter $d.response_time > 1000` |
-| `~` | Contains (substring match) | `filter $d.message ~ 'timeout'` |
+| `~` | Case-insensitive token match (matches whole tokens, not arbitrary substrings) | `filter $d.message ~ 'timeout'` |
 | `&&` | AND | `filter $m.severity == ERROR && $l.applicationname == 'api'` |
 | `\|\|` | OR | `filter $m.severity == ERROR \|\| $m.severity == CRITICAL` |
 | `!= null` | Field exists | `filter $d.some_field != null` |
+
+> **`~` vs `contains()`:** `~` is a **case-insensitive, token-based** match — it matches whole tokens (words), so `~ 'timeout'` also matches `TIMEOUT` and `Timeout`. `contains()` is a **case-sensitive raw substring** match — `contains('time')` matches inside `timeout`, but only in that exact case. Use `~` for word/term search; use `contains()` when you need an exact-case partial-string match.
 
 ## Type Conversions
 
@@ -132,9 +134,12 @@ filter $d.http['status/code'] == 500
 | `median($field)` | Median value |
 | `stddev($field)` | Standard deviation |
 | `variance($field)` | Variance |
-| `distinct_count($field)` | Count unique values |
+| `distinct_count($field)` | Count unique values (exact) |
+| `approx_count_distinct($field)` | Approximate count of unique values |
 | `any_value($field)` | Random sample value |
 | `collect($field)` | Collect values into an array |
+
+> **`distinct_count` vs `approx_count_distinct`:** Exact `distinct_count` can be slow or run out of memory on high-cardinality fields. When an exact count isn't required, use `approx_count_distinct` instead.
 
 Example - full CLI invocation:
 ```bash
@@ -212,9 +217,11 @@ extract $d.json_payload into parsed using jsonobject() | filter $d.parsed.status
 # Remove duplicates by log template
 dedupeby $m.templateid
 
-# Dedupe by a custom field
-dedupeby $d.request_id
+# Keep one row per key (cost grows with the number of distinct keys)
+dedupeby $d.session_id
 ```
+
+> **Performance:** `dedupeby` cost scales with the number of **distinct keys** it tracks, so it gets slow and memory-heavy on high-cardinality or near-unique keys (e.g. a request id). Cardinality depends on your data and time window — a key like session or trace id can still be large. Keep `dedupeby` when you genuinely need one representative row per key; to cut cost, narrow the input first (tighter `filter`, smaller time window) rather than swapping in `filter`/`limit` (which does **not** keep one row per key) or an aggregation (which changes the row shape) unless that different output is acceptable. The `dedupeby <key> orderby ...` form (keep the latest row per key) is heavier still.
 
 ## Built-In Documentation
 

--- a/skills/cx-coding-agents/references/logs-querying.md
+++ b/skills/cx-coding-agents/references/logs-querying.md
@@ -51,7 +51,7 @@ The `source logs` prefix is automatically injected if the query doesn't already 
 
 Severity keywords are used **without quotes** in DataPrime:
 
-`DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
+`VERBOSE` | `DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
 
 ```bash
 cx logs 'filter $m.severity == ERROR'
@@ -79,9 +79,13 @@ cx logs 'filter $m.severity == ERROR | groupby $l.subsystemname aggregate count(
 cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 ```
 
+> **`~` (text match):** `~` is a **case-insensitive, token-based** match — `~ 'timeout'` also matches `TIMEOUT`/`Timeout`, and it matches whole tokens (words), not arbitrary substrings. For a **case-sensitive raw substring** match, use `contains()` instead. See the operator table in `dataprime-reference.md`.
+
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and returns noisy results, especially for generic terms.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
@@ -174,12 +178,12 @@ cx logs "filter \$l.subsystemname == 'checkout' && \$m.severity == ERROR | group
 
 ### 4. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-4. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+3. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+4. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-coding-agents/references/logs-querying.md
+++ b/skills/cx-coding-agents/references/logs-querying.md
@@ -87,6 +87,8 @@ cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-coding-agents/references/spans-querying.md
+++ b/skills/cx-coding-agents/references/spans-querying.md
@@ -110,6 +110,8 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-coding-agents/references/spans-querying.md
+++ b/skills/cx-coding-agents/references/spans-querying.md
@@ -10,7 +10,7 @@ Spans are the fundamental unit of tracing data. **Traces are not stored as singl
 
 This means:
 - **Metadata (`$m.*`)** and **labels (`$l.*`)** are predictable - you can always filter on timestamp, duration, service name, and operation name without discovery.
-- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentSpanID`) and application-specific tags/attributes that vary by service. Always verify custom `$d` fields before assuming they exist.
+- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentId`) and application-specific tags/attributes that vary by service. Exact attribute names depend on the instrumentation and can differ across tenants, so verify `$d` fields with a sample query before assuming they exist.
 
 ---
 
@@ -48,7 +48,7 @@ The `source spans` is automatically injected - do not include it in the query.
 | `$l.operationName` | Operation name - the span title (e.g. "POST /checkout", "db.query"). |
 | `$d.traceID` | Trace ID - groups spans into a single trace. |
 | `$d.spanID` | Unique span identifier. |
-| `$d.parentSpanID` | Parent span ID (empty string for root spans). |
+| `$d.parentId` | Parent span ID. Root spans have `parentId == null` (not an empty string). |
 | `$d.*` | Application-specific tags and attributes (see [Field Discovery](#field-discovery)). |
 
 > **Note on label fields:** The meaning of `$l.applicationName` and `$l.subsystemName` varies by customer - they may represent environments, teams, regions, or something else entirely. Don't assume what they map to. Use `cx search-fields` or sample queries to verify actual values.
@@ -106,7 +106,9 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and is expensive.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
@@ -184,14 +186,14 @@ cx spans "filter \$l.serviceName == '<service>' && \$m.duration > 1000000 | dist
 
 ### 3. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Check field availability**: the field you're filtering by may only exist in a subset of spans
-4. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-5. **Check service names**: service names are case-sensitive
-6. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Check field availability**: the field you're filtering by may only exist in a subset of spans
+3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+4. **Check service names**: service names are case-sensitive
+5. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+6. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-dashboards/references/dataprime-reference.md
+++ b/skills/cx-dashboards/references/dataprime-reference.md
@@ -66,7 +66,7 @@ All fields are accessed through three namespaces:
 | `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
 | `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
-> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
+> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage. `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
 
 ### Aggregation
 

--- a/skills/cx-dashboards/references/dataprime-reference.md
+++ b/skills/cx-dashboards/references/dataprime-reference.md
@@ -63,8 +63,8 @@ All fields are accessed through three namespaces:
 | `filter` | Keep rows matching a condition | `filter $m.severity == ERROR` |
 | `choose` | Select specific fields | `choose $m.timestamp, $d.message` |
 | `limit` | Cap the number of results | `limit 10` |
-| `wildfind` | Search all fields for a string (see note below) | `wildfind 'connection refused'` |
-| `lucene` | Filter using Lucene syntax | `lucene 'key:field:"value"'` |
+| `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
+| `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
 > **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
 
@@ -85,7 +85,7 @@ All fields are accessed through three namespaces:
 | `create` | Add a computed field | `create latency_ms from $m.duration / 1000` |
 | `orderby` | Sort results | `orderby $d.timestamp desc` |
 | `extract` | Parse fields with regex or JSON | See [Text Extraction](#text-extraction) |
-| `dedupeby` | Remove duplicates by a field | `dedupeby $m.templateid` |
+| `dedupeby` | Remove duplicates by a field (cost grows with number of distinct keys) | `dedupeby $m.templateid` |
 
 ## Operators
 
@@ -94,10 +94,12 @@ All fields are accessed through three namespaces:
 | `==` | Equals | `filter $m.severity == ERROR` |
 | `!=` | Not equals | `filter $l.subsystemname != 'test'` |
 | `>`, `<`, `>=`, `<=` | Comparison | `filter $d.response_time > 1000` |
-| `~` | Contains (substring match) | `filter $d.message ~ 'timeout'` |
+| `~` | Case-insensitive token match (matches whole tokens, not arbitrary substrings) | `filter $d.message ~ 'timeout'` |
 | `&&` | AND | `filter $m.severity == ERROR && $l.applicationname == 'api'` |
 | `\|\|` | OR | `filter $m.severity == ERROR \|\| $m.severity == CRITICAL` |
 | `!= null` | Field exists | `filter $d.some_field != null` |
+
+> **`~` vs `contains()`:** `~` is a **case-insensitive, token-based** match — it matches whole tokens (words), so `~ 'timeout'` also matches `TIMEOUT` and `Timeout`. `contains()` is a **case-sensitive raw substring** match — `contains('time')` matches inside `timeout`, but only in that exact case. Use `~` for word/term search; use `contains()` when you need an exact-case partial-string match.
 
 ## Type Conversions
 
@@ -132,9 +134,12 @@ filter $d.http['status/code'] == 500
 | `median($field)` | Median value |
 | `stddev($field)` | Standard deviation |
 | `variance($field)` | Variance |
-| `distinct_count($field)` | Count unique values |
+| `distinct_count($field)` | Count unique values (exact) |
+| `approx_count_distinct($field)` | Approximate count of unique values |
 | `any_value($field)` | Random sample value |
 | `collect($field)` | Collect values into an array |
+
+> **`distinct_count` vs `approx_count_distinct`:** Exact `distinct_count` can be slow or run out of memory on high-cardinality fields. When an exact count isn't required, use `approx_count_distinct` instead.
 
 Example - full CLI invocation:
 ```bash
@@ -212,9 +217,11 @@ extract $d.json_payload into parsed using jsonobject() | filter $d.parsed.status
 # Remove duplicates by log template
 dedupeby $m.templateid
 
-# Dedupe by a custom field
-dedupeby $d.request_id
+# Keep one row per key (cost grows with the number of distinct keys)
+dedupeby $d.session_id
 ```
+
+> **Performance:** `dedupeby` cost scales with the number of **distinct keys** it tracks, so it gets slow and memory-heavy on high-cardinality or near-unique keys (e.g. a request id). Cardinality depends on your data and time window — a key like session or trace id can still be large. Keep `dedupeby` when you genuinely need one representative row per key; to cut cost, narrow the input first (tighter `filter`, smaller time window) rather than swapping in `filter`/`limit` (which does **not** keep one row per key) or an aggregation (which changes the row shape) unless that different output is acceptable. The `dedupeby <key> orderby ...` form (keep the latest row per key) is heavier still.
 
 ## Built-In Documentation
 

--- a/skills/cx-dashboards/references/logs-querying.md
+++ b/skills/cx-dashboards/references/logs-querying.md
@@ -51,7 +51,7 @@ The `source logs` prefix is automatically injected if the query doesn't already 
 
 Severity keywords are used **without quotes** in DataPrime:
 
-`DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
+`VERBOSE` | `DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
 
 ```bash
 cx logs 'filter $m.severity == ERROR'
@@ -79,9 +79,13 @@ cx logs 'filter $m.severity == ERROR | groupby $l.subsystemname aggregate count(
 cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 ```
 
+> **`~` (text match):** `~` is a **case-insensitive, token-based** match — `~ 'timeout'` also matches `TIMEOUT`/`Timeout`, and it matches whole tokens (words), not arbitrary substrings. For a **case-sensitive raw substring** match, use `contains()` instead. See the operator table in `dataprime-reference.md`.
+
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and returns noisy results, especially for generic terms.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
@@ -174,12 +178,12 @@ cx logs "filter \$l.subsystemname == 'checkout' && \$m.severity == ERROR | group
 
 ### 4. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-4. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+3. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+4. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-dashboards/references/logs-querying.md
+++ b/skills/cx-dashboards/references/logs-querying.md
@@ -87,6 +87,8 @@ cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-dashboards/references/spans-querying.md
+++ b/skills/cx-dashboards/references/spans-querying.md
@@ -110,6 +110,8 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-dashboards/references/spans-querying.md
+++ b/skills/cx-dashboards/references/spans-querying.md
@@ -10,7 +10,7 @@ Spans are the fundamental unit of tracing data. **Traces are not stored as singl
 
 This means:
 - **Metadata (`$m.*`)** and **labels (`$l.*`)** are predictable - you can always filter on timestamp, duration, service name, and operation name without discovery.
-- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentSpanID`) and application-specific tags/attributes that vary by service. Always verify custom `$d` fields before assuming they exist.
+- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentId`) and application-specific tags/attributes that vary by service. Exact attribute names depend on the instrumentation and can differ across tenants, so verify `$d` fields with a sample query before assuming they exist.
 
 ---
 
@@ -48,7 +48,7 @@ The `source spans` is automatically injected - do not include it in the query.
 | `$l.operationName` | Operation name - the span title (e.g. "POST /checkout", "db.query"). |
 | `$d.traceID` | Trace ID - groups spans into a single trace. |
 | `$d.spanID` | Unique span identifier. |
-| `$d.parentSpanID` | Parent span ID (empty string for root spans). |
+| `$d.parentId` | Parent span ID. Root spans have `parentId == null` (not an empty string). |
 | `$d.*` | Application-specific tags and attributes (see [Field Discovery](#field-discovery)). |
 
 > **Note on label fields:** The meaning of `$l.applicationName` and `$l.subsystemName` varies by customer - they may represent environments, teams, regions, or something else entirely. Don't assume what they map to. Use `cx search-fields` or sample queries to verify actual values.
@@ -106,7 +106,9 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and is expensive.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
@@ -184,14 +186,14 @@ cx spans "filter \$l.serviceName == '<service>' && \$m.duration > 1000000 | dist
 
 ### 3. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Check field availability**: the field you're filtering by may only exist in a subset of spans
-4. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-5. **Check service names**: service names are case-sensitive
-6. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Check field availability**: the field you're filtering by may only exist in a subset of spans
+3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+4. **Check service names**: service names are case-sensitive
+5. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+6. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-telemetry-querying/references/dataprime-reference.md
+++ b/skills/cx-telemetry-querying/references/dataprime-reference.md
@@ -66,7 +66,7 @@ All fields are accessed through three namespaces:
 | `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
 | `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
-> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
+> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage. `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
 
 ### Aggregation
 

--- a/skills/cx-telemetry-querying/references/dataprime-reference.md
+++ b/skills/cx-telemetry-querying/references/dataprime-reference.md
@@ -63,8 +63,8 @@ All fields are accessed through three namespaces:
 | `filter` | Keep rows matching a condition | `filter $m.severity == ERROR` |
 | `choose` | Select specific fields | `choose $m.timestamp, $d.message` |
 | `limit` | Cap the number of results | `limit 10` |
-| `wildfind` | Search all fields for a string (see note below) | `wildfind 'connection refused'` |
-| `lucene` | Filter using Lucene syntax | `lucene 'key:field:"value"'` |
+| `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
+| `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
 > **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
 
@@ -85,7 +85,7 @@ All fields are accessed through three namespaces:
 | `create` | Add a computed field | `create latency_ms from $m.duration / 1000` |
 | `orderby` | Sort results | `orderby $d.timestamp desc` |
 | `extract` | Parse fields with regex or JSON | See [Text Extraction](#text-extraction) |
-| `dedupeby` | Remove duplicates by a field | `dedupeby $m.templateid` |
+| `dedupeby` | Remove duplicates by a field (cost grows with number of distinct keys) | `dedupeby $m.templateid` |
 
 ## Operators
 
@@ -94,10 +94,12 @@ All fields are accessed through three namespaces:
 | `==` | Equals | `filter $m.severity == ERROR` |
 | `!=` | Not equals | `filter $l.subsystemname != 'test'` |
 | `>`, `<`, `>=`, `<=` | Comparison | `filter $d.response_time > 1000` |
-| `~` | Contains (substring match) | `filter $d.message ~ 'timeout'` |
+| `~` | Case-insensitive token match (matches whole tokens, not arbitrary substrings) | `filter $d.message ~ 'timeout'` |
 | `&&` | AND | `filter $m.severity == ERROR && $l.applicationname == 'api'` |
 | `\|\|` | OR | `filter $m.severity == ERROR \|\| $m.severity == CRITICAL` |
 | `!= null` | Field exists | `filter $d.some_field != null` |
+
+> **`~` vs `contains()`:** `~` is a **case-insensitive, token-based** match — it matches whole tokens (words), so `~ 'timeout'` also matches `TIMEOUT` and `Timeout`. `contains()` is a **case-sensitive raw substring** match — `contains('time')` matches inside `timeout`, but only in that exact case. Use `~` for word/term search; use `contains()` when you need an exact-case partial-string match.
 
 ## Type Conversions
 
@@ -132,9 +134,12 @@ filter $d.http['status/code'] == 500
 | `median($field)` | Median value |
 | `stddev($field)` | Standard deviation |
 | `variance($field)` | Variance |
-| `distinct_count($field)` | Count unique values |
+| `distinct_count($field)` | Count unique values (exact) |
+| `approx_count_distinct($field)` | Approximate count of unique values |
 | `any_value($field)` | Random sample value |
 | `collect($field)` | Collect values into an array |
+
+> **`distinct_count` vs `approx_count_distinct`:** Exact `distinct_count` can be slow or run out of memory on high-cardinality fields. When an exact count isn't required, use `approx_count_distinct` instead.
 
 Example - full CLI invocation:
 ```bash
@@ -212,9 +217,11 @@ extract $d.json_payload into parsed using jsonobject() | filter $d.parsed.status
 # Remove duplicates by log template
 dedupeby $m.templateid
 
-# Dedupe by a custom field
-dedupeby $d.request_id
+# Keep one row per key (cost grows with the number of distinct keys)
+dedupeby $d.session_id
 ```
+
+> **Performance:** `dedupeby` cost scales with the number of **distinct keys** it tracks, so it gets slow and memory-heavy on high-cardinality or near-unique keys (e.g. a request id). Cardinality depends on your data and time window — a key like session or trace id can still be large. Keep `dedupeby` when you genuinely need one representative row per key; to cut cost, narrow the input first (tighter `filter`, smaller time window) rather than swapping in `filter`/`limit` (which does **not** keep one row per key) or an aggregation (which changes the row shape) unless that different output is acceptable. The `dedupeby <key> orderby ...` form (keep the latest row per key) is heavier still.
 
 ## Built-In Documentation
 

--- a/skills/cx-telemetry-querying/references/logs-querying.md
+++ b/skills/cx-telemetry-querying/references/logs-querying.md
@@ -51,7 +51,7 @@ The `source logs` prefix is automatically injected if the query doesn't already 
 
 Severity keywords are used **without quotes** in DataPrime:
 
-`DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
+`VERBOSE` | `DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
 
 ```bash
 cx logs 'filter $m.severity == ERROR'
@@ -79,9 +79,13 @@ cx logs 'filter $m.severity == ERROR | groupby $l.subsystemname aggregate count(
 cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 ```
 
+> **`~` (text match):** `~` is a **case-insensitive, token-based** match — `~ 'timeout'` also matches `TIMEOUT`/`Timeout`, and it matches whole tokens (words), not arbitrary substrings. For a **case-sensitive raw substring** match, use `contains()` instead. See the operator table in `dataprime-reference.md`.
+
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and returns noisy results, especially for generic terms.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
@@ -174,12 +178,12 @@ cx logs "filter \$l.subsystemname == 'checkout' && \$m.severity == ERROR | group
 
 ### 4. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-4. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+3. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+4. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/cx-telemetry-querying/references/logs-querying.md
+++ b/skills/cx-telemetry-querying/references/logs-querying.md
@@ -87,6 +87,8 @@ cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-telemetry-querying/references/rum-querying.md
+++ b/skills/cx-telemetry-querying/references/rum-querying.md
@@ -166,11 +166,11 @@ Use the `LT` (Load Time) web vital for page loading time questions. Group by `$d
 
 ## Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-7d` or `--start now-30d`
-2. **Relax filters**: remove the most restrictive condition
-3. **Verify field names**: run a sample query with `-o json` to inspect actual fields
-4. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Verify field names**: run a sample query with `-o json` to inspect actual fields
+3. **Extend the time range**: widen gradually from your current window (e.g. `now-24h` → `now-7d` → `now-30d`)
+4. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 **Note:** Filtering by `cx_rum` fields will show **only RUM/frontend logs** and hide backend logs. This is expected when analyzing RUM data.

--- a/skills/cx-telemetry-querying/references/spans-querying.md
+++ b/skills/cx-telemetry-querying/references/spans-querying.md
@@ -110,6 +110,8 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
 ```bash

--- a/skills/cx-telemetry-querying/references/spans-querying.md
+++ b/skills/cx-telemetry-querying/references/spans-querying.md
@@ -10,7 +10,7 @@ Spans are the fundamental unit of tracing data. **Traces are not stored as singl
 
 This means:
 - **Metadata (`$m.*`)** and **labels (`$l.*`)** are predictable - you can always filter on timestamp, duration, service name, and operation name without discovery.
-- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentSpanID`) and application-specific tags/attributes that vary by service. Always verify custom `$d` fields before assuming they exist.
+- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentId`) and application-specific tags/attributes that vary by service. Exact attribute names depend on the instrumentation and can differ across tenants, so verify `$d` fields with a sample query before assuming they exist.
 
 ---
 
@@ -48,7 +48,7 @@ The `source spans` is automatically injected - do not include it in the query.
 | `$l.operationName` | Operation name - the span title (e.g. "POST /checkout", "db.query"). |
 | `$d.traceID` | Trace ID - groups spans into a single trace. |
 | `$d.spanID` | Unique span identifier. |
-| `$d.parentSpanID` | Parent span ID (empty string for root spans). |
+| `$d.parentId` | Parent span ID. Root spans have `parentId == null` (not an empty string). |
 | `$d.*` | Application-specific tags and attributes (see [Field Discovery](#field-discovery)). |
 
 > **Note on label fields:** The meaning of `$l.applicationName` and `$l.subsystemName` varies by customer - they may represent environments, teams, regions, or something else entirely. Don't assume what they map to. Use `cx search-fields` or sample queries to verify actual values.
@@ -106,7 +106,9 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and is expensive.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
@@ -184,14 +186,14 @@ cx spans "filter \$l.serviceName == '<service>' && \$m.duration > 1000000 | dist
 
 ### 3. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Check field availability**: the field you're filtering by may only exist in a subset of spans
-4. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-5. **Check service names**: service names are case-sensitive
-6. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Check field availability**: the field you're filtering by may only exist in a subset of spans
+3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+4. **Check service names**: service names are case-sensitive
+5. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+6. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/shared/dataprime-reference.md
+++ b/skills/shared/dataprime-reference.md
@@ -66,7 +66,7 @@ All fields are accessed through three namespaces:
 | `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
 | `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
-> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
+> **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage. `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
 
 ### Aggregation
 

--- a/skills/shared/dataprime-reference.md
+++ b/skills/shared/dataprime-reference.md
@@ -63,8 +63,8 @@ All fields are accessed through three namespaces:
 | `filter` | Keep rows matching a condition | `filter $m.severity == ERROR` |
 | `choose` | Select specific fields | `choose $m.timestamp, $d.message` |
 | `limit` | Cap the number of results | `limit 10` |
-| `wildfind` | Search all fields for a string (see note below) | `wildfind 'connection refused'` |
-| `lucene` | Filter using Lucene syntax | `lucene 'key:field:"value"'` |
+| `wildfind` | Token match across the whole record (see note below) | `wildfind 'connection refused'` |
+| `lucene` | Filter using Lucene syntax (`field:value`, field names relative to `$d`, combine with `AND`/`OR`/parens) | `lucene 'field:"value"'` |
 
 > **Note on `wildfind`:** It is a standalone command, not a condition within `filter`. You cannot combine it with other filter expressions - use it as its own pipeline stage.
 
@@ -85,7 +85,7 @@ All fields are accessed through three namespaces:
 | `create` | Add a computed field | `create latency_ms from $m.duration / 1000` |
 | `orderby` | Sort results | `orderby $d.timestamp desc` |
 | `extract` | Parse fields with regex or JSON | See [Text Extraction](#text-extraction) |
-| `dedupeby` | Remove duplicates by a field | `dedupeby $m.templateid` |
+| `dedupeby` | Remove duplicates by a field (cost grows with number of distinct keys) | `dedupeby $m.templateid` |
 
 ## Operators
 
@@ -94,10 +94,12 @@ All fields are accessed through three namespaces:
 | `==` | Equals | `filter $m.severity == ERROR` |
 | `!=` | Not equals | `filter $l.subsystemname != 'test'` |
 | `>`, `<`, `>=`, `<=` | Comparison | `filter $d.response_time > 1000` |
-| `~` | Contains (substring match) | `filter $d.message ~ 'timeout'` |
+| `~` | Case-insensitive token match (matches whole tokens, not arbitrary substrings) | `filter $d.message ~ 'timeout'` |
 | `&&` | AND | `filter $m.severity == ERROR && $l.applicationname == 'api'` |
 | `\|\|` | OR | `filter $m.severity == ERROR \|\| $m.severity == CRITICAL` |
 | `!= null` | Field exists | `filter $d.some_field != null` |
+
+> **`~` vs `contains()`:** `~` is a **case-insensitive, token-based** match — it matches whole tokens (words), so `~ 'timeout'` also matches `TIMEOUT` and `Timeout`. `contains()` is a **case-sensitive raw substring** match — `contains('time')` matches inside `timeout`, but only in that exact case. Use `~` for word/term search; use `contains()` when you need an exact-case partial-string match.
 
 ## Type Conversions
 
@@ -132,9 +134,12 @@ filter $d.http['status/code'] == 500
 | `median($field)` | Median value |
 | `stddev($field)` | Standard deviation |
 | `variance($field)` | Variance |
-| `distinct_count($field)` | Count unique values |
+| `distinct_count($field)` | Count unique values (exact) |
+| `approx_count_distinct($field)` | Approximate count of unique values |
 | `any_value($field)` | Random sample value |
 | `collect($field)` | Collect values into an array |
+
+> **`distinct_count` vs `approx_count_distinct`:** Exact `distinct_count` can be slow or run out of memory on high-cardinality fields. When an exact count isn't required, use `approx_count_distinct` instead.
 
 Example - full CLI invocation:
 ```bash
@@ -212,9 +217,11 @@ extract $d.json_payload into parsed using jsonobject() | filter $d.parsed.status
 # Remove duplicates by log template
 dedupeby $m.templateid
 
-# Dedupe by a custom field
-dedupeby $d.request_id
+# Keep one row per key (cost grows with the number of distinct keys)
+dedupeby $d.session_id
 ```
+
+> **Performance:** `dedupeby` cost scales with the number of **distinct keys** it tracks, so it gets slow and memory-heavy on high-cardinality or near-unique keys (e.g. a request id). Cardinality depends on your data and time window — a key like session or trace id can still be large. Keep `dedupeby` when you genuinely need one representative row per key; to cut cost, narrow the input first (tighter `filter`, smaller time window) rather than swapping in `filter`/`limit` (which does **not** keep one row per key) or an aggregation (which changes the row shape) unless that different output is acceptable. The `dedupeby <key> orderby ...` form (keep the latest row per key) is heavier still.
 
 ## Built-In Documentation
 

--- a/skills/shared/logs-querying.md
+++ b/skills/shared/logs-querying.md
@@ -51,7 +51,7 @@ The `source logs` prefix is automatically injected if the query doesn't already 
 
 Severity keywords are used **without quotes** in DataPrime:
 
-`DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
+`VERBOSE` | `DEBUG` | `INFO` | `WARNING` | `ERROR` | `CRITICAL`
 
 ```bash
 cx logs 'filter $m.severity == ERROR'
@@ -79,9 +79,13 @@ cx logs 'filter $m.severity == ERROR | groupby $l.subsystemname aggregate count(
 cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 ```
 
+> **`~` (text match):** `~` is a **case-insensitive, token-based** match — `~ 'timeout'` also matches `TIMEOUT`/`Timeout`, and it matches whole tokens (words), not arbitrary substrings. For a **case-sensitive raw substring** match, use `contains()` instead. See the operator table in `dataprime-reference.md`.
+
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and returns noisy results, especially for generic terms.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
@@ -174,12 +178,12 @@ cx logs "filter \$l.subsystemname == 'checkout' && \$m.severity == ERROR | group
 
 ### 4. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-4. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+3. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+4. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 

--- a/skills/shared/logs-querying.md
+++ b/skills/shared/logs-querying.md
@@ -87,6 +87,8 @@ cx logs "filter \$l.subsystemname == 'payments'" --tier archive --start now-7d
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field and will match the term in fields you didn't intend.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific, quoted error message or log string and you don't know which field contains it:
 
 ```bash

--- a/skills/shared/rum-querying.md
+++ b/skills/shared/rum-querying.md
@@ -166,11 +166,11 @@ Use the `LT` (Load Time) web vital for page loading time questions. Group by `$d
 
 ## Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-7d` or `--start now-30d`
-2. **Relax filters**: remove the most restrictive condition
-3. **Verify field names**: run a sample query with `-o json` to inspect actual fields
-4. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Verify field names**: run a sample query with `-o json` to inspect actual fields
+3. **Extend the time range**: widen gradually from your current window (e.g. `now-24h` → `now-7d` → `now-30d`)
+4. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 **Note:** Filtering by `cx_rum` fields will show **only RUM/frontend logs** and hide backend logs. This is expected when analyzing RUM data.

--- a/skills/shared/spans-querying.md
+++ b/skills/shared/spans-querying.md
@@ -110,6 +110,8 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 **Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
+**Performance:** `wildfind` with very short search terms (only a few characters) is much slower — prefer longer, more specific terms.
+
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
 ```bash

--- a/skills/shared/spans-querying.md
+++ b/skills/shared/spans-querying.md
@@ -10,7 +10,7 @@ Spans are the fundamental unit of tracing data. **Traces are not stored as singl
 
 This means:
 - **Metadata (`$m.*`)** and **labels (`$l.*`)** are predictable - you can always filter on timestamp, duration, service name, and operation name without discovery.
-- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentSpanID`) and application-specific tags/attributes that vary by service. Always verify custom `$d` fields before assuming they exist.
+- **User data (`$d.*`)** contains trace identifiers (`traceID`, `spanID`, `parentId`) and application-specific tags/attributes that vary by service. Exact attribute names depend on the instrumentation and can differ across tenants, so verify `$d` fields with a sample query before assuming they exist.
 
 ---
 
@@ -48,7 +48,7 @@ The `source spans` is automatically injected - do not include it in the query.
 | `$l.operationName` | Operation name - the span title (e.g. "POST /checkout", "db.query"). |
 | `$d.traceID` | Trace ID - groups spans into a single trace. |
 | `$d.spanID` | Unique span identifier. |
-| `$d.parentSpanID` | Parent span ID (empty string for root spans). |
+| `$d.parentId` | Parent span ID. Root spans have `parentId == null` (not an empty string). |
 | `$d.*` | Application-specific tags and attributes (see [Field Discovery](#field-discovery)). |
 
 > **Note on label fields:** The meaning of `$l.applicationName` and `$l.subsystemName` varies by customer - they may represent environments, teams, regions, or something else entirely. Don't assume what they map to. Use `cx search-fields` or sample queries to verify actual values.
@@ -106,7 +106,9 @@ cx spans "filter \$l.serviceName == 'api'" --start now-6h
 
 ### Wildfind Policy
 
-**Avoid `wildfind` by default.** It scans all fields and is expensive.
+`wildfind` runs the same **case-insensitive, token-based** match as `~` (whole tokens, not arbitrary substrings), but over the whole record instead of a single field — it matches tokens anywhere, in any field.
+
+**Prefer a field-targeted `~`/`filter` when you know the field** — for **precision**: because `wildfind` matches tokens anywhere in the record, it can't be narrowed to a specific field.
 
 The **one exception**: when the user provides a specific string and you don't know which field contains it:
 
@@ -184,14 +186,14 @@ cx spans "filter \$l.serviceName == '<service>' && \$m.duration > 1000000 | dist
 
 ### 3. Troubleshooting
 
-If a query returns no results, change **one thing at a time**:
+If a query returns no results, change **one thing at a time**. Keep the query window as **narrow** as possible and widen it deliberately — start from the window you already have rather than jumping to a huge range:
 
-1. **Extend the time range**: `--start now-6h` or `--start now-24h`
-2. **Relax filters**: remove the most restrictive condition
-3. **Check field availability**: the field you're filtering by may only exist in a subset of spans
-4. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
-5. **Check service names**: service names are case-sensitive
-6. **Try archive tier**: `--tier archive --start now-30d` for older data
+1. **Relax filters**: remove the most restrictive condition
+2. **Check field availability**: the field you're filtering by may only exist in a subset of spans
+3. **Verify field names**: run a sample query with `-o json` to inspect the actual schema
+4. **Check service names**: service names are case-sensitive
+5. **Extend the time range**: widen gradually from your current window (e.g. `now-1h` → `now-6h` → `now-24h`)
+6. **Try archive tier**: for older data, add `--tier archive` and widen the window to cover the period you're after
 
 ---
 


### PR DESCRIPTION
Docs-only hardening of the shared DataPrime references used by the **cx-telemetry-querying** skill family. Edited in `skills/shared/` and synced to consumers via `scripts/sync-shared-references.sh`. Verified against the DataPrime parser and live data.

**Correctness fixes**
- `~` is a case-insensitive, token-based match (vs `contains()`, a case-sensitive substring match)
- `lucene` example → `'field:"value"'`
- severity list adds **VERBOSE**
- spans: `$d.parentSpanID` → `$d.parentId`; root spans have `parentId == null` (not empty string)
- add `approx_count_distinct` alongside exact `distinct_count`

**Anti-pattern / wording fixes**
- `wildfind` framed by **precision** (matches tokens in any field, can't scope to one) instead of "scans all fields / expensive"
- `dedupeby` cost tied to number of distinct keys; don't substitute `filter`/`limit` (doesn't keep one row per key) or aggregation (changes row shape)
- troubleshooting: prefer narrow windows, widen deliberately; drop hardcoded `now-30d` (I have seen that agent jumps straight to 30d window too frequently)

**Out of scope:** `assets/dataprime_docs.yaml` (generated from public docs; carries stale wildfind/dedupeby wording) and a `cx` bug that swallows failing queries into `[]` — both need separate fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)