### PR TITLE
fix(schema): distinguish options from positional args (FORGE-125)

### DIFF
--- a/src/commands/schema/mod.rs
+++ b/src/commands/schema/mod.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use clap::Command;
+use clap::{ArgAction, Command};
 use serde_json::{json, Value};
 
 use crate::update_check;
@@ -38,8 +38,10 @@ fn build_command(cmd: &Command) -> Value {
         .get_arguments()
         .filter(|arg| arg.get_id() != "help" && arg.get_id() != "version")
         .map(|arg| {
+            let positional = arg.is_positional();
             let mut obj = json!({
                 "name": arg.get_id().as_str(),
+                "positional": positional,
                 "required": arg.is_required_set(),
             });
             if let Some(help) = arg.get_help() {
@@ -48,7 +50,20 @@ fn build_command(cmd: &Command) -> Value {
             if let Some(vals) = arg.get_default_values().first() {
                 obj["default"] = json!(vals.to_string_lossy());
             }
-            if let Some(value_names) = arg.get_value_names() {
+            // For options, tell agents exactly how to pass the argument.
+            if let Some(long) = arg.get_long() {
+                obj["flag"] = json!(format!("--{long}"));
+            }
+            if let Some(short) = arg.get_short() {
+                obj["short"] = json!(format!("-{short}"));
+            }
+            // Boolean flags (e.g. `--yes`) take no value; everything else
+            // carries a value hint from its placeholder name.
+            let takes_no_value =
+                matches!(arg.get_action(), ArgAction::SetTrue | ArgAction::SetFalse);
+            if takes_no_value {
+                obj["type"] = json!("boolean");
+            } else if let Some(value_names) = arg.get_value_names() {
                 let type_name = value_names
                     .first()
                     .map(|v| v.to_lowercase())

--- a/tests/schema/main.rs
+++ b/tests/schema/main.rs
@@ -97,4 +97,42 @@ fn schema_outputs_valid_json_with_expected_commands() {
         .collect();
     assert!(docs_subs.contains(&"search"));
     assert!(docs_subs.contains(&"fetch"));
+
+    // Regression (FORGE-125): schema must distinguish options from positionals
+    // so agents build commands the CLI accepts.
+    let alerts_subs = alerts["subcommands"].as_array().unwrap();
+
+    // `alerts list --name` is an option, not a positional.
+    let list = alerts_subs.iter().find(|s| s["name"] == "list").unwrap();
+    let name_arg = list["arguments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["name"] == "name")
+        .expect("alerts list should expose a 'name' argument");
+    assert_eq!(
+        name_arg["positional"], false,
+        "alerts list --name must be reported as an option, not positional"
+    );
+    assert_eq!(
+        name_arg["flag"], "--name",
+        "alerts list --name must advertise its flag string"
+    );
+
+    // `alerts get <alert_id>` is a genuine positional with no flag.
+    let get = alerts_subs.iter().find(|s| s["name"] == "get").unwrap();
+    let id_arg = get["arguments"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|a| a["name"] == "alert_id")
+        .expect("alerts get should expose an 'alert_id' argument");
+    assert_eq!(
+        id_arg["positional"], true,
+        "alerts get <alert_id> must be reported as positional"
+    );
+    assert!(
+        id_arg.get("flag").is_none(),
+        "positional args must not advertise a flag"
+    );
 }


### PR DESCRIPTION
## Summary

`cx schema` — the documented agent-consumption interface — advertised the `--name` filter on `alerts list` as if it were a bare positional `<name>`. Agents built `cx alerts list "DynamoDB"`, which the CLI rejects (`error: unexpected argument 'DynamoDB' found`); only `cx alerts list --name "DynamoDB"` works.

The schema generator auto-generates from clap but emitted every argument identically, with no way to tell a positional from an option and no flag string. This fix records how to pass each argument.

Fixes [FORGE-125](https://linear.app/coralogix/issue/FORGE-125) / closes #136.

## Changes

- `src/commands/schema/mod.rs` — each argument object now reports:
  - `"positional": <bool>` (`arg.is_positional()`)
  - `"flag": "--<long>"` and `"short": "-<c>"` for options (omitted for positionals)
  - `"type": "boolean"` for value-less flags (`SetTrue`/`SetFalse`)
- `tests/schema/main.rs` — regression assertions: `alerts list`'s `name` is `positional: false` / `flag: "--name"`; `alerts get`'s `alert_id` is `positional: true` with no flag.

Additive only — no existing keys removed. No CLI behavior change.

## Examples (run against the new build)

### 1. `alerts list --name` — the bug: an option, now described as one
```console
$ cx schema | jq '..|select(.name=="list"?)?.arguments'
[
  {
    "name": "name",
    "positional": false,
    "required": false,
    "description": "Filter by name (case-insensitive substring match)",
    "flag": "--name",
    "type": "name"
  }
]
```
The `flag` the schema now advertises is exactly what the CLI accepts:
```console
$ cx alerts list "DynamoDB"          # positional — what the OLD schema implied
error: unexpected argument 'DynamoDB' found

$ cx alerts list --help
Options:
      --name <NAME>
          Filter by name (case-insensitive substring match)
```

### 2. `alerts get <alert_id>` — a genuine positional, no flag
```console
$ cx schema | jq '..|select(.name=="get"?)?.arguments'
[
  {
    "name": "alert_id",
    "positional": true,
    "required": true,
    "description": "Alert definition ID or alert version ID (UUID). ...",
    "type": "alert_id"
  }
]
```

### 3. Boolean flag — value-less, `type: "boolean"`, with short form
```console
$ cx schema | jq '..|.arguments?//empty|.[]|select(.name=="force")' | head
{
  "name": "force",
  "positional": false,
  "required": false,
  "description": "Skip confirmation prompt",
  "flag": "--force",
  "short": "-f",
  "type": "boolean"
}
```

### Whole-schema invariant check
Walking every subcommand in the generated schema:
```
positional args: 110
option args:     164   (all 164 carry a "flag": OK)
boolean flags:   8
args w/ short:   3
```
Every option has a `flag`; no positional carries one.

## Verification

- `cargo build`, `cargo fmt`, `cargo clippy` (no new warnings) ✅
- `cargo test` → 739 passed, 0 failed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)