### PR TITLE
fix(suppression-rules): unwrap alertSchedulerRule envelope in list response

### DIFF
--- a/src/commands/suppression_rules/api.rs
+++ b/src/commands/suppression_rules/api.rs
@@ -20,10 +20,41 @@ pub struct AlertSchedulerRule {
     pub updated_at: Option<String>,
 }
 
+/// Each element of the live API's `alertSchedulerRules` array arrives wrapped:
+/// `{ "alertSchedulerRule": { ... }, "nextActiveTimeframes": [ ... ] }`.
+/// Deserializing the element directly as `AlertSchedulerRule` made every field
+/// miss, and the all-`Option` struct silently produced rules with null fields.
+/// Accept both the wrapped (live) and flat (legacy/fixture) shapes.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum ListedAlertSchedulerRule {
+    Wrapped {
+        #[serde(rename = "alertSchedulerRule")]
+        rule: AlertSchedulerRule,
+    },
+    Flat(AlertSchedulerRule),
+}
+
+fn unwrap_rule_envelopes<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Vec<AlertSchedulerRule>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let items = Vec::<ListedAlertSchedulerRule>::deserialize(deserializer)?;
+    Ok(items
+        .into_iter()
+        .map(|item| match item {
+            ListedAlertSchedulerRule::Wrapped { rule } => rule,
+            ListedAlertSchedulerRule::Flat(rule) => rule,
+        })
+        .collect())
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct GetBulkAlertSchedulerRuleResponse {
-    #[serde(default)]
+    #[serde(default, deserialize_with = "unwrap_rule_envelopes")]
     pub alert_scheduler_rules: Vec<AlertSchedulerRule>,
 }
 
@@ -86,7 +117,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn deserialize_list_response() {
+    fn deserialize_list_response_flat_legacy_shape() {
         let json = json!({
             "alertSchedulerRules": [
                 {
@@ -103,6 +134,56 @@ mod tests {
             resp.alert_scheduler_rules[0].name.as_deref(),
             Some("Maintenance Window")
         );
+    }
+
+    // Real live-API shape (us1, July 2026): each element wraps the rule under
+    // "alertSchedulerRule" alongside "nextActiveTimeframes". Regression test for
+    // list rendering every field as null/empty.
+    #[test]
+    fn deserialize_list_response_wrapped_live_shape() {
+        let json = json!({
+            "alertSchedulerRules": [
+                {
+                    "alertSchedulerRule": {
+                        "uniqueIdentifier": "1a9f690e-2d08-4992-8529-59ff5630592f",
+                        "id": "faba7566-0e31-4e5e-9813-5e2d02fbc5f8",
+                        "name": "Maintenance window mute",
+                        "description": "one-time mute",
+                        "metaLabels": [],
+                        "filter": {
+                            "whatExpression": "source logs | filter true",
+                            "alertUniqueIds": { "value": ["033848bf-942a-4de9-954e-64ce3e27af51"] }
+                        },
+                        "schedule": {
+                            "scheduleOperation": "SCHEDULE_OPERATION_MUTE",
+                            "oneTime": {
+                                "timeframe": {
+                                    "startTime": "2026-07-17T00:00:00.000",
+                                    "endTime": "2026-07-19T23:59:00.000",
+                                    "timezone": "UTC-4"
+                                }
+                            }
+                        },
+                        "enabled": true,
+                        "createdAt": "2026-07-18T04:47:58.000Z",
+                        "updatedAt": "2026-07-18T04:47:58.000Z"
+                    },
+                    "nextActiveTimeframes": []
+                }
+            ],
+            "nextPageToken": ""
+        });
+        let resp: GetBulkAlertSchedulerRuleResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.alert_scheduler_rules.len(), 1);
+        let rule = &resp.alert_scheduler_rules[0];
+        assert_eq!(
+            rule.id.as_deref(),
+            Some("faba7566-0e31-4e5e-9813-5e2d02fbc5f8")
+        );
+        assert_eq!(rule.name.as_deref(), Some("Maintenance window mute"));
+        assert_eq!(rule.enabled, Some(true));
+        assert_eq!(rule.created_at.as_deref(), Some("2026-07-18T04:47:58.000Z"));
+        assert!(rule.schedule.is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Context

`cx alerts suppression-rules list` renders a row for each rule but every field is null/empty (`-o json` gives `[{"id":null,"name":null,...}]`, the text table shows a blank row). The rule exists and `create` works — same failure mode as the earlier `integrations list` (#146) / `webhooks list` (#162) bugs: a response-shape mismatch that serde silently swallows because every field on `AlertSchedulerRule` is `Option`.

## Linked Issues

- Same class as #135 (integrations/webhooks list) and #153 (recording-rules list)

## Design

The live API (`GET /mgmt/openapi/5/alerts/suppression-rules/v1`, verified on us1, 2026-07-18) wraps each array element:

```json
{
  "alertSchedulerRules": [
    { "alertSchedulerRule": { "id": "...", "name": "...", ... },
      "nextActiveTimeframes": [] }
  ],
  "nextPageToken": ""
}
```

`GetBulkAlertSchedulerRuleResponse` deserialized each element directly as `AlertSchedulerRule`, so every field missed. Following the #162 pattern: the Rust field `alert_scheduler_rules: Vec<AlertSchedulerRule>` is unchanged (no `mod.rs` changes) — a `deserialize_with` unwraps the envelope at the JSON boundary. An untagged enum accepts both the wrapped (live) and flat (legacy/fixture) shapes, so the existing flat unit fixture still parses.

## Changes

- `src/commands/suppression_rules/api.rs`: envelope unwrap via `ListedAlertSchedulerRule` untagged enum + `unwrap_rule_envelopes` deserializer
- Regression test with the real live-API payload shape (incl. `nextActiveTimeframes` sibling and `nextPageToken`); existing flat-shape test kept as back-compat coverage

## Testing

- `cargo test suppression_rules::api::tests` — 4 passed (new wrapped-shape regression test + existing 3)
- Full `cargo test` — green
- Manual against live us1 tenant: `cargo run -- alerts suppression-rules list` now renders the rule's real id/name/enabled/created (was a blank row); `-o json` returns populated fields

## Risks & Rollout

Low — deserialization-only, list path only. If the API ever returns flat rule objects again, the `Flat` variant still parses them. Rollback is a revert.

## Out of Scope / Follow-ups

- `GET .../suppression-rules/v1/{id}` returns `{}` from the API itself (verified via raw curl on us1) — `run_get` faithfully prints it, so `suppression-rules get <id>` shows nothing useful; that looks API-side, not CLI-side. Happy to file separately if useful.
- #153 (recording-rules list) — didn't touch here, but likely the same envelope pattern is worth checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)