### PR TITLE
fix(fan-out): stop rendering query/API failures as empty results (FORGE-482)

### DIFF
--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -214,7 +214,7 @@ fn normalize_endpoint(endpoint: &str) -> String {
 ///
 /// Returns `None` when the body is not JSON, none of the fields are present,
 /// or every candidate is an empty string.
-fn extract_error_detail(body: &str) -> Option<String> {
+pub(crate) fn extract_error_detail(body: &str) -> Option<String> {
     let v: Value = serde_json::from_str(body).ok()?;
     let non_empty = |val: &Value| val.as_str().filter(|s| !s.is_empty()).map(String::from);
     non_empty(&v["message"])

--- a/src/commands/actions/mod.rs
+++ b/src/commands/actions/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Action, ActionsApi};
 
@@ -166,10 +166,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(action) = resp.action {
             let name = action.display_name().to_string();
-            let id = action.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created action '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "action",
+                Some(&name),
+                action.id.as_deref(),
+                &profile,
             );
             all_results.push(action_to_json(&action, include_profile, &profile));
         }

--- a/src/commands/actions/mod.rs
+++ b/src/commands/actions/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -55,6 +55,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Action)> = Vec::new();
     for (profile, result) in per_profile {
@@ -65,8 +67,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), action));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -122,6 +130,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -131,8 +141,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -172,6 +188,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -187,8 +205,14 @@ pub async fn run_create(
                     all_results.push(action_to_json(&action, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -225,6 +249,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -235,8 +261,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -263,14 +295,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Action {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -293,6 +333,8 @@ pub async fn run_batch(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -306,8 +348,14 @@ pub async fn run_batch(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -344,6 +392,8 @@ pub async fn run_reorder(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -357,8 +407,14 @@ pub async fn run_reorder(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/actions/mod.rs
+++ b/src/commands/actions/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Action, ActionsApi};
 
@@ -55,26 +55,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Action)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for action in resp.actions {
-                    all_json.push(action_to_json(&action, include_profile, &profile));
-                    all_items.push((profile.clone(), action));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for action in resp.actions {
+            all_json.push(action_to_json(&action, include_profile, &profile));
+            all_items.push((profile.clone(), action));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -130,25 +117,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -188,31 +162,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(action) = resp.action {
-                    let name = action.display_name().to_string();
-                    let id = action.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created action '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(action_to_json(&action, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(action) = resp.action {
+            let name = action.display_name().to_string();
+            let id = action.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created action '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(action_to_json(&action, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -249,26 +209,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated action in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated action in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -295,22 +242,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Action {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Action {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -333,29 +269,16 @@ pub async fn run_batch(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                eprintln!(
-                    "{}",
-                    format!("Batch action executed in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        eprintln!(
+            "{}",
+            format!("Batch action executed in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -392,29 +315,16 @@ pub async fn run_reorder(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                eprintln!(
-                    "{}",
-                    format!("Actions reordered in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        eprintln!(
+            "{}",
+            format!("Actions reordered in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/actions/mod.rs
+++ b/src/commands/actions/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Action, ActionsApi};
 
@@ -57,7 +57,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Action)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for action in resp.actions {
             all_json.push(action_to_json(&action, include_profile, &profile));
             all_items.push((profile.clone(), action));
@@ -118,7 +118,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -163,7 +163,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(action) = resp.action {
             let name = action.display_name().to_string();
             let id = action.id.as_deref().unwrap_or("unknown");
@@ -210,7 +210,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated action in profile '{profile}'.").green()
@@ -242,7 +242,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Action {id} deleted in profile '{profile}'.").green()
@@ -270,7 +270,7 @@ pub async fn run_batch(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -316,7 +316,7 @@ pub async fn run_reorder(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/commands/ai_center/mod.rs
+++ b/src/commands/ai_center/mod.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::AiCenterApi;
 
@@ -115,7 +115,7 @@ fn collect_objects(
     include_profile: bool,
 ) -> Result<Vec<Value>> {
     let mut all: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -158,7 +158,7 @@ pub async fn run_applications_list(
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
-    for (profile, items) in collect_successes(per_profile)? {
+    for (profile, items) in report_errors_and_collect_successes(per_profile)? {
         for item in items {
             rows.push(vec![
                 profile.clone(),
@@ -246,7 +246,7 @@ pub async fn run_evaluations_list(
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
-    for (profile, items) in collect_successes(per_profile)? {
+    for (profile, items) in report_errors_and_collect_successes(per_profile)? {
         for item in items {
             rows.push(vec![
                 profile.clone(),
@@ -440,7 +440,7 @@ async fn run_custom_evaluations_table(
     let mut rows: Vec<Vec<String>> = Vec::new();
     // Items are raw API objects: the text table reads a few columns, but
     // JSON/agents output keeps the full policy (config, instructions, etc.).
-    for (profile, items) in collect_successes(per_profile)? {
+    for (profile, items) in report_errors_and_collect_successes(per_profile)? {
         for item in items {
             let app_count = item
                 .get("applicationIds")

--- a/src/commands/ai_center/mod.rs
+++ b/src/commands/ai_center/mod.rs
@@ -9,13 +9,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::AiCenterApi;
 
@@ -114,25 +114,12 @@ fn collect_objects(
     per_profile: Vec<(String, Result<Value>)>,
     include_profile: bool,
 ) -> Result<Vec<Value>> {
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all.push(val);
     }
     Ok(all)
 }
@@ -169,34 +156,19 @@ pub async fn run_applications_list(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(items) => {
-                for item in items {
-                    rows.push(vec![
-                        profile.clone(),
-                        col(&item, "id").to_string(),
-                        col(&item, "application").to_string(),
-                        col(&item, "subsystem").to_string(),
-                        render::bool_display(
-                            item.get("guardrailsIntegrated").and_then(Value::as_bool),
-                        ),
-                    ]);
-                    all_json.push(tag_item(item, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, items) in collect_successes(per_profile)? {
+        for item in items {
+            rows.push(vec![
+                profile.clone(),
+                col(&item, "id").to_string(),
+                col(&item, "application").to_string(),
+                col(&item, "subsystem").to_string(),
+                render::bool_display(item.get("guardrailsIntegrated").and_then(Value::as_bool)),
+            ]);
+            all_json.push(tag_item(item, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     emit_table(
@@ -272,38 +244,25 @@ pub async fn run_evaluations_list(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(items) => {
-                for item in items {
-                    rows.push(vec![
-                        profile.clone(),
-                        col(&item, "id").to_string(),
-                        col(&item, "application").to_string(),
-                        col(&item, "subsystem").to_string(),
-                        api::eval_config_type(&item),
-                        col(&item, "target").to_string(),
-                        render::bool_display(item.get("isEnabled").and_then(Value::as_bool)),
-                        item.get("threshold")
-                            .and_then(Value::as_f64)
-                            .map(|t| t.to_string())
-                            .unwrap_or_default(),
-                    ]);
-                    all_json.push(tag_item(item, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, items) in collect_successes(per_profile)? {
+        for item in items {
+            rows.push(vec![
+                profile.clone(),
+                col(&item, "id").to_string(),
+                col(&item, "application").to_string(),
+                col(&item, "subsystem").to_string(),
+                api::eval_config_type(&item),
+                col(&item, "target").to_string(),
+                render::bool_display(item.get("isEnabled").and_then(Value::as_bool)),
+                item.get("threshold")
+                    .and_then(Value::as_f64)
+                    .map(|t| t.to_string())
+                    .unwrap_or_default(),
+            ]);
+            all_json.push(tag_item(item, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     emit_table(
@@ -477,39 +436,26 @@ async fn run_custom_evaluations_table(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            // Items are raw API objects: the text table reads a few columns, but
-            // JSON/agents output keeps the full policy (config, instructions, etc.).
-            Ok(items) => {
-                for item in items {
-                    let app_count = item
-                        .get("applicationIds")
-                        .and_then(Value::as_array)
-                        .map(|a| a.len())
-                        .unwrap_or(0);
-                    rows.push(vec![
-                        profile.clone(),
-                        col(&item, "id").to_string(),
-                        col(&item, "name").to_string(),
-                        app_count.to_string(),
-                        col(&item, "description").chars().take(60).collect(),
-                    ]);
-                    all_json.push(tag_item(item, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    // Items are raw API objects: the text table reads a few columns, but
+    // JSON/agents output keeps the full policy (config, instructions, etc.).
+    for (profile, items) in collect_successes(per_profile)? {
+        for item in items {
+            let app_count = item
+                .get("applicationIds")
+                .and_then(Value::as_array)
+                .map(|a| a.len())
+                .unwrap_or(0);
+            rows.push(vec![
+                profile.clone(),
+                col(&item, "id").to_string(),
+                col(&item, "name").to_string(),
+                app_count.to_string(),
+                col(&item, "description").chars().take(60).collect(),
+            ]);
+            all_json.push(tag_item(item, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     emit_table(

--- a/src/commands/ai_center/mod.rs
+++ b/src/commands/ai_center/mod.rs
@@ -9,7 +9,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
@@ -110,7 +110,12 @@ fn tag_item(mut item: Value, include_profile: bool, profile: &str) -> Value {
 
 /// Collect per-profile `Value` results, printing per-profile errors to stderr and
 /// tagging each object with its profile in multi-profile mode.
-fn collect_objects(per_profile: Vec<(String, Result<Value>)>, include_profile: bool) -> Vec<Value> {
+fn collect_objects(
+    per_profile: Vec<(String, Result<Value>)>,
+    include_profile: bool,
+) -> Result<Vec<Value>> {
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -120,10 +125,16 @@ fn collect_objects(per_profile: Vec<(String, Result<Value>)>, include_profile: b
                 }
                 all.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
     }
-    all
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
+    }
+    Ok(all)
 }
 
 // ── Applications ────────────────────────────────────────────────────
@@ -158,6 +169,8 @@ pub async fn run_applications_list(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
     for (profile, result) in per_profile {
@@ -176,8 +189,14 @@ pub async fn run_applications_list(
                     all_json.push(tag_item(item, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     emit_table(
@@ -208,7 +227,7 @@ pub async fn run_applications_get(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     emit_objects(&all, include_profile, output, "AI application not found.")
 }
 
@@ -253,6 +272,8 @@ pub async fn run_evaluations_list(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
     for (profile, result) in per_profile {
@@ -275,8 +296,14 @@ pub async fn run_evaluations_list(
                     all_json.push(tag_item(item, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     emit_table(
@@ -315,7 +342,7 @@ pub async fn run_evaluations_get(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     emit_objects(&all, include_profile, output, "AI evaluation not found.")
 }
 
@@ -337,7 +364,7 @@ pub async fn run_evaluations_create(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Created AI evaluation.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }
@@ -363,7 +390,7 @@ pub async fn run_evaluations_update(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Updated AI evaluation.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }
@@ -386,7 +413,7 @@ pub async fn run_evaluations_delete(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Deleted AI evaluation.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }
@@ -403,7 +430,7 @@ pub async fn run_coverage(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     emit_objects(&all, include_profile, output, "No coverage data.")
 }
 
@@ -450,6 +477,8 @@ async fn run_custom_evaluations_table(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut rows: Vec<Vec<String>> = Vec::new();
     for (profile, result) in per_profile {
@@ -473,8 +502,14 @@ async fn run_custom_evaluations_table(
                     all_json.push(tag_item(item, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     emit_table(
@@ -505,7 +540,7 @@ pub async fn run_custom_evaluations_create(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Created custom evaluation.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }
@@ -531,7 +566,7 @@ pub async fn run_custom_evaluations_update(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Updated custom evaluation.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }
@@ -562,7 +597,7 @@ pub async fn run_add_policy(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Attached policy to application.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }
@@ -593,7 +628,7 @@ pub async fn run_remove_policy(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Detached policy from application.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }
@@ -613,7 +648,7 @@ pub async fn run_model_pricing_get(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     emit_objects(&all, include_profile, output, "No model pricing overrides.")
 }
 
@@ -635,7 +670,7 @@ pub async fn run_model_pricing_set(
     })
     .await;
 
-    let all = collect_objects(per_profile, include_profile);
+    let all = collect_objects(per_profile, include_profile)?;
     eprintln!("{}", "Set model pricing.".green());
     emit_objects(&all, include_profile, output, "No result.")
 }

--- a/src/commands/ai_center/mod.rs
+++ b/src/commands/ai_center/mod.rs
@@ -15,7 +15,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::AiCenterApi;
 

--- a/src/commands/alerts/mod.rs
+++ b/src/commands/alerts/mod.rs
@@ -9,7 +9,7 @@ pub mod api;
 
 use crate::config::OutputFormat;
 use crate::error::CxError;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{normalize_alert_payload, AlertDef, AlertsApi};
 
@@ -92,7 +92,7 @@ pub async fn run_list(
     // Merge & filter
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, AlertDef)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for alert in resp.alert_defs {
             if let Some(filter) = name_filter {
                 let name = alert.display_name().to_lowercase();
@@ -171,7 +171,7 @@ pub async fn run_get(
 
     // Merge - collect raw API responses
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -269,7 +269,7 @@ pub async fn run_create(
 
     // Merge
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(alert) = resp.alert_def {
             let name = alert.display_name();
             let id = alert.id.as_deref().unwrap_or("unknown");
@@ -318,7 +318,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Deleted alert {alert_id} in profile '{profile}'.").green()
@@ -372,7 +372,7 @@ pub async fn run_enable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Alert {alert_id} enabled in profile '{profile}'.").green()
@@ -399,7 +399,7 @@ pub async fn run_disable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Re
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Alert {alert_id} disabled in profile '{profile}'.").green()
@@ -480,7 +480,7 @@ pub async fn run_events(
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Value)> = Vec::new();
-    for (profile, events) in collect_successes(per_profile)? {
+    for (profile, events) in report_errors_and_collect_successes(per_profile)? {
         for event in events {
             all_json.push(event_to_json(&event, include_profile, &profile));
             all_items.push((profile.clone(), event));
@@ -541,7 +541,7 @@ pub async fn run_event_stats(targets: &[Arc<ExecutionTarget>], output: OutputFor
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for mut stat in resp.stats {
             if include_profile {
                 if let Value::Object(ref mut m) = stat {

--- a/src/commands/alerts/mod.rs
+++ b/src/commands/alerts/mod.rs
@@ -9,7 +9,7 @@ pub mod api;
 
 use crate::config::OutputFormat;
 use crate::error::CxError;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{normalize_alert_payload, AlertDef, AlertsApi};
 
@@ -272,10 +272,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(alert) = resp.alert_def {
             let name = alert.display_name();
-            let id = alert.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created alert '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "alert",
+                Some(&name),
+                alert.id.as_deref(),
+                &profile,
             );
             let json = alert_to_json(&alert, include_profile, &profile);
             all_results.push(json);

--- a/src/commands/alerts/mod.rs
+++ b/src/commands/alerts/mod.rs
@@ -9,7 +9,7 @@ pub mod api;
 
 use crate::config::OutputFormat;
 use crate::error::CxError;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{normalize_alert_payload, AlertDef, AlertsApi};
 
@@ -90,32 +90,19 @@ pub async fn run_list(
     .await;
 
     // Merge & filter
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, AlertDef)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for alert in resp.alert_defs {
-                    if let Some(filter) = name_filter {
-                        let name = alert.display_name().to_lowercase();
-                        if !name.contains(&filter.to_lowercase()) {
-                            continue;
-                        }
-                    }
-                    all_json.push(alert_to_json(&alert, include_profile, &profile));
-                    all_items.push((profile.clone(), alert));
+    for (profile, resp) in collect_successes(per_profile)? {
+        for alert in resp.alert_defs {
+            if let Some(filter) = name_filter {
+                let name = alert.display_name().to_lowercase();
+                if !name.contains(&filter.to_lowercase()) {
+                    continue;
                 }
             }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+            all_json.push(alert_to_json(&alert, include_profile, &profile));
+            all_items.push((profile.clone(), alert));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     // Render
@@ -183,25 +170,12 @@ pub async fn run_get(
     .await;
 
     // Merge - collect raw API responses
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     // Render
@@ -294,38 +268,23 @@ pub async fn run_create(
     .await;
 
     // Merge
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(alert) = resp.alert_def {
-                    let name = alert.display_name();
-                    let id = alert.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created alert '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    let json = alert_to_json(&alert, include_profile, &profile);
-                    all_results.push(json);
-                } else {
-                    eprintln!(
-                        "{}",
-                        format!("Alert created in profile '{profile}' but response was empty.")
-                            .yellow()
-                    );
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(alert) = resp.alert_def {
+            let name = alert.display_name();
+            let id = alert.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created alert '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            let json = alert_to_json(&alert, include_profile, &profile);
+            all_results.push(json);
+        } else {
+            eprintln!(
+                "{}",
+                format!("Alert created in profile '{profile}' but response was empty.").yellow()
+            );
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     // Render
@@ -359,22 +318,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Deleted alert {alert_id} in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Deleted alert {alert_id} in profile '{profile}'.").green()
+        );
     }
 
     Ok(())
@@ -424,22 +372,11 @@ pub async fn run_enable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Alert {alert_id} enabled in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Alert {alert_id} enabled in profile '{profile}'.").green()
+        );
     }
 
     Ok(())
@@ -462,22 +399,11 @@ pub async fn run_disable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Re
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Alert {alert_id} disabled in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Alert {alert_id} disabled in profile '{profile}'.").green()
+        );
     }
 
     Ok(())
@@ -552,26 +478,13 @@ pub async fn run_events(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Value)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(events) => {
-                for event in events {
-                    all_json.push(event_to_json(&event, include_profile, &profile));
-                    all_items.push((profile.clone(), event));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, events) in collect_successes(per_profile)? {
+        for event in events {
+            all_json.push(event_to_json(&event, include_profile, &profile));
+            all_items.push((profile.clone(), event));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -627,29 +540,16 @@ pub async fn run_event_stats(targets: &[Arc<ExecutionTarget>], output: OutputFor
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for mut stat in resp.stats {
-                    if include_profile {
-                        if let Value::Object(ref mut m) = stat {
-                            m.insert("profile".to_string(), Value::String(profile.clone()));
-                        }
-                    }
-                    all_json.push(stat);
+    for (profile, resp) in collect_successes(per_profile)? {
+        for mut stat in resp.stats {
+            if include_profile {
+                if let Value::Object(ref mut m) = stat {
+                    m.insert("profile".to_string(), Value::String(profile.clone()));
                 }
             }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+            all_json.push(stat);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/alerts/mod.rs
+++ b/src/commands/alerts/mod.rs
@@ -90,6 +90,8 @@ pub async fn run_list(
     .await;
 
     // Merge & filter
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, AlertDef)> = Vec::new();
     for (profile, result) in per_profile {
@@ -106,8 +108,14 @@ pub async fn run_list(
                     all_items.push((profile.clone(), alert));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     // Render
@@ -175,6 +183,8 @@ pub async fn run_get(
     .await;
 
     // Merge - collect raw API responses
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -184,8 +194,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     // Render
@@ -278,6 +294,8 @@ pub async fn run_create(
     .await;
 
     // Merge
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -300,8 +318,14 @@ pub async fn run_create(
                     );
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     // Render
@@ -335,14 +359,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Deleted alert {alert_id} in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())
@@ -392,14 +424,22 @@ pub async fn run_enable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Res
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Alert {alert_id} enabled in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())
@@ -422,14 +462,22 @@ pub async fn run_disable(targets: &[Arc<ExecutionTarget>], alert_id: &str) -> Re
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Alert {alert_id} disabled in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())
@@ -504,6 +552,8 @@ pub async fn run_events(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Value)> = Vec::new();
     for (profile, result) in per_profile {
@@ -514,8 +564,14 @@ pub async fn run_events(
                     all_items.push((profile.clone(), event));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -571,6 +627,8 @@ pub async fn run_event_stats(targets: &[Arc<ExecutionTarget>], output: OutputFor
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -584,8 +642,14 @@ pub async fn run_event_stats(targets: &[Arc<ExecutionTarget>], output: OutputFor
                     all_json.push(stat);
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/api_keys/mod.rs
+++ b/src/commands/api_keys/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -56,6 +56,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, KeyInfo)> = Vec::new();
     for (profile, result) in per_profile {
@@ -66,8 +68,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), key));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -129,6 +137,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -138,8 +148,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -178,6 +194,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -200,8 +218,14 @@ pub async fn run_create(
                 }
                 all_results.push(v);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -236,6 +260,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -246,8 +272,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -274,14 +306,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("API key {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -313,6 +353,8 @@ pub async fn run_send_data_keys(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -322,8 +364,14 @@ pub async fn run_send_data_keys(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -371,6 +419,8 @@ pub async fn run_admin_list(targets: &[Arc<ExecutionTarget>], output: OutputForm
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -380,8 +430,14 @@ pub async fn run_admin_list(targets: &[Arc<ExecutionTarget>], output: OutputForm
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -419,14 +475,22 @@ pub async fn run_admin_delete(targets: &[Arc<ExecutionTarget>], ids: &[String]) 
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Bulk deleted API keys in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -452,14 +516,22 @@ pub async fn run_admin_set_status(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Updated API key status in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/api_keys/mod.rs
+++ b/src/commands/api_keys/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{ApiKeysApi, KeyInfo};
 
@@ -170,11 +170,12 @@ pub async fn run_create(
 
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
-        let name = resp.name.as_deref().unwrap_or("unknown");
-        let id = resp.key_id.as_deref().unwrap_or("unknown");
-        eprintln!(
-            "{}",
-            format!("Created API key '{name}' (ID: {id}) in profile '{profile}'.").green()
+        render::print_created(
+            "Created",
+            "API key",
+            resp.name.as_deref(),
+            resp.key_id.as_deref(),
+            &profile,
         );
         let mut v = json!({
             "key_id": resp.key_id,

--- a/src/commands/api_keys/mod.rs
+++ b/src/commands/api_keys/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{ApiKeysApi, KeyInfo};
 
@@ -58,7 +58,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, KeyInfo)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for key in resp.keys {
             all_json.push(key_to_json(&key, include_profile, &profile));
             all_items.push((profile.clone(), key));
@@ -125,7 +125,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -169,7 +169,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         let name = resp.name.as_deref().unwrap_or("unknown");
         let id = resp.key_id.as_deref().unwrap_or("unknown");
         eprintln!(
@@ -222,7 +222,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated API key in profile '{profile}'.").green()
@@ -254,7 +254,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("API key {id} deleted in profile '{profile}'.").green()
@@ -291,7 +291,7 @@ pub async fn run_send_data_keys(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -344,7 +344,7 @@ pub async fn run_admin_list(targets: &[Arc<ExecutionTarget>], output: OutputForm
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -386,7 +386,7 @@ pub async fn run_admin_delete(targets: &[Arc<ExecutionTarget>], ids: &[String]) 
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Bulk deleted API keys in profile '{profile}'.").green()
@@ -416,7 +416,7 @@ pub async fn run_admin_set_status(
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated API key status in profile '{profile}'.").green()

--- a/src/commands/api_keys/mod.rs
+++ b/src/commands/api_keys/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{ApiKeysApi, KeyInfo};
 
@@ -56,26 +56,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, KeyInfo)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for key in resp.keys {
-                    all_json.push(key_to_json(&key, include_profile, &profile));
-                    all_items.push((profile.clone(), key));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for key in resp.keys {
+            all_json.push(key_to_json(&key, include_profile, &profile));
+            all_items.push((profile.clone(), key));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -137,25 +124,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -194,38 +168,25 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                let name = resp.name.as_deref().unwrap_or("unknown");
-                let id = resp.key_id.as_deref().unwrap_or("unknown");
-                eprintln!(
-                    "{}",
-                    format!("Created API key '{name}' (ID: {id}) in profile '{profile}'.").green()
-                );
-                let mut v = json!({
-                    "key_id": resp.key_id,
-                    "name": resp.name,
-                    "value": resp.value,
-                });
-                if targets.len() > 1 {
-                    if let Value::Object(ref mut m) = v {
-                        m.insert("profile".to_string(), Value::String(profile.to_string()));
-                    }
-                }
-                all_results.push(v);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+    for (profile, resp) in collect_successes(per_profile)? {
+        let name = resp.name.as_deref().unwrap_or("unknown");
+        let id = resp.key_id.as_deref().unwrap_or("unknown");
+        eprintln!(
+            "{}",
+            format!("Created API key '{name}' (ID: {id}) in profile '{profile}'.").green()
+        );
+        let mut v = json!({
+            "key_id": resp.key_id,
+            "name": resp.name,
+            "value": resp.value,
+        });
+        if targets.len() > 1 {
+            if let Value::Object(ref mut m) = v {
+                m.insert("profile".to_string(), Value::String(profile.to_string()));
             }
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(v);
     }
 
     match output {
@@ -260,26 +221,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated API key in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated API key in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -306,22 +254,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("API key {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("API key {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -353,25 +290,12 @@ pub async fn run_send_data_keys(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -419,25 +343,12 @@ pub async fn run_admin_list(targets: &[Arc<ExecutionTarget>], output: OutputForm
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -475,22 +386,11 @@ pub async fn run_admin_delete(targets: &[Arc<ExecutionTarget>], ids: &[String]) 
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Bulk deleted API keys in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Bulk deleted API keys in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -516,22 +416,11 @@ pub async fn run_admin_set_status(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Updated API key status in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated API key status in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/cases/mod.rs
+++ b/src/commands/cases/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Case, CasesApi, TeammateDirectory};
 
@@ -299,7 +299,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<(Value, TeammateDirectory)> = Vec::new();
-    for (profile, (mut val, directory)) in collect_successes(per_profile)? {
+    for (profile, (mut val, directory)) in report_errors_and_collect_successes(per_profile)? {
         if let Some(case) = val.get_mut("case") {
             substitute_assignee_email(case, &directory);
         }
@@ -716,7 +716,7 @@ pub async fn run_events_list(
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
-    for (profile, (resp, directory)) in collect_successes(per_profile)? {
+    for (profile, (resp, directory)) in report_errors_and_collect_successes(per_profile)? {
         for mut event in resp.events {
             substitute_user_emails(&mut event, &directory);
             if include_profile {
@@ -806,7 +806,7 @@ pub async fn run_event_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -860,7 +860,7 @@ pub async fn run_notifications(
     // Response shape: { "deliveriesByCase": { "<case-id>": { "notificationDeliveries": [ ... ] } } }
     // For text/json rendering, flatten into rows tagged with caseId so the output is tabular-friendly.
     let mut all_json: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         let map = val.get("deliveriesByCase").and_then(|v| v.as_object());
         if let Some(map) = map {
             for (case_id, payload) in map {
@@ -944,7 +944,7 @@ fn finish_lifecycle(
     success_label: &str,
 ) -> Result<()> {
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut v) in collect_successes(per_profile)? {
+    for (profile, mut v) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut v, &profile);
         }

--- a/src/commands/cases/mod.rs
+++ b/src/commands/cases/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Case, CasesApi, TeammateDirectory};
 
@@ -299,27 +299,14 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<(Value, TeammateDirectory)> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok((mut val, directory)) => {
-                if let Some(case) = val.get_mut("case") {
-                    substitute_assignee_email(case, &directory);
-                }
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push((val, directory));
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, (mut val, directory)) in collect_successes(per_profile)? {
+        if let Some(case) = val.get_mut("case") {
+            substitute_assignee_email(case, &directory);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
+        }
+        all_results.push((val, directory));
     }
 
     // Most renderers want only the JSON values; the directory we keep for the
@@ -729,29 +716,16 @@ pub async fn run_events_list(
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok((resp, directory)) => {
-                for mut event in resp.events {
-                    substitute_user_emails(&mut event, &directory);
-                    if include_profile {
-                        if let Value::Object(ref mut m) = event {
-                            m.insert("profile".to_string(), Value::String(profile.clone()));
-                        }
-                    }
-                    all_json.push(event);
+    for (profile, (resp, directory)) in collect_successes(per_profile)? {
+        for mut event in resp.events {
+            substitute_user_emails(&mut event, &directory);
+            if include_profile {
+                if let Value::Object(ref mut m) = event {
+                    m.insert("profile".to_string(), Value::String(profile.clone()));
                 }
             }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+            all_json.push(event);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -832,24 +806,11 @@ pub async fn run_event_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -899,39 +860,26 @@ pub async fn run_notifications(
     // Response shape: { "deliveriesByCase": { "<case-id>": { "notificationDeliveries": [ ... ] } } }
     // For text/json rendering, flatten into rows tagged with caseId so the output is tabular-friendly.
     let mut all_json: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                let map = val.get("deliveriesByCase").and_then(|v| v.as_object());
-                if let Some(map) = map {
-                    for (case_id, payload) in map {
-                        let deliveries = payload
-                            .get("notificationDeliveries")
-                            .and_then(|v| v.as_array())
-                            .cloned()
-                            .unwrap_or_default();
-                        for mut delivery in deliveries {
-                            if let Value::Object(ref mut m) = delivery {
-                                m.insert("caseId".to_string(), Value::String(case_id.clone()));
-                                if include_profile {
-                                    m.insert("profile".to_string(), Value::String(profile.clone()));
-                                }
-                            }
-                            all_json.push(delivery);
+    for (profile, val) in collect_successes(per_profile)? {
+        let map = val.get("deliveriesByCase").and_then(|v| v.as_object());
+        if let Some(map) = map {
+            for (case_id, payload) in map {
+                let deliveries = payload
+                    .get("notificationDeliveries")
+                    .and_then(|v| v.as_array())
+                    .cloned()
+                    .unwrap_or_default();
+                for mut delivery in deliveries {
+                    if let Value::Object(ref mut m) = delivery {
+                        m.insert("caseId".to_string(), Value::String(case_id.clone()));
+                        if include_profile {
+                            m.insert("profile".to_string(), Value::String(profile.clone()));
                         }
                     }
+                    all_json.push(delivery);
                 }
             }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -996,28 +944,15 @@ fn finish_lifecycle(
     success_label: &str,
 ) -> Result<()> {
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut v) => {
-                if include_profile {
-                    render::tag_get_result(&mut v, &profile);
-                }
-                all_results.push(v);
-                eprintln!(
-                    "{}",
-                    format!("{success_label} in profile '{profile}'.").green()
-                );
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut v) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut v, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(v);
+        eprintln!(
+            "{}",
+            format!("{success_label} in profile '{profile}'.").green()
+        );
     }
 
     match output {

--- a/src/commands/cases/mod.rs
+++ b/src/commands/cases/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
@@ -299,6 +299,8 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<(Value, TeammateDirectory)> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok((mut val, directory)) => {
@@ -310,8 +312,14 @@ pub async fn run_get(
                 }
                 all_results.push((val, directory));
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     // Most renderers want only the JSON values; the directory we keep for the
@@ -721,6 +729,8 @@ pub async fn run_events_list(
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok((resp, directory)) => {
@@ -734,8 +744,14 @@ pub async fn run_events_list(
                     all_json.push(event);
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -816,6 +832,8 @@ pub async fn run_event_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -824,8 +842,14 @@ pub async fn run_event_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -875,6 +899,8 @@ pub async fn run_notifications(
     // Response shape: { "deliveriesByCase": { "<case-id>": { "notificationDeliveries": [ ... ] } } }
     // For text/json rendering, flatten into rows tagged with caseId so the output is tabular-friendly.
     let mut all_json: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -898,8 +924,14 @@ pub async fn run_notifications(
                     }
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -964,6 +996,8 @@ fn finish_lifecycle(
     success_label: &str,
 ) -> Result<()> {
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut v) => {
@@ -976,8 +1010,14 @@ fn finish_lifecycle(
                     format!("{success_label} in profile '{profile}'.").green()
                 );
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/cases/mod.rs
+++ b/src/commands/cases/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Case, CasesApi, TeammateDirectory};
 

--- a/src/commands/connectors/mod.rs
+++ b/src/commands/connectors/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -55,6 +55,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Connector)> = Vec::new();
     for (profile, result) in per_profile {
@@ -65,8 +67,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), conn));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -122,6 +130,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -131,8 +141,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -172,6 +188,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -187,8 +205,14 @@ pub async fn run_create(
                     all_results.push(connector_to_json(&conn, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -220,6 +244,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -230,8 +256,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -258,14 +290,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Connector {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -280,6 +320,8 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -289,8 +331,14 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -322,6 +370,8 @@ pub async fn run_entity_types(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -331,8 +381,14 @@ pub async fn run_entity_types(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -375,6 +431,8 @@ pub async fn run_entity_subtypes(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -384,8 +442,14 @@ pub async fn run_entity_subtypes(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/connectors/mod.rs
+++ b/src/commands/connectors/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Connector, ConnectorsApi};
 
@@ -57,7 +57,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Connector)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for conn in resp.connectors {
             all_json.push(connector_to_json(&conn, include_profile, &profile));
             all_items.push((profile.clone(), conn));
@@ -118,7 +118,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -163,7 +163,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(conn) = resp.connector {
             let name = conn.display_name().to_string();
             let id = conn.id.as_deref().unwrap_or("unknown");
@@ -205,7 +205,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated connector in profile '{profile}'.").green()
@@ -237,7 +237,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Connector {id} deleted in profile '{profile}'.").green()
@@ -257,7 +257,7 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -294,7 +294,7 @@ pub async fn run_entity_types(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -342,7 +342,7 @@ pub async fn run_entity_subtypes(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/commands/connectors/mod.rs
+++ b/src/commands/connectors/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Connector, ConnectorsApi};
 
@@ -166,10 +166,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(conn) = resp.connector {
             let name = conn.display_name().to_string();
-            let id = conn.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created connector '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "connector",
+                Some(&name),
+                conn.id.as_deref(),
+                &profile,
             );
             all_results.push(connector_to_json(&conn, include_profile, &profile));
         }

--- a/src/commands/connectors/mod.rs
+++ b/src/commands/connectors/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Connector, ConnectorsApi};
 
@@ -55,26 +55,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Connector)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for conn in resp.connectors {
-                    all_json.push(connector_to_json(&conn, include_profile, &profile));
-                    all_items.push((profile.clone(), conn));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for conn in resp.connectors {
+            all_json.push(connector_to_json(&conn, include_profile, &profile));
+            all_items.push((profile.clone(), conn));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -130,25 +117,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -188,31 +162,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(conn) = resp.connector {
-                    let name = conn.display_name().to_string();
-                    let id = conn.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created connector '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(connector_to_json(&conn, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(conn) = resp.connector {
+            let name = conn.display_name().to_string();
+            let id = conn.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created connector '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(connector_to_json(&conn, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -244,26 +204,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated connector in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated connector in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -290,22 +237,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Connector {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Connector {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -320,25 +256,12 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -370,25 +293,12 @@ pub async fn run_entity_types(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -431,25 +341,12 @@ pub async fn run_entity_subtypes(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/contextual_data/mod.rs
+++ b/src/commands/contextual_data/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{ContextualDataApi, ContextualDataIntegration};
 
@@ -58,27 +58,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, ContextualDataIntegration)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for wrapper in resp.integrations {
-                    let item: ContextualDataIntegration = wrapper.into();
-                    all_json.push(item_to_json(&item, include_profile, &profile));
-                    all_items.push((profile.clone(), item));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for wrapper in resp.integrations {
+            let item: ContextualDataIntegration = wrapper.into();
+            all_json.push(item_to_json(&item, include_profile, &profile));
+            all_items.push((profile.clone(), item));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -143,36 +130,23 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                // Normalize: API returns {integrationDetail: {integration: {...}, ...}}
-                // Extract the inner integration and flatten to match list output.
-                if let Some(detail) = val.get("integrationDetail") {
-                    if let Some(inner) = detail.get("integration") {
-                        val = json!({
-                            "id": inner.get("id"),
-                            "name": inner.get("name"),
-                            "description": inner.get("description"),
-                        });
-                    }
-                }
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+    for (profile, mut val) in collect_successes(per_profile)? {
+        // Normalize: API returns {integrationDetail: {integration: {...}, ...}}
+        // Extract the inner integration and flatten to match list output.
+        if let Some(detail) = val.get("integrationDetail") {
+            if let Some(inner) = detail.get("integration") {
+                val = json!({
+                    "id": inner.get("id"),
+                    "name": inner.get("name"),
+                    "description": inner.get("description"),
+                });
             }
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
+        }
+        all_results.push(val);
     }
 
     match output {
@@ -212,36 +186,21 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                let id = resp.integration_id.as_deref().unwrap_or("unknown");
-                eprintln!(
-                    "{}",
-                    format!(
-                        "Created contextual data integration (ID: {id}) in profile '{profile}'."
-                    )
-                    .green()
-                );
-                let mut v = json!({ "id": resp.integration_id });
-                if include_profile {
-                    if let Value::Object(ref mut m) = v {
-                        m.insert("profile".to_string(), Value::String(profile.to_string()));
-                    }
-                }
-                all_results.push(v);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+    for (profile, resp) in collect_successes(per_profile)? {
+        let id = resp.integration_id.as_deref().unwrap_or("unknown");
+        eprintln!(
+            "{}",
+            format!("Created contextual data integration (ID: {id}) in profile '{profile}'.")
+                .green()
+        );
+        let mut v = json!({ "id": resp.integration_id });
+        if include_profile {
+            if let Value::Object(ref mut m) = v {
+                m.insert("profile".to_string(), Value::String(profile.to_string()));
             }
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(v);
     }
 
     match output {
@@ -279,27 +238,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated contextual data integration {id} in profile '{profile}'.")
-                        .green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated contextual data integration {id} in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -329,22 +274,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Contextual data integration {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Contextual data integration {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -370,25 +304,12 @@ pub async fn run_definition(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -430,26 +351,13 @@ pub async fn run_test(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Test completed in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Test completed in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/contextual_data/mod.rs
+++ b/src/commands/contextual_data/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{ContextualDataApi, ContextualDataIntegration};
 
@@ -60,7 +60,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, ContextualDataIntegration)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for wrapper in resp.integrations {
             let item: ContextualDataIntegration = wrapper.into();
             all_json.push(item_to_json(&item, include_profile, &profile));
@@ -131,7 +131,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         // Normalize: API returns {integrationDetail: {integration: {...}, ...}}
         // Extract the inner integration and flatten to match list output.
         if let Some(detail) = val.get("integrationDetail") {
@@ -187,7 +187,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         let id = resp.integration_id.as_deref().unwrap_or("unknown");
         eprintln!(
             "{}",
@@ -239,7 +239,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated contextual data integration {id} in profile '{profile}'.").green()
@@ -274,7 +274,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Contextual data integration {id} deleted in profile '{profile}'.").green()
@@ -305,7 +305,7 @@ pub async fn run_definition(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -352,7 +352,7 @@ pub async fn run_test(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Test completed in profile '{profile}'.").green()

--- a/src/commands/contextual_data/mod.rs
+++ b/src/commands/contextual_data/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -58,6 +58,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, ContextualDataIntegration)> = Vec::new();
     for (profile, result) in per_profile {
@@ -69,8 +71,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), item));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -135,6 +143,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -155,8 +165,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -196,6 +212,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -216,8 +234,14 @@ pub async fn run_create(
                 }
                 all_results.push(v);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -255,6 +279,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -266,8 +292,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -297,14 +329,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Contextual data integration {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -330,6 +370,8 @@ pub async fn run_definition(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -339,8 +381,14 @@ pub async fn run_definition(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -382,6 +430,8 @@ pub async fn run_test(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -392,8 +442,14 @@ pub async fn run_test(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/contextual_data/mod.rs
+++ b/src/commands/contextual_data/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{ContextualDataApi, ContextualDataIntegration};
 
@@ -134,14 +134,15 @@ pub async fn run_get(
     for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         // Normalize: API returns {integrationDetail: {integration: {...}, ...}}
         // Extract the inner integration and flatten to match list output.
-        if let Some(detail) = val.get("integrationDetail") {
-            if let Some(inner) = detail.get("integration") {
-                val = json!({
-                    "id": inner.get("id"),
-                    "name": inner.get("name"),
-                    "description": inner.get("description"),
-                });
-            }
+        if let Some(inner) = val
+            .get("integrationDetail")
+            .and_then(|d| d.get("integration"))
+        {
+            val = json!({
+                "id": inner.get("id"),
+                "name": inner.get("name"),
+                "description": inner.get("description"),
+            });
         }
         if include_profile {
             render::tag_get_result(&mut val, &profile);
@@ -188,11 +189,12 @@ pub async fn run_create(
 
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
-        let id = resp.integration_id.as_deref().unwrap_or("unknown");
-        eprintln!(
-            "{}",
-            format!("Created contextual data integration (ID: {id}) in profile '{profile}'.")
-                .green()
+        render::print_created(
+            "Created",
+            "contextual data integration",
+            None,
+            resp.integration_id.as_deref(),
+            &profile,
         );
         let mut v = json!({ "id": resp.integration_id });
         if include_profile {

--- a/src/commands/custom_enrichments/mod.rs
+++ b/src/commands/custom_enrichments/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{CustomEnrichment, CustomEnrichmentsApi};
 
@@ -108,7 +108,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     .await;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, CustomEnrichment)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for ce in resp.custom_enrichments {
             all_json.push(ce_to_json(&ce, include_profile, &profile));
             all_items.push((profile.clone(), ce));
@@ -166,7 +166,7 @@ pub async fn run_get(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -209,7 +209,7 @@ pub async fn run_create(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(ce) = resp.custom_enrichment {
             eprintln!(
                 "{}",
@@ -251,7 +251,7 @@ pub async fn run_update(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated custom enrichment in profile '{profile}'.").green()
@@ -282,7 +282,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Custom enrichment {id} deleted in profile '{profile}'.").green()
@@ -313,7 +313,7 @@ pub async fn run_search(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
     match output {

--- a/src/commands/custom_enrichments/mod.rs
+++ b/src/commands/custom_enrichments/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -106,6 +106,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
         Ok(api.list().await?)
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, CustomEnrichment)> = Vec::new();
     for (profile, result) in per_profile {
@@ -116,8 +118,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), ce));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -170,6 +178,8 @@ pub async fn run_get(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -179,8 +189,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -218,6 +234,8 @@ pub async fn run_create(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -234,8 +252,14 @@ pub async fn run_create(
                     all_results.push(ce_to_json(&ce, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -265,6 +289,8 @@ pub async fn run_update(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -275,8 +301,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -302,14 +334,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Custom enrichment {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -335,12 +375,20 @@ pub async fn run_search(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,

--- a/src/commands/custom_enrichments/mod.rs
+++ b/src/commands/custom_enrichments/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{CustomEnrichment, CustomEnrichmentsApi};
 

--- a/src/commands/custom_enrichments/mod.rs
+++ b/src/commands/custom_enrichments/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{CustomEnrichment, CustomEnrichmentsApi};
 
@@ -106,26 +106,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
         Ok(api.list().await?)
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, CustomEnrichment)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for ce in resp.custom_enrichments {
-                    all_json.push(ce_to_json(&ce, include_profile, &profile));
-                    all_items.push((profile.clone(), ce));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for ce in resp.custom_enrichments {
+            all_json.push(ce_to_json(&ce, include_profile, &profile));
+            all_items.push((profile.clone(), ce));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -178,25 +165,12 @@ pub async fn run_get(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -234,32 +208,19 @@ pub async fn run_create(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(ce) = resp.custom_enrichment {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Created custom enrichment '{}' in profile '{profile}'.",
-                            ce.display_name()
-                        )
-                        .green()
-                    );
-                    all_results.push(ce_to_json(&ce, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(ce) = resp.custom_enrichment {
+            eprintln!(
+                "{}",
+                format!(
+                    "Created custom enrichment '{}' in profile '{profile}'.",
+                    ce.display_name()
+                )
+                .green()
+            );
+            all_results.push(ce_to_json(&ce, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -289,26 +250,13 @@ pub async fn run_update(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated custom enrichment in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated custom enrichment in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -334,22 +282,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Custom enrichment {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Custom enrichment {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -375,20 +312,9 @@ pub async fn run_search(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -11,7 +11,7 @@ use toon_format::encode_default as toon_encode;
 pub mod api;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{
     DashboardFolderItem, DashboardSearchResult, DashboardsApi, IssueSeverity, QueryByFieldResult,
@@ -126,7 +126,7 @@ async fn collect_semantic_search_results(
     .await;
 
     let mut all_results: Vec<(String, DashboardSearchResult)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for r in resp.results {
             all_results.push((profile.clone(), r));
         }
@@ -195,7 +195,7 @@ async fn collect_query_search_results(
     .await;
 
     let mut all_results: Vec<(String, QuerySearchResult)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for r in resp.results {
             all_results.push((profile.clone(), r));
         }
@@ -254,7 +254,7 @@ async fn collect_queries_by_field_results(
     .await;
 
     let mut all_results: Vec<(String, QueryByFieldResult)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for r in resp.queries {
             all_results.push((profile.clone(), r));
         }
@@ -351,7 +351,7 @@ pub async fn run_catalog(targets: &[Arc<ExecutionTarget>], output: OutputFormat)
 
     let mut all_rows: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, api::DashboardCatalogItem)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for item in resp.items {
             all_rows.push(catalog_item_to_json(&item, include_profile, &profile));
             all_items.push((profile.clone(), item));
@@ -490,7 +490,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -633,7 +633,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<(String, String, Value)> = Vec::new();
-    for (profile, mut resp) in collect_successes(per_profile)? {
+    for (profile, mut resp) in report_errors_and_collect_successes(per_profile)? {
         let created_id = resp
             .get("dashboardId")
             .and_then(|v| v.as_str())
@@ -851,7 +851,7 @@ pub async fn run_folders_list(
 
     let mut all_rows: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, DashboardFolderItem)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for item in resp.folders {
             all_rows.push(folder_item_to_json(&item, include_profile, &profile));
             all_items.push((profile.clone(), item));
@@ -925,7 +925,7 @@ pub async fn run_folders_create(
     .await;
 
     let mut all_results: Vec<(String, String, Value)> = Vec::new();
-    for (profile, mut resp) in collect_successes(per_profile)? {
+    for (profile, mut resp) in report_errors_and_collect_successes(per_profile)? {
         let created_id = resp
             .get("folderId")
             .and_then(|v| v.as_str())
@@ -1093,7 +1093,7 @@ pub async fn run_check(
     .await;
 
     let mut all_issues: Vec<(String, Vec<api::DashboardCheckIssue>)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         all_issues.push((profile, resp.issues));
     }
 

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -11,7 +11,7 @@ use toon_format::encode_default as toon_encode;
 pub mod api;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{
     DashboardFolderItem, DashboardSearchResult, DashboardsApi, IssueSeverity, QueryByFieldResult,
@@ -24,6 +24,30 @@ use crate::safety::confirm_destructive;
 
 /// JSON key for the source profile when merging multi-profile dashboard REST rows.
 const JSON_KEY_PROFILE: &str = "profile";
+
+/// Look up a string value at a JSON pointer path (e.g. `/dashboard/id`).
+fn json_str_at(v: &Value, pointer: &str) -> Option<String> {
+    v.pointer(pointer)
+        .and_then(|v| v.as_str())
+        .map(String::from)
+}
+
+/// Extract a dashboard ID from a create/replace response, trying the shapes
+/// the API has been observed to return: a top-level `dashboardId`, a
+/// top-level `id`, or a nested `dashboard.id`.
+fn dashboard_id_from_response(resp: &Value) -> String {
+    json_str_at(resp, "/dashboardId")
+        .or_else(|| json_str_at(resp, "/id"))
+        .or_else(|| json_str_at(resp, "/dashboard/id"))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Extract a folder ID from a folder-create response, trying `folderId` then `id`.
+fn folder_id_from_response(resp: &Value) -> String {
+    json_str_at(resp, "/folderId")
+        .or_else(|| json_str_at(resp, "/id"))
+        .unwrap_or_else(|| "unknown".to_string())
+}
 
 /// Builds one catalog row as JSON for `json` / `agents` output after fan-out.
 ///
@@ -634,22 +658,7 @@ pub async fn run_create(
 
     let mut all_results: Vec<(String, String, Value)> = Vec::new();
     for (profile, mut resp) in report_errors_and_collect_successes(per_profile)? {
-        let created_id = resp
-            .get("dashboardId")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .or_else(|| {
-                resp.get("id")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-            })
-            .or_else(|| {
-                resp.get("dashboard")
-                    .and_then(|d| d.get("id"))
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-            })
-            .unwrap_or_else(|| "unknown".to_string());
+        let created_id = dashboard_id_from_response(&resp);
 
         if include_profile {
             render::tag_get_result(&mut resp, &profile);
@@ -745,22 +754,7 @@ pub async fn run_replace(
     for (profile, result) in per_profile {
         match result {
             Ok(mut resp) => {
-                let replaced_id = resp
-                    .get("dashboardId")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-                    .or_else(|| {
-                        resp.get("id")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .or_else(|| {
-                        resp.get("dashboard")
-                            .and_then(|d| d.get("id"))
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .unwrap_or_else(|| "unknown".to_string());
+                let replaced_id = dashboard_id_from_response(&resp);
 
                 if include_profile {
                     render::tag_get_result(&mut resp, &profile);
@@ -926,16 +920,7 @@ pub async fn run_folders_create(
 
     let mut all_results: Vec<(String, String, Value)> = Vec::new();
     for (profile, mut resp) in report_errors_and_collect_successes(per_profile)? {
-        let created_id = resp
-            .get("folderId")
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string())
-            .or_else(|| {
-                resp.get("id")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s.to_string())
-            })
-            .unwrap_or_else(|| "unknown".to_string());
+        let created_id = folder_id_from_response(&resp);
         if include_profile {
             render::tag_get_result(&mut resp, &profile);
         }

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -11,7 +11,7 @@ use toon_format::encode_default as toon_encode;
 pub mod api;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{
     DashboardFolderItem, DashboardSearchResult, DashboardsApi, IssueSeverity, QueryByFieldResult,
@@ -125,24 +125,11 @@ async fn collect_semantic_search_results(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<(String, DashboardSearchResult)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for r in resp.results {
-                    all_results.push((profile.clone(), r));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for r in resp.results {
+            all_results.push((profile.clone(), r));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     Ok(all_results)
 }
@@ -207,24 +194,11 @@ async fn collect_query_search_results(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<(String, QuerySearchResult)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for r in resp.results {
-                    all_results.push((profile.clone(), r));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for r in resp.results {
+            all_results.push((profile.clone(), r));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     Ok(all_results)
 }
@@ -279,24 +253,11 @@ async fn collect_queries_by_field_results(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<(String, QueryByFieldResult)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for r in resp.queries {
-                    all_results.push((profile.clone(), r));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for r in resp.queries {
+            all_results.push((profile.clone(), r));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     Ok(all_results)
 }
@@ -388,26 +349,13 @@ pub async fn run_catalog(targets: &[Arc<ExecutionTarget>], output: OutputFormat)
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_rows: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, api::DashboardCatalogItem)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for item in resp.items {
-                    all_rows.push(catalog_item_to_json(&item, include_profile, &profile));
-                    all_items.push((profile.clone(), item));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for item in resp.items {
+            all_rows.push(catalog_item_to_json(&item, include_profile, &profile));
+            all_items.push((profile.clone(), item));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -541,25 +489,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -697,42 +632,29 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<(String, String, Value)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut resp) => {
-                let created_id = resp
-                    .get("dashboardId")
+    for (profile, mut resp) in collect_successes(per_profile)? {
+        let created_id = resp
+            .get("dashboardId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                resp.get("id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
-                    .or_else(|| {
-                        resp.get("id")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .or_else(|| {
-                        resp.get("dashboard")
-                            .and_then(|d| d.get("id"))
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .unwrap_or_else(|| "unknown".to_string());
+            })
+            .or_else(|| {
+                resp.get("dashboard")
+                    .and_then(|d| d.get("id"))
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+            })
+            .unwrap_or_else(|| "unknown".to_string());
 
-                if include_profile {
-                    render::tag_get_result(&mut resp, &profile);
-                }
-                all_results.push((profile, created_id, resp));
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+        if include_profile {
+            render::tag_get_result(&mut resp, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push((profile, created_id, resp));
     }
 
     match output {
@@ -927,26 +849,13 @@ pub async fn run_folders_list(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_rows: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, DashboardFolderItem)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for item in resp.folders {
-                    all_rows.push(folder_item_to_json(&item, include_profile, &profile));
-                    all_items.push((profile.clone(), item));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for item in resp.folders {
+            all_rows.push(folder_item_to_json(&item, include_profile, &profile));
+            all_items.push((profile.clone(), item));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -1015,35 +924,22 @@ pub async fn run_folders_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<(String, String, Value)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut resp) => {
-                let created_id = resp
-                    .get("folderId")
+    for (profile, mut resp) in collect_successes(per_profile)? {
+        let created_id = resp
+            .get("folderId")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .or_else(|| {
+                resp.get("id")
                     .and_then(|v| v.as_str())
                     .map(|s| s.to_string())
-                    .or_else(|| {
-                        resp.get("id")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string())
-                    })
-                    .unwrap_or_else(|| "unknown".to_string());
-                if include_profile {
-                    render::tag_get_result(&mut resp, &profile);
-                }
-                all_results.push((profile, created_id, resp));
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+            })
+            .unwrap_or_else(|| "unknown".to_string());
+        if include_profile {
+            render::tag_get_result(&mut resp, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push((profile, created_id, resp));
     }
 
     match output {
@@ -1196,20 +1092,9 @@ pub async fn run_check(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_issues: Vec<(String, Vec<api::DashboardCheckIssue>)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => all_issues.push((profile, resp.issues)),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, resp) in collect_successes(per_profile)? {
+        all_issues.push((profile, resp.issues));
     }
 
     // CI-gate semantics: any error-severity issue (in any profile) fails.

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -34,19 +34,18 @@ fn json_str_at(v: &Value, pointer: &str) -> Option<String> {
 
 /// Extract a dashboard ID from a create/replace response, trying the shapes
 /// the API has been observed to return: a top-level `dashboardId`, a
-/// top-level `id`, or a nested `dashboard.id`.
-fn dashboard_id_from_response(resp: &Value) -> String {
+/// top-level `id`, or a nested `dashboard.id`. Returns `None` when the
+/// response carried no ID so callers can flag that rather than fabricate one.
+fn dashboard_id_from_response(resp: &Value) -> Option<String> {
     json_str_at(resp, "/dashboardId")
         .or_else(|| json_str_at(resp, "/id"))
         .or_else(|| json_str_at(resp, "/dashboard/id"))
-        .unwrap_or_else(|| "unknown".to_string())
 }
 
-/// Extract a folder ID from a folder-create response, trying `folderId` then `id`.
-fn folder_id_from_response(resp: &Value) -> String {
-    json_str_at(resp, "/folderId")
-        .or_else(|| json_str_at(resp, "/id"))
-        .unwrap_or_else(|| "unknown".to_string())
+/// Extract a folder ID from a folder-create response, trying `folderId` then
+/// `id`. Returns `None` when the response carried no ID.
+fn folder_id_from_response(resp: &Value) -> Option<String> {
+    json_str_at(resp, "/folderId").or_else(|| json_str_at(resp, "/id"))
 }
 
 /// Builds one catalog row as JSON for `json` / `agents` output after fan-out.
@@ -656,44 +655,31 @@ pub async fn run_create(
     })
     .await;
 
-    let mut all_results: Vec<(String, String, Value)> = Vec::new();
+    let mut all_results: Vec<Value> = Vec::new();
     for (profile, mut resp) in report_errors_and_collect_successes(per_profile)? {
         let created_id = dashboard_id_from_response(&resp);
-
+        render::print_created(
+            "Created",
+            "dashboard",
+            Some(&name),
+            created_id.as_deref(),
+            &profile,
+        );
         if include_profile {
             render::tag_get_result(&mut resp, &profile);
         }
-        all_results.push((profile, created_id, resp));
+        all_results.push(resp);
     }
 
     match output {
-        OutputFormat::Json => {
-            let vals: Vec<Value> = all_results.iter().map(|(_, _, v)| v.clone()).collect();
-            render::render_json_auto(&vals)?;
-        }
+        OutputFormat::Json => render::render_json_auto(&all_results)?,
         OutputFormat::Agents => {
-            let vals: Vec<&Value> = all_results.iter().map(|(_, _, v)| v).collect();
-            let toon =
-                toon_encode(&vals).map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
+            let toon = toon_encode(&all_results)
+                .map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
             println!("{toon}");
         }
-        OutputFormat::Text => {
-            if include_profile {
-                let rows: Vec<Vec<String>> = all_results
-                    .iter()
-                    .map(|(profile, id, _)| vec![profile.clone(), id.clone(), name.clone()])
-                    .collect();
-                render::render_table(&["ID", "Name"], rows, true);
-            } else {
-                let (_, id, _) = &all_results[0];
-                println!(
-                    "{}",
-                    format!("Created dashboard '{name}' (ID: {id})")
-                        .green()
-                        .bold()
-                );
-            }
-        }
+        // Status lines already printed to stderr via `print_created`.
+        OutputFormat::Text => {}
     }
 
     Ok(())
@@ -750,52 +736,31 @@ pub async fn run_replace(
     })
     .await;
 
-    let mut all_results: Vec<(String, String, Value)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut resp) => {
-                let replaced_id = dashboard_id_from_response(&resp);
-
-                if include_profile {
-                    render::tag_get_result(&mut resp, &profile);
-                }
-                all_results.push((profile, replaced_id, resp));
-            }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+    let mut all_results: Vec<Value> = Vec::new();
+    for (profile, mut resp) in report_errors_and_collect_successes(per_profile)? {
+        let replaced_id = dashboard_id_from_response(&resp);
+        render::print_created(
+            "Replaced",
+            "dashboard",
+            Some(&name),
+            replaced_id.as_deref(),
+            &profile,
+        );
+        if include_profile {
+            render::tag_get_result(&mut resp, &profile);
         }
+        all_results.push(resp);
     }
 
     match output {
-        OutputFormat::Json => {
-            let vals: Vec<Value> = all_results.iter().map(|(_, _, v)| v.clone()).collect();
-            render::render_json_auto(&vals)?;
-        }
+        OutputFormat::Json => render::render_json_auto(&all_results)?,
         OutputFormat::Agents => {
-            let vals: Vec<&Value> = all_results.iter().map(|(_, _, v)| v).collect();
-            let toon =
-                toon_encode(&vals).map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
+            let toon = toon_encode(&all_results)
+                .map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
             println!("{toon}");
         }
-        OutputFormat::Text => {
-            if all_results.is_empty() {
-                return Ok(());
-            }
-            if include_profile {
-                let rows: Vec<Vec<String>> = all_results
-                    .iter()
-                    .map(|(profile, id, _)| vec![profile.clone(), id.clone(), name.clone()])
-                    .collect();
-                render::render_table(&["ID", "Name"], rows, true);
-            } else {
-                let (_, id, _) = &all_results[0];
-                println!(
-                    "{}",
-                    format!("Replaced dashboard '{name}' (ID: {id})")
-                        .green()
-                        .bold()
-                );
-            }
-        }
+        // Status lines already printed to stderr via `print_created`.
+        OutputFormat::Text => {}
     }
 
     Ok(())
@@ -815,14 +780,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Dashboard {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
-        }
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Dashboard {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -918,41 +880,31 @@ pub async fn run_folders_create(
     })
     .await;
 
-    let mut all_results: Vec<(String, String, Value)> = Vec::new();
+    let mut all_results: Vec<Value> = Vec::new();
     for (profile, mut resp) in report_errors_and_collect_successes(per_profile)? {
         let created_id = folder_id_from_response(&resp);
+        render::print_created(
+            "Created",
+            "dashboard folder",
+            Some(name),
+            created_id.as_deref(),
+            &profile,
+        );
         if include_profile {
             render::tag_get_result(&mut resp, &profile);
         }
-        all_results.push((profile, created_id, resp));
+        all_results.push(resp);
     }
 
     match output {
-        OutputFormat::Json => {
-            let vals: Vec<Value> = all_results.iter().map(|(_, _, v)| v.clone()).collect();
-            render::render_json_auto(&vals)?;
-        }
+        OutputFormat::Json => render::render_json_auto(&all_results)?,
         OutputFormat::Agents => {
-            let vals: Vec<&Value> = all_results.iter().map(|(_, _, v)| v).collect();
-            let toon =
-                toon_encode(&vals).map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
+            let toon = toon_encode(&all_results)
+                .map_err(|e| anyhow::anyhow!("TOON encoding failed: {e}"))?;
             println!("{toon}");
         }
-        OutputFormat::Text => {
-            if include_profile {
-                let rows: Vec<Vec<String>> = all_results
-                    .iter()
-                    .map(|(profile, id, _)| vec![profile.clone(), id.clone(), name.to_string()])
-                    .collect();
-                render::render_table(&["ID", "Name"], rows, true);
-            } else {
-                let (_, id, _) = &all_results[0];
-                println!(
-                    "{}",
-                    format!("Created folder '{name}' (ID: {id})").green().bold()
-                );
-            }
-        }
+        // Status lines already printed to stderr via `print_created`.
+        OutputFormat::Text => {}
     }
 
     Ok(())
@@ -970,14 +922,11 @@ pub async fn run_folders_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> R
         }
     })
     .await;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Folder {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
-        }
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Folder {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/data_archive/mod.rs
+++ b/src/commands/data_archive/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::DataArchiveApi;
 
@@ -38,25 +38,12 @@ pub async fn run_metrics_get(targets: &[Arc<ExecutionTarget>], output: OutputFor
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -95,26 +82,13 @@ pub async fn run_metrics_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Created metrics archive config in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Created metrics archive config in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -146,26 +120,13 @@ pub async fn run_metrics_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated metrics archive config in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated metrics archive config in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -190,22 +151,11 @@ pub async fn run_metrics_enable(targets: &[Arc<ExecutionTarget>]) -> Result<()> 
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Metrics archive enabled in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Metrics archive enabled in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -220,22 +170,11 @@ pub async fn run_metrics_disable(targets: &[Arc<ExecutionTarget>]) -> Result<()>
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Metrics archive disabled in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Metrics archive disabled in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -258,29 +197,16 @@ pub async fn run_metrics_validate(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                eprintln!(
-                    "{}",
-                    format!("Validation complete in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        eprintln!(
+            "{}",
+            format!("Validation complete in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -311,25 +237,12 @@ pub async fn run_logs_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -368,26 +281,13 @@ pub async fn run_logs_set(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Logs archive target set in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Logs archive target set in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/data_archive/mod.rs
+++ b/src/commands/data_archive/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::DataArchiveApi;
 

--- a/src/commands/data_archive/mod.rs
+++ b/src/commands/data_archive/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
@@ -38,6 +38,8 @@ pub async fn run_metrics_get(targets: &[Arc<ExecutionTarget>], output: OutputFor
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -47,8 +49,14 @@ pub async fn run_metrics_get(targets: &[Arc<ExecutionTarget>], output: OutputFor
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -87,6 +95,8 @@ pub async fn run_metrics_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -97,8 +107,14 @@ pub async fn run_metrics_create(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -130,6 +146,8 @@ pub async fn run_metrics_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -140,8 +158,14 @@ pub async fn run_metrics_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -166,14 +190,22 @@ pub async fn run_metrics_enable(targets: &[Arc<ExecutionTarget>]) -> Result<()> 
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Metrics archive enabled in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -188,14 +220,22 @@ pub async fn run_metrics_disable(targets: &[Arc<ExecutionTarget>]) -> Result<()>
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Metrics archive disabled in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -218,6 +258,8 @@ pub async fn run_metrics_validate(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -231,8 +273,14 @@ pub async fn run_metrics_validate(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -263,6 +311,8 @@ pub async fn run_logs_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -272,8 +322,14 @@ pub async fn run_logs_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -312,6 +368,8 @@ pub async fn run_logs_set(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -322,8 +380,14 @@ pub async fn run_logs_set(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/data_archive/mod.rs
+++ b/src/commands/data_archive/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::DataArchiveApi;
 
@@ -39,7 +39,7 @@ pub async fn run_metrics_get(targets: &[Arc<ExecutionTarget>], output: OutputFor
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -83,7 +83,7 @@ pub async fn run_metrics_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Created metrics archive config in profile '{profile}'.").green()
@@ -121,7 +121,7 @@ pub async fn run_metrics_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated metrics archive config in profile '{profile}'.").green()
@@ -151,7 +151,7 @@ pub async fn run_metrics_enable(targets: &[Arc<ExecutionTarget>]) -> Result<()> 
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Metrics archive enabled in profile '{profile}'.").green()
@@ -170,7 +170,7 @@ pub async fn run_metrics_disable(targets: &[Arc<ExecutionTarget>]) -> Result<()>
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Metrics archive disabled in profile '{profile}'.").green()
@@ -198,7 +198,7 @@ pub async fn run_metrics_validate(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -238,7 +238,7 @@ pub async fn run_logs_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -282,7 +282,7 @@ pub async fn run_logs_set(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Logs archive target set in profile '{profile}'.").green()

--- a/src/commands/data_usage/mod.rs
+++ b/src/commands/data_usage/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::DataUsageApi;
 

--- a/src/commands/data_usage/mod.rs
+++ b/src/commands/data_usage/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::DataUsageApi;
 
@@ -106,24 +106,11 @@ pub async fn run_summary(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -190,24 +177,11 @@ pub async fn run_daily(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -254,24 +228,11 @@ pub async fn run_logs_count(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match options.output {
@@ -314,24 +275,11 @@ pub async fn run_spans_count(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match options.output {
@@ -366,24 +314,11 @@ pub async fn run_export_status(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/data_usage/mod.rs
+++ b/src/commands/data_usage/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::DataUsageApi;
 
@@ -106,7 +106,7 @@ pub async fn run_summary(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -177,7 +177,7 @@ pub async fn run_daily(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -228,7 +228,7 @@ pub async fn run_logs_count(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -275,7 +275,7 @@ pub async fn run_spans_count(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -314,7 +314,7 @@ pub async fn run_export_status(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/commands/data_usage/mod.rs
+++ b/src/commands/data_usage/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
@@ -106,6 +106,8 @@ pub async fn run_summary(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -114,8 +116,14 @@ pub async fn run_summary(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -182,6 +190,8 @@ pub async fn run_daily(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -190,8 +200,14 @@ pub async fn run_daily(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -238,6 +254,8 @@ pub async fn run_logs_count(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -246,8 +264,14 @@ pub async fn run_logs_count(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match options.output {
@@ -290,6 +314,8 @@ pub async fn run_spans_count(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -298,8 +324,14 @@ pub async fn run_spans_count(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match options.output {
@@ -334,6 +366,8 @@ pub async fn run_export_status(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -342,8 +376,14 @@ pub async fn run_export_status(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/dataprime/api.rs
+++ b/src/commands/dataprime/api.rs
@@ -177,13 +177,20 @@ pub fn parse_ndjson_response(raw: &str) -> Result<(Vec<Value>, Vec<String>)> {
                     "query did not complete successfully (status: {status}): {line}"
                 )));
             }
-        } else {
-            // Unrecognized envelope. Don't silently drop it and report
-            // whatever rows were collected so far as a complete success.
+        } else if value.get("error").is_some() || value.get("errors").is_some() {
+            // Explicit mid-stream error envelope: the engine can report a
+            // failure in the response body after the 200 has been sent, rather
+            // than via the terminal `statistics` status. Surface it instead of
+            // reporting whatever rows arrived first as a complete success.
             let detail =
                 crate::api_client::extract_error_detail(line).unwrap_or_else(|| line.to_string());
             return Err(crate::error::CxError::QueryStream(detail));
         }
+        // Any other line is an unrecognized, non-error envelope (e.g. a future
+        // progress/heartbeat line). Skip it rather than failing an
+        // otherwise-successful query - the authoritative outcome is the
+        // terminal `statistics` status handled above, and a real failure also
+        // arrives as a non-COMPLETED status or an explicit error envelope.
     }
     Ok((rows, warnings))
 }
@@ -479,7 +486,7 @@ mod tests {
     }
 
     #[test]
-    fn ndjson_unrecognized_envelope_with_message_returns_query_stream_err() {
+    fn ndjson_error_envelope_with_message_returns_query_stream_err() {
         let raw = r#"{"queryId":{"queryId":"test-query-id"}}
 {"error":{"message":"engine out of memory"}}"#;
         let err = parse_ndjson_response(raw).unwrap_err();
@@ -492,17 +499,17 @@ mod tests {
     }
 
     #[test]
-    fn ndjson_unrecognized_envelope_without_message_falls_back_to_raw_line() {
+    fn ndjson_unknown_benign_envelope_is_skipped() {
+        // An unrecognized, non-error envelope (e.g. a future progress/heartbeat
+        // line) must not fail an otherwise-successful query: the authoritative
+        // outcome is the terminal COMPLETED statistics status.
         let raw = r#"{"queryId":{"queryId":"test-query-id"}}
-{"somethingUnexpected":true}"#;
-        let err = parse_ndjson_response(raw).unwrap_err();
-        match err {
-            crate::error::CxError::QueryStream(msg) => {
-                assert!(!msg.is_empty());
-                assert!(msg.contains("somethingUnexpected"));
-            }
-            other => panic!("expected QueryStream error, got: {other:?}"),
-        }
+{"progress":{"percent":50}}
+{"result":{"results":[{"metadata":[],"labels":[],"userData":"{}"}]}}
+{"statistics":{"status":"COMPLETED","outputRowCount":"1"}}"#;
+        let (rows, warnings) = parse_ndjson_response(raw).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(warnings.is_empty());
     }
 
     #[test]

--- a/src/commands/dataprime/api.rs
+++ b/src/commands/dataprime/api.rs
@@ -151,7 +151,9 @@ pub fn parse_ndjson_response(raw: &str) -> Result<(Vec<Value>, Vec<String>)> {
             continue;
         }
         let value: Value = serde_json::from_str(line)?;
-        if let Some(batch) = value
+        if value.get("queryId").is_some() {
+            continue;
+        } else if let Some(batch) = value
             .get("result")
             .and_then(|r| r.get("results"))
             .and_then(|r| r.as_array())
@@ -163,6 +165,24 @@ pub fn parse_ndjson_response(raw: &str) -> Result<(Vec<Value>, Vec<String>)> {
                     warnings.push(msg.to_string());
                 }
             }
+        } else if let Some(stats) = value.get("statistics") {
+            // Every query - success or failure - ends with a statistics
+            // envelope. `status` is the authoritative outcome: a query that
+            // died mid-execution (e.g. an engine OOM) reports a non-COMPLETED
+            // status here rather than an HTTP-level error, since the 200
+            // response has already been sent by the time it happens.
+            let status = stats.get("status").and_then(|s| s.as_str()).unwrap_or("");
+            if status != "COMPLETED" {
+                return Err(crate::error::CxError::QueryStream(format!(
+                    "query did not complete successfully (status: {status}): {line}"
+                )));
+            }
+        } else {
+            // Unrecognized envelope. Don't silently drop it and report
+            // whatever rows were collected so far as a complete success.
+            let detail =
+                crate::api_client::extract_error_detail(line).unwrap_or_else(|| line.to_string());
+            return Err(crate::error::CxError::QueryStream(detail));
         }
     }
     Ok((rows, warnings))
@@ -411,6 +431,78 @@ mod tests {
                 .map(|(k, v)| json!({"key": k, "value": v}))
                 .collect(),
         )
+    }
+
+    // ── parse_ndjson_response ─────────────────────────────────────────────────
+
+    #[test]
+    fn ndjson_ignores_query_id_line() {
+        let raw = r#"{"queryId":{"queryId":"test-query-id"}}
+{"result":{"results":[{"metadata":[],"labels":[],"userData":"{}"}]}}"#;
+        let (rows, warnings) = parse_ndjson_response(raw).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn ndjson_completed_statistics_line_is_benign() {
+        let raw = r#"{"queryId":{"queryId":"test-query-id"}}
+{"result":{"results":[{"metadata":[],"labels":[],"userData":"{}"}]}}
+{"statistics":{"status":"COMPLETED","outputRowCount":"1"}}"#;
+        let (rows, warnings) = parse_ndjson_response(raw).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn ndjson_completed_statistics_line_on_zero_rows_is_not_an_error() {
+        // A query that legitimately matches nothing still ends with a
+        // COMPLETED statistics line and no `result` line at all.
+        let raw = r#"{"queryId":{"queryId":"test-query-id"}}
+{"statistics":{"status":"COMPLETED","outputRowCount":"0"}}"#;
+        let (rows, warnings) = parse_ndjson_response(raw).unwrap();
+        assert!(rows.is_empty());
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn ndjson_non_completed_statistics_status_returns_query_stream_err() {
+        let raw = r#"{"queryId":{"queryId":"test-query-id"}}
+{"statistics":{"status":"FAILED","outputRowCount":"0"}}"#;
+        let err = parse_ndjson_response(raw).unwrap_err();
+        match err {
+            crate::error::CxError::QueryStream(msg) => {
+                assert!(msg.contains("FAILED"), "got: {msg}");
+            }
+            other => panic!("expected QueryStream error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ndjson_unrecognized_envelope_with_message_returns_query_stream_err() {
+        let raw = r#"{"queryId":{"queryId":"test-query-id"}}
+{"error":{"message":"engine out of memory"}}"#;
+        let err = parse_ndjson_response(raw).unwrap_err();
+        match err {
+            crate::error::CxError::QueryStream(msg) => {
+                assert!(msg.contains("engine out of memory"), "got: {msg}");
+            }
+            other => panic!("expected QueryStream error, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn ndjson_unrecognized_envelope_without_message_falls_back_to_raw_line() {
+        let raw = r#"{"queryId":{"queryId":"test-query-id"}}
+{"somethingUnexpected":true}"#;
+        let err = parse_ndjson_response(raw).unwrap_err();
+        match err {
+            crate::error::CxError::QueryStream(msg) => {
+                assert!(!msg.is_empty());
+                assert!(msg.contains("somethingUnexpected"));
+            }
+            other => panic!("expected QueryStream error, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/commands/dataprime/mod.rs
+++ b/src/commands/dataprime/mod.rs
@@ -15,7 +15,7 @@ use api::{DataprimeApi, QueryGenericResponse};
 
 use crate::cases_query_rules::check_cases_query_rules;
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::spill::{maybe_spill, transform_for_agents, SpillOutcome};
 use crate::time::parse_timestamp;
 use crate::Tier;
@@ -284,8 +284,6 @@ pub fn merge_results(
     include_profile: bool,
     cases_warning: Option<&str>,
 ) -> Result<MergedResults> {
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut rows: Vec<Value> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
     if let Some(w) = cases_warning {
@@ -293,35 +291,23 @@ pub fn merge_results(
     }
     let mut is_aggregate: Option<bool> = None;
 
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for w in resp.warnings {
-                    warnings.push(format!("[{profile}] {w}"));
-                }
-                if is_aggregate.is_none() {
-                    is_aggregate = Some(resp.is_aggregate);
-                }
-                if include_profile {
-                    rows.extend(resp.raw_results.into_iter().map(|mut row| {
-                        if let Value::Object(ref mut m) = row {
-                            m.insert("profile".to_string(), Value::String(profile.clone()));
-                        }
-                        row
-                    }));
-                } else {
-                    rows.extend(resp.raw_results);
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for w in resp.warnings {
+            warnings.push(format!("[{profile}] {w}"));
         }
-    }
-
-    if target_count > 0 && error_count == target_count {
-        anyhow::bail!("all profiles returned errors; see above for details");
+        if is_aggregate.is_none() {
+            is_aggregate = Some(resp.is_aggregate);
+        }
+        if include_profile {
+            rows.extend(resp.raw_results.into_iter().map(|mut row| {
+                if let Value::Object(ref mut m) = row {
+                    m.insert("profile".to_string(), Value::String(profile.clone()));
+                }
+                row
+            }));
+        } else {
+            rows.extend(resp.raw_results);
+        }
     }
 
     Ok(MergedResults {

--- a/src/commands/dataprime/mod.rs
+++ b/src/commands/dataprime/mod.rs
@@ -15,7 +15,7 @@ use api::{DataprimeApi, QueryGenericResponse};
 
 use crate::cases_query_rules::check_cases_query_rules;
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::spill::{maybe_spill, transform_for_agents, SpillOutcome};
 use crate::time::parse_timestamp;
 use crate::Tier;
@@ -291,7 +291,7 @@ pub fn merge_results(
     }
     let mut is_aggregate: Option<bool> = None;
 
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for w in resp.warnings {
             warnings.push(format!("[{profile}] {w}"));
         }

--- a/src/commands/dataprime/mod.rs
+++ b/src/commands/dataprime/mod.rs
@@ -15,7 +15,7 @@ use api::{DataprimeApi, QueryGenericResponse};
 
 use crate::cases_query_rules::check_cases_query_rules;
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::spill::{maybe_spill, transform_for_agents, SpillOutcome};
 use crate::time::parse_timestamp;
 use crate::Tier;

--- a/src/commands/dataprime/mod.rs
+++ b/src/commands/dataprime/mod.rs
@@ -283,7 +283,9 @@ pub fn merge_results(
     per_profile: Vec<(String, Result<QueryGenericResponse>)>,
     include_profile: bool,
     cases_warning: Option<&str>,
-) -> MergedResults {
+) -> Result<MergedResults> {
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut rows: Vec<Value> = Vec::new();
     let mut warnings: Vec<String> = Vec::new();
     if let Some(w) = cases_warning {
@@ -312,17 +314,22 @@ pub fn merge_results(
                 }
             }
             Err(e) => {
+                error_count += 1;
                 eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
             }
         }
     }
 
-    MergedResults {
+    if target_count > 0 && error_count == target_count {
+        anyhow::bail!("all profiles returned errors; see above for details");
+    }
+
+    Ok(MergedResults {
         rows,
         warnings,
         is_aggregate: is_aggregate.unwrap_or(false),
         include_profile,
-    }
+    })
 }
 
 /// Render merged results to stdout.
@@ -418,7 +425,7 @@ pub async fn run_query(
     })
     .await;
 
-    let merged = merge_results(per_profile, include_profile, cases_warning.as_deref());
+    let merged = merge_results(per_profile, include_profile, cases_warning.as_deref())?;
     render_results(&merged, output, max_direct, temp_dir, text_renderer)
 }
 
@@ -508,7 +515,7 @@ category: ["Commands reference", "test"]
     fn merge_single_profile_omits_profile_field() {
         let rows = vec![json!({"userData": {"message": "hello"}})];
         let per_profile = vec![("prod".to_string(), Ok(make_generic_response(rows, false)))];
-        let merged = merge_results(per_profile, false, None);
+        let merged = merge_results(per_profile, false, None).unwrap();
 
         assert_eq!(merged.rows.len(), 1);
         assert!(!merged.include_profile);
@@ -533,7 +540,7 @@ category: ["Commands reference", "test"]
                 )),
             ),
         ];
-        let merged = merge_results(per_profile, true, None);
+        let merged = merge_results(per_profile, true, None).unwrap();
 
         assert_eq!(merged.rows.len(), 2);
         assert_eq!(merged.rows[0]["profile"], json!("prod"));
@@ -549,7 +556,7 @@ category: ["Commands reference", "test"]
             ),
             ("bad".to_string(), Err(anyhow::anyhow!("network error"))),
         ];
-        let merged = merge_results(per_profile, true, None);
+        let merged = merge_results(per_profile, true, None).unwrap();
 
         assert_eq!(merged.rows.len(), 1);
         assert_eq!(merged.rows[0]["profile"], json!("good"));
@@ -560,7 +567,7 @@ category: ["Commands reference", "test"]
         let mut resp = make_generic_response(vec![], false);
         resp.warnings = vec!["too many results".to_string()];
         let per_profile = vec![("prod".to_string(), Ok(resp))];
-        let merged = merge_results(per_profile, true, None);
+        let merged = merge_results(per_profile, true, None).unwrap();
 
         assert_eq!(merged.warnings.len(), 1);
         assert!(merged.warnings[0].contains("[prod]"));
@@ -572,8 +579,31 @@ category: ["Commands reference", "test"]
             ("p1".to_string(), Ok(make_generic_response(vec![], true))),
             ("p2".to_string(), Ok(make_generic_response(vec![], true))),
         ];
-        let merged = merge_results(per_profile, true, None);
+        let merged = merge_results(per_profile, true, None).unwrap();
         assert!(merged.is_aggregate);
+    }
+
+    #[test]
+    fn merge_single_profile_failure_returns_err() {
+        let per_profile: Vec<(String, anyhow::Result<QueryGenericResponse>)> =
+            vec![("prod".to_string(), Err(anyhow::anyhow!("boom")))];
+        let result = merge_results(per_profile, false, None);
+
+        assert!(result.is_err(), "single failing profile must bail");
+    }
+
+    #[test]
+    fn merge_all_profiles_failing_returns_err() {
+        let per_profile: Vec<(String, anyhow::Result<QueryGenericResponse>)> = vec![
+            ("prod".to_string(), Err(anyhow::anyhow!("timeout"))),
+            ("staging".to_string(), Err(anyhow::anyhow!("auth failed"))),
+        ];
+        let result = merge_results(per_profile, true, None);
+
+        assert!(
+            result.is_err(),
+            "must bail when every profile in the fan-out failed"
+        );
     }
 
     // ── check_cases_query_rules integration via merge_results ────────────────
@@ -596,7 +626,7 @@ category: ["Commands reference", "test"]
             "prod".to_string(),
             Ok(make_generic_response(vec![json!({"data": 1})], false)),
         )];
-        let merged = merge_results(per_profile, false, warning.as_deref());
+        let merged = merge_results(per_profile, false, warning.as_deref()).unwrap();
 
         assert_eq!(merged.warnings.len(), 1);
         assert!(
@@ -613,7 +643,7 @@ category: ["Commands reference", "test"]
         let mut resp = make_generic_response(vec![], false);
         resp.warnings = vec!["too many results".to_string()];
         let per_profile = vec![("prod".to_string(), Ok(resp))];
-        let merged = merge_results(per_profile, true, cases_warn.as_deref());
+        let merged = merge_results(per_profile, true, cases_warn.as_deref()).unwrap();
 
         assert_eq!(
             merged.warnings.len(),
@@ -640,7 +670,7 @@ category: ["Commands reference", "test"]
             ),
             ("bad".to_string(), Err(anyhow::anyhow!("timeout"))),
         ];
-        let merged = merge_results(per_profile, true, cases_warn.as_deref());
+        let merged = merge_results(per_profile, true, cases_warn.as_deref()).unwrap();
 
         // The cases warning appears in merged.warnings regardless of profile errors.
         assert!(
@@ -664,7 +694,7 @@ category: ["Commands reference", "test"]
             CASES_END,
         );
         let per_profile = vec![("prod".to_string(), Ok(make_generic_response(vec![], false)))];
-        let merged = merge_results(per_profile, false, warning.as_deref());
+        let merged = merge_results(per_profile, false, warning.as_deref()).unwrap();
 
         assert!(
             merged.warnings.is_empty(),
@@ -681,7 +711,7 @@ category: ["Commands reference", "test"]
             "prod".to_string(),
             Ok(make_generic_response(vec![json!({"msg": "hi"})], false)),
         )];
-        let merged = merge_results(per_profile, false, warning.as_deref());
+        let merged = merge_results(per_profile, false, warning.as_deref()).unwrap();
 
         assert!(merged.warnings.is_empty());
         assert_eq!(merged.rows.len(), 1);

--- a/src/commands/e2m/mod.rs
+++ b/src/commands/e2m/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{E2mApi, E2mDefinition};
 
@@ -200,11 +200,7 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(def) = resp.e2m {
             let name = def.display_name().to_string();
-            let id = def.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created E2M '{name}' (ID: {id}) in profile '{profile}'.").green()
-            );
+            render::print_created("Created", "E2M", Some(&name), def.id.as_deref(), &profile);
             all_results.push(e2m_to_json(&def, include_profile, &profile));
         }
     }
@@ -246,11 +242,7 @@ pub async fn run_update(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(def) = resp.e2m {
             let name = def.display_name().to_string();
-            let id = def.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Updated E2M '{name}' (ID: {id}) in profile '{profile}'.").green()
-            );
+            render::print_created("Updated", "E2M", Some(&name), def.id.as_deref(), &profile);
             all_results.push(e2m_to_json(&def, include_profile, &profile));
         }
     }

--- a/src/commands/e2m/mod.rs
+++ b/src/commands/e2m/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{E2mApi, E2mDefinition};
 
@@ -62,26 +62,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, E2mDefinition)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for def in resp.e2m {
-                    all_json.push(e2m_to_json(&def, include_profile, &profile));
-                    all_items.push((profile.clone(), def));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for def in resp.e2m {
+            all_json.push(e2m_to_json(&def, include_profile, &profile));
+            all_items.push((profile.clone(), def));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -139,25 +126,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -222,30 +196,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(def) = resp.e2m {
-                    let name = def.display_name().to_string();
-                    let id = def.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created E2M '{name}' (ID: {id}) in profile '{profile}'.").green()
-                    );
-                    all_results.push(e2m_to_json(&def, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(def) = resp.e2m {
+            let name = def.display_name().to_string();
+            let id = def.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created E2M '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(e2m_to_json(&def, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -281,30 +242,17 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(def) = resp.e2m {
-                    let name = def.display_name().to_string();
-                    let id = def.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Updated E2M '{name}' (ID: {id}) in profile '{profile}'.").green()
-                    );
-                    all_results.push(e2m_to_json(&def, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(def) = resp.e2m {
+            let name = def.display_name().to_string();
+            let id = def.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Updated E2M '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(e2m_to_json(&def, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -335,22 +283,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("E2M {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("E2M {id} deleted in profile '{profile}'.").green()
+        );
     }
 
     Ok(())
@@ -368,24 +305,11 @@ pub async fn run_labels_cardinality(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for label in resp.labels {
-                    all_json.push(label);
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (_profile, resp) in collect_successes(per_profile)? {
+        for label in resp.labels {
+            all_json.push(label);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -420,31 +344,18 @@ pub async fn run_limits(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                let mut v = json!({
-                    "limit": resp.limit,
-                    "used": resp.used,
-                });
-                if include_profile {
-                    if let Value::Object(ref mut m) = v {
-                        m.insert("profile".to_string(), Value::String(profile.clone()));
-                    }
-                }
-                all_json.push(v);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+    for (profile, resp) in collect_successes(per_profile)? {
+        let mut v = json!({
+            "limit": resp.limit,
+            "used": resp.used,
+        });
+        if include_profile {
+            if let Value::Object(ref mut m) = v {
+                m.insert("profile".to_string(), Value::String(profile.clone()));
             }
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_json.push(v);
     }
 
     match output {

--- a/src/commands/e2m/mod.rs
+++ b/src/commands/e2m/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{E2mApi, E2mDefinition};
 
@@ -64,7 +64,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, E2mDefinition)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for def in resp.e2m {
             all_json.push(e2m_to_json(&def, include_profile, &profile));
             all_items.push((profile.clone(), def));
@@ -127,7 +127,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -197,7 +197,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(def) = resp.e2m {
             let name = def.display_name().to_string();
             let id = def.id.as_deref().unwrap_or("unknown");
@@ -243,7 +243,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(def) = resp.e2m {
             let name = def.display_name().to_string();
             let id = def.id.as_deref().unwrap_or("unknown");
@@ -283,7 +283,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("E2M {id} deleted in profile '{profile}'.").green()
@@ -306,7 +306,7 @@ pub async fn run_labels_cardinality(
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
-    for (_profile, resp) in collect_successes(per_profile)? {
+    for (_profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for label in resp.labels {
             all_json.push(label);
         }
@@ -345,7 +345,7 @@ pub async fn run_limits(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
     .await;
 
     let mut all_json: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         let mut v = json!({
             "limit": resp.limit,
             "used": resp.used,

--- a/src/commands/e2m/mod.rs
+++ b/src/commands/e2m/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -62,6 +62,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, E2mDefinition)> = Vec::new();
     for (profile, result) in per_profile {
@@ -72,8 +74,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), def));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -131,6 +139,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -140,8 +150,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -206,6 +222,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -220,8 +238,14 @@ pub async fn run_create(
                     all_results.push(e2m_to_json(&def, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -257,6 +281,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -271,8 +297,14 @@ pub async fn run_update(
                     all_results.push(e2m_to_json(&def, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -303,14 +335,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("E2M {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())
@@ -328,6 +368,8 @@ pub async fn run_labels_cardinality(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -336,8 +378,14 @@ pub async fn run_labels_cardinality(
                     all_json.push(label);
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -372,6 +420,8 @@ pub async fn run_limits(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -387,8 +437,14 @@ pub async fn run_limits(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
                 }
                 all_json.push(v);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/enrichments/mod.rs
+++ b/src/commands/enrichments/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::EnrichmentsApi;
 

--- a/src/commands/enrichments/mod.rs
+++ b/src/commands/enrichments/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
@@ -121,6 +121,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -129,8 +131,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output, include_profile)
 }
@@ -152,6 +160,8 @@ pub async fn run_add(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -161,8 +171,14 @@ pub async fn run_add(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output, targets.len() > 1)
 }
@@ -183,6 +199,8 @@ pub async fn run_remove(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -192,8 +210,14 @@ pub async fn run_remove(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output, targets.len() > 1)
 }
@@ -215,6 +239,8 @@ pub async fn run_overwrite(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -224,8 +250,14 @@ pub async fn run_overwrite(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output, targets.len() > 1)
 }
@@ -239,6 +271,8 @@ pub async fn run_limit(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -247,8 +281,14 @@ pub async fn run_limit(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output, include_profile)
 }
@@ -262,6 +302,8 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -270,8 +312,14 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output, include_profile)
 }

--- a/src/commands/enrichments/mod.rs
+++ b/src/commands/enrichments/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::EnrichmentsApi;
 
@@ -121,24 +121,11 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     render_results(&all_results, output, include_profile)
 }
@@ -160,25 +147,12 @@ pub async fn run_add(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Added enrichments in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Added enrichments in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     render_results(&all_results, output, targets.len() > 1)
 }
@@ -199,25 +173,12 @@ pub async fn run_remove(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Removed enrichments in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Removed enrichments in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     render_results(&all_results, output, targets.len() > 1)
 }
@@ -239,25 +200,12 @@ pub async fn run_overwrite(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Overwrote enrichments in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Overwrote enrichments in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     render_results(&all_results, output, targets.len() > 1)
 }
@@ -271,24 +219,11 @@ pub async fn run_limit(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     render_results(&all_results, output, include_profile)
 }
@@ -302,24 +237,11 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     render_results(&all_results, output, include_profile)
 }

--- a/src/commands/enrichments/mod.rs
+++ b/src/commands/enrichments/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::EnrichmentsApi;
 
@@ -121,7 +121,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -147,7 +147,7 @@ pub async fn run_add(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Added enrichments in profile '{profile}'.").green()
@@ -173,7 +173,7 @@ pub async fn run_remove(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Removed enrichments in profile '{profile}'.").green()
@@ -200,7 +200,7 @@ pub async fn run_overwrite(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Overwrote enrichments in profile '{profile}'.").green()
@@ -219,7 +219,7 @@ pub async fn run_limit(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -237,7 +237,7 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/commands/extensions/mod.rs
+++ b/src/commands/extensions/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -57,6 +57,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Extension)> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
@@ -65,8 +67,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), ext));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -123,6 +131,8 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(mut val) => {
@@ -131,8 +141,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -166,6 +182,8 @@ pub async fn run_deployed(targets: &[Arc<ExecutionTarget>], output: OutputFormat
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Extension)> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
@@ -174,8 +192,14 @@ pub async fn run_deployed(targets: &[Arc<ExecutionTarget>], output: OutputFormat
                     all_items.push((profile.clone(), ext));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -231,6 +255,8 @@ pub async fn run_deploy(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -240,8 +266,14 @@ pub async fn run_deploy(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -274,6 +306,8 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -283,8 +317,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -317,6 +357,8 @@ pub async fn run_undeploy(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -326,8 +368,14 @@ pub async fn run_undeploy(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/extensions/mod.rs
+++ b/src/commands/extensions/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Extension, ExtensionsApi};
 
@@ -57,24 +57,11 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Extension)> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for ext in resp.extensions {
-                    all_json.push(extension_to_json(&ext, include_profile, &profile));
-                    all_items.push((profile.clone(), ext));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for ext in resp.extensions {
+            all_json.push(extension_to_json(&ext, include_profile, &profile));
+            all_items.push((profile.clone(), ext));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -131,24 +118,11 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -182,24 +156,11 @@ pub async fn run_deployed(targets: &[Arc<ExecutionTarget>], output: OutputFormat
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Extension)> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for ext in resp.deployed_extensions {
-                    all_json.push(extension_to_json(&ext, include_profile, &profile));
-                    all_items.push((profile.clone(), ext));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for ext in resp.deployed_extensions {
+            all_json.push(extension_to_json(&ext, include_profile, &profile));
+            all_items.push((profile.clone(), ext));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -255,25 +216,12 @@ pub async fn run_deploy(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Extension deployed in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Extension deployed in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -306,25 +254,12 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Extension updated in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Extension updated in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -357,25 +292,12 @@ pub async fn run_undeploy(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Extension undeployed in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Extension undeployed in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/extensions/mod.rs
+++ b/src/commands/extensions/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Extension, ExtensionsApi};
 

--- a/src/commands/extensions/mod.rs
+++ b/src/commands/extensions/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Extension, ExtensionsApi};
 
@@ -57,7 +57,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Extension)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for ext in resp.extensions {
             all_json.push(extension_to_json(&ext, include_profile, &profile));
             all_items.push((profile.clone(), ext));
@@ -118,7 +118,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -156,7 +156,7 @@ pub async fn run_deployed(targets: &[Arc<ExecutionTarget>], output: OutputFormat
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Extension)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for ext in resp.deployed_extensions {
             all_json.push(extension_to_json(&ext, include_profile, &profile));
             all_items.push((profile.clone(), ext));
@@ -216,7 +216,7 @@ pub async fn run_deploy(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Extension deployed in profile '{profile}'.").green()
@@ -254,7 +254,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Extension updated in profile '{profile}'.").green()
@@ -292,7 +292,7 @@ pub async fn run_undeploy(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Extension undeployed in profile '{profile}'.").green()

--- a/src/commands/integrations/mod.rs
+++ b/src/commands/integrations/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Integration, IntegrationsApi};
 
@@ -60,7 +60,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Integration)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for entry in resp.integrations {
             let integration = entry.integration;
             all_json.push(rg_to_json(&integration, include_profile, &profile));
@@ -122,7 +122,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -167,7 +167,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(integration) = resp.deployment {
             let name = integration.name.clone().unwrap_or_default();
             let id = integration.id.as_deref().unwrap_or("unknown");
@@ -212,7 +212,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated integration {id} in profile '{profile}'.").green()
@@ -244,7 +244,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Integration {id} deleted in profile '{profile}'.").green()
@@ -275,7 +275,7 @@ pub async fn run_definition(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -323,7 +323,7 @@ pub async fn run_deployed(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -367,7 +367,7 @@ pub async fn run_test(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Test completed in profile '{profile}'.").green()
@@ -402,7 +402,7 @@ pub async fn run_template(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/commands/integrations/mod.rs
+++ b/src/commands/integrations/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Integration, IntegrationsApi};
 
@@ -170,10 +170,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(integration) = resp.deployment {
             let name = integration.name.clone().unwrap_or_default();
-            let id = integration.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created integration '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "integration",
+                Some(&name),
+                integration.id.as_deref(),
+                &profile,
             );
             all_results.push(rg_to_json(&integration, include_profile, &profile));
         }

--- a/src/commands/integrations/mod.rs
+++ b/src/commands/integrations/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Integration, IntegrationsApi};
 
@@ -58,27 +58,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Integration)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for entry in resp.integrations {
-                    let integration = entry.integration;
-                    all_json.push(rg_to_json(&integration, include_profile, &profile));
-                    all_items.push((profile.clone(), integration));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for entry in resp.integrations {
+            let integration = entry.integration;
+            all_json.push(rg_to_json(&integration, include_profile, &profile));
+            all_items.push((profile.clone(), integration));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -134,25 +121,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -192,31 +166,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(integration) = resp.deployment {
-                    let name = integration.name.clone().unwrap_or_default();
-                    let id = integration.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created integration '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(rg_to_json(&integration, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(integration) = resp.deployment {
+            let name = integration.name.clone().unwrap_or_default();
+            let id = integration.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created integration '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(rg_to_json(&integration, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -251,26 +211,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated integration {id} in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated integration {id} in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -297,22 +244,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Integration {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Integration {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -338,25 +274,12 @@ pub async fn run_definition(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -399,25 +322,12 @@ pub async fn run_deployed(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -456,26 +366,13 @@ pub async fn run_test(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Test completed in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Test completed in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -504,25 +401,12 @@ pub async fn run_template(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/integrations/mod.rs
+++ b/src/commands/integrations/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -58,6 +58,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Integration)> = Vec::new();
     for (profile, result) in per_profile {
@@ -69,8 +71,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), integration));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -126,6 +134,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -135,8 +145,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -176,6 +192,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -191,8 +209,14 @@ pub async fn run_create(
                     all_results.push(rg_to_json(&integration, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -227,6 +251,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -237,8 +263,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -265,14 +297,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Integration {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -298,6 +338,8 @@ pub async fn run_definition(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -307,8 +349,14 @@ pub async fn run_definition(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -351,6 +399,8 @@ pub async fn run_deployed(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -360,8 +410,14 @@ pub async fn run_deployed(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -400,6 +456,8 @@ pub async fn run_test(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -410,8 +468,14 @@ pub async fn run_test(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -440,6 +504,8 @@ pub async fn run_template(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -449,8 +515,14 @@ pub async fn run_template(targets: &[Arc<ExecutionTarget>], output: OutputFormat
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/ip_access/mod.rs
+++ b/src/commands/ip_access/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -39,6 +39,8 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -48,8 +50,14 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -88,6 +96,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -106,8 +116,14 @@ pub async fn run_create(
                     }));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -139,6 +155,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -155,8 +173,14 @@ pub async fn run_update(
                     }));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -179,14 +203,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>]) -> Result<()> {
         Ok(())
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("IP access settings deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/ip_access/mod.rs
+++ b/src/commands/ip_access/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::IpAccessApi;
 
@@ -39,25 +39,12 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -96,34 +83,20 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(settings) = resp.settings {
-                    let id = settings.display_id();
-                    eprintln!(
-                        "{}",
-                        format!("Created IP access settings (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(json!({
-                        "id": settings.id,
-                        "ip_access": settings.ip_access,
-                        "enable_coralogix_customer_support_access": settings.enable_coralogix_customer_support_access,
-                    }));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(settings) = resp.settings {
+            let id = settings.display_id();
+            eprintln!(
+                "{}",
+                format!("Created IP access settings (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(json!({
+                "id": settings.id,
+                "ip_access": settings.ip_access,
+                "enable_coralogix_customer_support_access": settings.enable_coralogix_customer_support_access,
+            }));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -155,32 +128,19 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(settings) = resp.settings {
-                    eprintln!(
-                        "{}",
-                        format!("Updated IP access settings in profile '{profile}'.").green()
-                    );
-                    all_results.push(json!({
-                        "id": settings.id,
-                        "ip_access": settings.ip_access,
-                        "enable_coralogix_customer_support_access": settings.enable_coralogix_customer_support_access,
-                    }));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(settings) = resp.settings {
+            eprintln!(
+                "{}",
+                format!("Updated IP access settings in profile '{profile}'.").green()
+            );
+            all_results.push(json!({
+                "id": settings.id,
+                "ip_access": settings.ip_access,
+                "enable_coralogix_customer_support_access": settings.enable_coralogix_customer_support_access,
+            }));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -203,22 +163,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>]) -> Result<()> {
         Ok(())
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("IP access settings deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("IP access settings deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/ip_access/mod.rs
+++ b/src/commands/ip_access/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::IpAccessApi;
 
@@ -40,7 +40,7 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -84,7 +84,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(settings) = resp.settings {
             let id = settings.display_id();
             eprintln!(
@@ -129,7 +129,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(settings) = resp.settings {
             eprintln!(
                 "{}",
@@ -163,7 +163,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>]) -> Result<()> {
         Ok(())
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("IP access settings deleted in profile '{profile}'.").green()

--- a/src/commands/ip_access/mod.rs
+++ b/src/commands/ip_access/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::IpAccessApi;
 

--- a/src/commands/metrics/mod.rs
+++ b/src/commands/metrics/mod.rs
@@ -13,7 +13,7 @@ use api::{MetricsApi, PromQueryInstantResponse, PromQueryRangeResponse};
 use crate::api_client::CxClient;
 use crate::commands::dataprime::semantic_search::{semantic_metric_lookup, SemanticMetricResult};
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use crate::time::parse_timestamp;
 
@@ -360,7 +360,7 @@ pub async fn run_query(
 
     // Merge: convert each profile's response to optionally tagged rows.
     let mut all_rows: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         all_rows.extend(instant_response_to_rows(&profile, resp, include_profile));
     }
 
@@ -424,7 +424,7 @@ pub async fn run_query_range(
     .await;
 
     let mut all_rows: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         all_rows.extend(range_response_to_rows(&profile, resp, include_profile));
     }
 
@@ -492,7 +492,7 @@ pub async fn run_search(
         .await;
 
         let mut all_results: Vec<(String, SemanticMetricResult)> = Vec::new();
-        for (profile, results) in collect_successes(per_profile)? {
+        for (profile, results) in report_errors_and_collect_successes(per_profile)? {
             for r in results {
                 all_results.push((profile.clone(), r));
             }
@@ -555,7 +555,7 @@ pub async fn run_search(
     .await;
 
     let mut all_matches: Vec<(String, String)> = Vec::new();
-    for (profile, names) in collect_successes(per_profile)? {
+    for (profile, names) in report_errors_and_collect_successes(per_profile)? {
         for n in names {
             all_matches.push((profile.clone(), n));
         }
@@ -623,7 +623,7 @@ pub async fn run_get_labels(
     .await;
 
     let mut all_labels: Vec<(String, String)> = Vec::new();
-    for (profile, labels) in collect_successes(per_profile)? {
+    for (profile, labels) in report_errors_and_collect_successes(per_profile)? {
         for l in labels {
             all_labels.push((profile.clone(), l));
         }

--- a/src/commands/metrics/mod.rs
+++ b/src/commands/metrics/mod.rs
@@ -13,7 +13,7 @@ use api::{MetricsApi, PromQueryInstantResponse, PromQueryRangeResponse};
 use crate::api_client::CxClient;
 use crate::commands::dataprime::semantic_search::{semantic_metric_lookup, SemanticMetricResult};
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use crate::time::parse_timestamp;
 

--- a/src/commands/metrics/mod.rs
+++ b/src/commands/metrics/mod.rs
@@ -359,12 +359,20 @@ pub async fn run_query(
     .await;
 
     // Merge: convert each profile's response to optionally tagged rows.
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_rows: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => all_rows.extend(instant_response_to_rows(&profile, resp, include_profile)),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -426,12 +434,20 @@ pub async fn run_query_range(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_rows: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => all_rows.extend(range_response_to_rows(&profile, resp, include_profile)),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -497,6 +513,8 @@ pub async fn run_search(
         })
         .await;
 
+        let target_count = per_profile.len();
+        let mut error_count = 0usize;
         let mut all_results: Vec<(String, SemanticMetricResult)> = Vec::new();
         for (profile, result) in per_profile {
             match result {
@@ -505,8 +523,14 @@ pub async fn run_search(
                         all_results.push((profile.clone(), r));
                     }
                 }
-                Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+                Err(e) => {
+                    error_count += 1;
+                    eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+                }
             }
+        }
+        if target_count > 0 && error_count == target_count {
+            bail!("all profiles returned errors; see above for details");
         }
 
         match output {
@@ -565,6 +589,8 @@ pub async fn run_search(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_matches: Vec<(String, String)> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -573,8 +599,14 @@ pub async fn run_search(
                     all_matches.push((profile.clone(), n));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -638,6 +670,8 @@ pub async fn run_get_labels(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_labels: Vec<(String, String)> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -646,8 +680,14 @@ pub async fn run_get_labels(
                     all_labels.push((profile.clone(), l));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/metrics/mod.rs
+++ b/src/commands/metrics/mod.rs
@@ -13,7 +13,7 @@ use api::{MetricsApi, PromQueryInstantResponse, PromQueryRangeResponse};
 use crate::api_client::CxClient;
 use crate::commands::dataprime::semantic_search::{semantic_metric_lookup, SemanticMetricResult};
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use crate::time::parse_timestamp;
 
@@ -359,20 +359,9 @@ pub async fn run_query(
     .await;
 
     // Merge: convert each profile's response to optionally tagged rows.
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_rows: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => all_rows.extend(instant_response_to_rows(&profile, resp, include_profile)),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, resp) in collect_successes(per_profile)? {
+        all_rows.extend(instant_response_to_rows(&profile, resp, include_profile));
     }
 
     match output {
@@ -434,20 +423,9 @@ pub async fn run_query_range(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_rows: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => all_rows.extend(range_response_to_rows(&profile, resp, include_profile)),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, resp) in collect_successes(per_profile)? {
+        all_rows.extend(range_response_to_rows(&profile, resp, include_profile));
     }
 
     match output {
@@ -513,24 +491,11 @@ pub async fn run_search(
         })
         .await;
 
-        let target_count = per_profile.len();
-        let mut error_count = 0usize;
         let mut all_results: Vec<(String, SemanticMetricResult)> = Vec::new();
-        for (profile, result) in per_profile {
-            match result {
-                Ok(results) => {
-                    for r in results {
-                        all_results.push((profile.clone(), r));
-                    }
-                }
-                Err(e) => {
-                    error_count += 1;
-                    eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-                }
+        for (profile, results) in collect_successes(per_profile)? {
+            for r in results {
+                all_results.push((profile.clone(), r));
             }
-        }
-        if target_count > 0 && error_count == target_count {
-            bail!("all profiles returned errors; see above for details");
         }
 
         match output {
@@ -589,24 +554,11 @@ pub async fn run_search(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_matches: Vec<(String, String)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(names) => {
-                for n in names {
-                    all_matches.push((profile.clone(), n));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, names) in collect_successes(per_profile)? {
+        for n in names {
+            all_matches.push((profile.clone(), n));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -670,24 +622,11 @@ pub async fn run_get_labels(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_labels: Vec<(String, String)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(labels) => {
-                for l in labels {
-                    all_labels.push((profile.clone(), l));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, labels) in collect_successes(per_profile)? {
+        for l in labels {
+            all_labels.push((profile.clone(), l));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/notification_testing/mod.rs
+++ b/src/commands/notification_testing/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::NotificationTestingApi;
 
@@ -62,7 +62,7 @@ pub async fn run_test_connector(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
     render_results(&all_results, output)
@@ -84,7 +84,7 @@ pub async fn run_test_destination(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
     render_results(&all_results, output)
@@ -106,7 +106,7 @@ pub async fn run_test_preset(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
     render_results(&all_results, output)
@@ -128,7 +128,7 @@ pub async fn run_test_routing_condition(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
     render_results(&all_results, output)
@@ -150,7 +150,7 @@ pub async fn run_test_template_render(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
     render_results(&all_results, output)

--- a/src/commands/notification_testing/mod.rs
+++ b/src/commands/notification_testing/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::NotificationTestingApi;
 

--- a/src/commands/notification_testing/mod.rs
+++ b/src/commands/notification_testing/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::NotificationTestingApi;
 
@@ -61,20 +61,9 @@ pub async fn run_test_connector(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
     render_results(&all_results, output)
 }
@@ -94,20 +83,9 @@ pub async fn run_test_destination(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
     render_results(&all_results, output)
 }
@@ -127,20 +105,9 @@ pub async fn run_test_preset(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
     render_results(&all_results, output)
 }
@@ -160,20 +127,9 @@ pub async fn run_test_routing_condition(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
     render_results(&all_results, output)
 }
@@ -193,20 +149,9 @@ pub async fn run_test_template_render(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
     render_results(&all_results, output)
 }

--- a/src/commands/notification_testing/mod.rs
+++ b/src/commands/notification_testing/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
@@ -61,12 +61,20 @@ pub async fn run_test_connector(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output)
 }
@@ -86,12 +94,20 @@ pub async fn run_test_destination(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output)
 }
@@ -111,12 +127,20 @@ pub async fn run_test_preset(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output)
 }
@@ -136,12 +160,20 @@ pub async fn run_test_routing_condition(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output)
 }
@@ -161,12 +193,20 @@ pub async fn run_test_template_render(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     render_results(&all_results, output)
 }

--- a/src/commands/parsing_rules/mod.rs
+++ b/src/commands/parsing_rules/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{RuleGroup, RuleGroupsApi};
 
@@ -56,7 +56,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     .await;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, RuleGroup)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for rg in resp.rule_groups {
             all_json.push(rg_to_json(&rg, include_profile, &profile));
             all_items.push((profile.clone(), rg));
@@ -115,7 +115,7 @@ pub async fn run_get(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -157,7 +157,7 @@ pub async fn run_create(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(rg) = resp.rule_group {
             eprintln!(
                 "{}",
@@ -201,7 +201,7 @@ pub async fn run_update(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated rule group in profile '{profile}'.").green()
@@ -232,7 +232,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Rule group {id} deleted in profile '{profile}'.").green()
@@ -253,7 +253,7 @@ pub async fn run_bulk_delete(targets: &[Arc<ExecutionTarget>], ids: &[String]) -
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Rule groups deleted in profile '{profile}'.").green()
@@ -274,7 +274,7 @@ pub async fn run_usage_limits(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/commands/parsing_rules/mod.rs
+++ b/src/commands/parsing_rules/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -54,6 +54,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
         Ok(api.list().await?)
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, RuleGroup)> = Vec::new();
     for (profile, result) in per_profile {
@@ -64,8 +66,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), rg));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -119,6 +127,8 @@ pub async fn run_get(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -128,8 +138,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -166,6 +182,8 @@ pub async fn run_create(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -182,8 +200,14 @@ pub async fn run_create(
                     all_results.push(rg_to_json(&rg, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -215,6 +239,8 @@ pub async fn run_update(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -225,8 +251,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -252,14 +284,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Rule group {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -276,14 +316,22 @@ pub async fn run_bulk_delete(targets: &[Arc<ExecutionTarget>], ids: &[String]) -
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Rule groups deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -299,6 +347,8 @@ pub async fn run_usage_limits(
         Ok(api.usage_limits().await?)
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -308,8 +358,14 @@ pub async fn run_usage_limits(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,

--- a/src/commands/parsing_rules/mod.rs
+++ b/src/commands/parsing_rules/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{RuleGroup, RuleGroupsApi};
 
@@ -54,26 +54,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
         Ok(api.list().await?)
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, RuleGroup)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for rg in resp.rule_groups {
-                    all_json.push(rg_to_json(&rg, include_profile, &profile));
-                    all_items.push((profile.clone(), rg));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for rg in resp.rule_groups {
+            all_json.push(rg_to_json(&rg, include_profile, &profile));
+            all_items.push((profile.clone(), rg));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -127,25 +114,12 @@ pub async fn run_get(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -182,32 +156,19 @@ pub async fn run_create(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(rg) = resp.rule_group {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Created rule group '{}' in profile '{profile}'.",
-                            rg.display_name()
-                        )
-                        .green()
-                    );
-                    all_results.push(rg_to_json(&rg, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(rg) = resp.rule_group {
+            eprintln!(
+                "{}",
+                format!(
+                    "Created rule group '{}' in profile '{profile}'.",
+                    rg.display_name()
+                )
+                .green()
+            );
+            all_results.push(rg_to_json(&rg, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -239,26 +200,13 @@ pub async fn run_update(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated rule group in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated rule group in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -284,22 +232,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Rule group {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Rule group {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -316,22 +253,11 @@ pub async fn run_bulk_delete(targets: &[Arc<ExecutionTarget>], ids: &[String]) -
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Rule groups deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Rule groups deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -347,25 +273,12 @@ pub async fn run_usage_limits(
         Ok(api.usage_limits().await?)
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,

--- a/src/commands/parsing_rules/mod.rs
+++ b/src/commands/parsing_rules/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{RuleGroup, RuleGroupsApi};
 

--- a/src/commands/presets/mod.rs
+++ b/src/commands/presets/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -62,6 +62,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Preset)> = Vec::new();
     for (profile, result) in per_profile {
@@ -72,8 +74,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), preset));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -127,6 +135,8 @@ pub async fn run_get(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -136,8 +146,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -174,6 +190,8 @@ pub async fn run_create(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -190,8 +208,14 @@ pub async fn run_create(
                     all_results.push(preset_to_json(&preset, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -220,6 +244,8 @@ pub async fn run_update(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -230,8 +256,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -257,14 +289,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Preset {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -281,14 +321,22 @@ pub async fn run_set_default(targets: &[Arc<ExecutionTarget>], id: &str) -> Resu
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Preset {id} set as default in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/presets/mod.rs
+++ b/src/commands/presets/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Preset, PresetsApi};
 

--- a/src/commands/presets/mod.rs
+++ b/src/commands/presets/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Preset, PresetsApi};
 
@@ -64,7 +64,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Preset)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for preset in resp.presets {
             all_json.push(preset_to_json(&preset, include_profile, &profile));
             all_items.push((profile.clone(), preset));
@@ -123,7 +123,7 @@ pub async fn run_get(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -165,7 +165,7 @@ pub async fn run_create(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(preset) = resp.preset {
             eprintln!(
                 "{}",
@@ -206,7 +206,7 @@ pub async fn run_update(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated preset in profile '{profile}'.").green()
@@ -237,7 +237,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Preset {id} deleted in profile '{profile}'.").green()
@@ -258,7 +258,7 @@ pub async fn run_set_default(targets: &[Arc<ExecutionTarget>], id: &str) -> Resu
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Preset {id} set as default in profile '{profile}'.").green()

--- a/src/commands/presets/mod.rs
+++ b/src/commands/presets/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Preset, PresetsApi};
 
@@ -62,26 +62,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Preset)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for preset in resp.presets {
-                    all_json.push(preset_to_json(&preset, include_profile, &profile));
-                    all_items.push((profile.clone(), preset));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for preset in resp.presets {
+            all_json.push(preset_to_json(&preset, include_profile, &profile));
+            all_items.push((profile.clone(), preset));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -135,25 +122,12 @@ pub async fn run_get(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -190,32 +164,19 @@ pub async fn run_create(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(preset) = resp.preset {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Created preset '{}' in profile '{profile}'.",
-                            preset.display_name()
-                        )
-                        .green()
-                    );
-                    all_results.push(preset_to_json(&preset, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(preset) = resp.preset {
+            eprintln!(
+                "{}",
+                format!(
+                    "Created preset '{}' in profile '{profile}'.",
+                    preset.display_name()
+                )
+                .green()
+            );
+            all_results.push(preset_to_json(&preset, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -244,26 +205,13 @@ pub async fn run_update(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated preset in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated preset in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -289,22 +237,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Preset {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Preset {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -321,22 +258,11 @@ pub async fn run_set_default(targets: &[Arc<ExecutionTarget>], id: &str) -> Resu
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Preset {id} set as default in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Preset {id} set as default in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/recording_rules/mod.rs
+++ b/src/commands/recording_rules/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -64,6 +64,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, RecordingRuleGroup)> = Vec::new();
     for (profile, result) in per_profile {
@@ -74,8 +76,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), group));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -136,6 +144,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -145,8 +155,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -208,6 +224,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -225,8 +243,14 @@ pub async fn run_create(
                     all_results.push(group_to_json(&group, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -268,6 +292,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -284,8 +310,14 @@ pub async fn run_update(
                     all_results.push(group_to_json(&group, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -319,14 +351,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Recording rule group {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())

--- a/src/commands/recording_rules/mod.rs
+++ b/src/commands/recording_rules/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{RecordingRuleGroup, RecordingRulesApi};
 
@@ -64,26 +64,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, RecordingRuleGroup)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for group in resp.groups {
-                    all_json.push(group_to_json(&group, include_profile, &profile));
-                    all_items.push((profile.clone(), group));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for group in resp.groups {
+            all_json.push(group_to_json(&group, include_profile, &profile));
+            all_items.push((profile.clone(), group));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -144,25 +131,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -224,33 +198,18 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(group) = resp.group {
-                    let name = group.display_name().to_string();
-                    let id = group.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Created recording rule group '{name}' (ID: {id}) in profile '{profile}'."
-                        )
-                        .green()
-                    );
-                    all_results.push(group_to_json(&group, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(group) = resp.group {
+            let name = group.display_name().to_string();
+            let id = group.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created recording rule group '{name}' (ID: {id}) in profile '{profile}'.")
+                    .green()
+            );
+            all_results.push(group_to_json(&group, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -292,32 +251,17 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(group) = resp.group {
-                    let name = group.display_name().to_string();
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Updated recording rule group '{name}' (ID: {id}) in profile '{profile}'."
-                        )
-                        .green()
-                    );
-                    all_results.push(group_to_json(&group, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(group) = resp.group {
+            let name = group.display_name().to_string();
+            eprintln!(
+                "{}",
+                format!("Updated recording rule group '{name}' (ID: {id}) in profile '{profile}'.")
+                    .green()
+            );
+            all_results.push(group_to_json(&group, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -351,22 +295,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Recording rule group {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Recording rule group {id} deleted in profile '{profile}'.").green()
+        );
     }
 
     Ok(())

--- a/src/commands/recording_rules/mod.rs
+++ b/src/commands/recording_rules/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{RecordingRuleGroup, RecordingRulesApi};
 
@@ -202,11 +202,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             let name = group.display_name().to_string();
-            let id = group.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created recording rule group '{name}' (ID: {id}) in profile '{profile}'.")
-                    .green()
+            render::print_created(
+                "Created",
+                "recording rule group",
+                Some(&name),
+                group.id.as_deref(),
+                &profile,
             );
             all_results.push(group_to_json(&group, include_profile, &profile));
         }

--- a/src/commands/recording_rules/mod.rs
+++ b/src/commands/recording_rules/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{RecordingRuleGroup, RecordingRulesApi};
 
@@ -66,7 +66,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, RecordingRuleGroup)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for group in resp.groups {
             all_json.push(group_to_json(&group, include_profile, &profile));
             all_items.push((profile.clone(), group));
@@ -132,7 +132,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -199,7 +199,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             let name = group.display_name().to_string();
             let id = group.id.as_deref().unwrap_or("unknown");
@@ -252,7 +252,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             let name = group.display_name().to_string();
             eprintln!(
@@ -295,7 +295,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Recording rule group {id} deleted in profile '{profile}'.").green()

--- a/src/commands/retentions/mod.rs
+++ b/src/commands/retentions/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
@@ -40,6 +40,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -49,8 +51,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -91,6 +99,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -101,8 +111,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -128,14 +144,22 @@ pub async fn run_activate(targets: &[Arc<ExecutionTarget>]) -> Result<()> {
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Retention activated in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())
@@ -152,6 +176,8 @@ pub async fn run_status(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -161,8 +187,14 @@ pub async fn run_status(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/retentions/mod.rs
+++ b/src/commands/retentions/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::RetentionsApi;
 
@@ -40,25 +40,12 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -99,26 +86,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated retention settings in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated retention settings in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -144,22 +118,11 @@ pub async fn run_activate(targets: &[Arc<ExecutionTarget>]) -> Result<()> {
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Retention activated in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Retention activated in profile '{profile}'.").green()
+        );
     }
 
     Ok(())
@@ -176,25 +139,12 @@ pub async fn run_status(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/retentions/mod.rs
+++ b/src/commands/retentions/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::RetentionsApi;
 

--- a/src/commands/retentions/mod.rs
+++ b/src/commands/retentions/mod.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::RetentionsApi;
 
@@ -41,7 +41,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -87,7 +87,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated retention settings in profile '{profile}'.").green()
@@ -118,7 +118,7 @@ pub async fn run_activate(targets: &[Arc<ExecutionTarget>]) -> Result<()> {
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Retention activated in profile '{profile}'.").green()
@@ -140,7 +140,7 @@ pub async fn run_status(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/commands/roles/api.rs
+++ b/src/commands/roles/api.rs
@@ -7,12 +7,37 @@ use crate::api_client::CxClient;
 
 // --- Response types ---
 
+/// The Roles API documents numeric IDs (e.g. `roleId: 101`) but some responses send them
+/// as strings; accept either so deserialization doesn't break on conforming responses.
+fn deserialize_opt_id_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IdValue {
+        String(String),
+        Number(i64),
+    }
+
+    Ok(
+        Option::<IdValue>::deserialize(deserializer)?.map(|v| match v {
+            IdValue::String(s) => s,
+            IdValue::Number(n) => n.to_string(),
+        }),
+    )
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomRole {
+    #[serde(default, deserialize_with = "deserialize_opt_id_string")]
     pub role_id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_opt_id_string")]
     pub parent_role_id: Option<String>,
     pub parent_role_name: Option<String>,
     #[serde(default)]
@@ -37,6 +62,7 @@ impl CustomRole {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemRole {
+    #[serde(default, deserialize_with = "deserialize_opt_id_string")]
     pub role_id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
@@ -81,6 +107,7 @@ pub struct GetCustomRoleResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRoleResponse {
+    #[serde(default, deserialize_with = "deserialize_opt_id_string")]
     pub id: Option<String>,
 }
 
@@ -213,6 +240,35 @@ mod tests {
         let json = json!({ "id": "201" });
         let resp: CreateRoleResponse = serde_json::from_value(json).unwrap();
         assert_eq!(resp.id, Some("201".to_string()));
+    }
+
+    #[test]
+    fn deserialize_numeric_ids() {
+        let json = json!({
+            "roles": [
+                {
+                    "roleId": 101,
+                    "name": "Developer",
+                    "parentRoleId": 1,
+                    "permissions": []
+                }
+            ]
+        });
+        let resp: ListCustomRolesResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.roles[0].role_id, Some("101".to_string()));
+        assert_eq!(resp.roles[0].parent_role_id, Some("1".to_string()));
+
+        let create_json = json!({ "id": 201 });
+        let resp: CreateRoleResponse = serde_json::from_value(create_json).unwrap();
+        assert_eq!(resp.id, Some("201".to_string()));
+
+        let system_json = json!({
+            "roles": [
+                { "roleId": 1, "name": "Admin", "permissions": ["*"] }
+            ]
+        });
+        let resp: ListSystemRolesResponse = serde_json::from_value(system_json).unwrap();
+        assert_eq!(resp.roles[0].role_id, Some("1".to_string()));
     }
 
     #[test]

--- a/src/commands/roles/api.rs
+++ b/src/commands/roles/api.rs
@@ -10,10 +10,10 @@ use crate::api_client::CxClient;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CustomRole {
-    pub role_id: Option<i64>,
+    pub role_id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
-    pub parent_role_id: Option<i64>,
+    pub parent_role_id: Option<String>,
     pub parent_role_name: Option<String>,
     #[serde(default)]
     pub permissions: Vec<String>,
@@ -37,7 +37,7 @@ impl CustomRole {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SystemRole {
-    pub role_id: Option<i64>,
+    pub role_id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
     #[serde(default)]
@@ -81,7 +81,7 @@ pub struct GetCustomRoleResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreateRoleResponse {
-    pub id: Option<i64>,
+    pub id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -147,7 +147,7 @@ mod tests {
         let json = json!({
             "roles": [
                 {
-                    "roleId": 101,
+                    "roleId": "101",
                     "name": "Developer",
                     "description": "Dev access",
                     "parentRoleName": "ReadOnly",
@@ -155,7 +155,7 @@ mod tests {
                     "teamId": 1234
                 },
                 {
-                    "roleId": 102,
+                    "roleId": "102",
                     "name": "Admin",
                     "permissions": []
                 }
@@ -181,7 +181,7 @@ mod tests {
         let json = json!({
             "roles": [
                 {
-                    "roleId": 1,
+                    "roleId": "1",
                     "name": "Admin",
                     "description": "Full access",
                     "permissions": ["*"]
@@ -199,7 +199,7 @@ mod tests {
     fn deserialize_get_custom_role() {
         let json = json!({
             "role": {
-                "roleId": 101,
+                "roleId": "101",
                 "name": "Developer",
                 "permissions": ["logs:read"]
             }
@@ -210,9 +210,9 @@ mod tests {
 
     #[test]
     fn deserialize_create_response() {
-        let json = json!({ "id": 201 });
+        let json = json!({ "id": "201" });
         let resp: CreateRoleResponse = serde_json::from_value(json).unwrap();
-        assert_eq!(resp.id, Some(201));
+        assert_eq!(resp.id, Some("201".to_string()));
     }
 
     #[test]

--- a/src/commands/roles/mod.rs
+++ b/src/commands/roles/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -74,6 +74,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, CustomRole)> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
@@ -82,8 +84,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), role));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -103,7 +111,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                 .map(|(profile, role)| {
                     vec![
                         profile.clone(),
-                        role.role_id.map(|id| id.to_string()).unwrap_or_default(),
+                        role.role_id.clone().unwrap_or_default(),
                         role.display_name().to_string(),
                         role.display_description().to_string(),
                         role.parent_role_name.clone().unwrap_or_default(),
@@ -146,6 +154,8 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
@@ -153,8 +163,14 @@ pub async fn run_get(
                     all_results.push(custom_role_to_json(&role, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -194,13 +210,12 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
-                let id = resp
-                    .id
-                    .map(|id| id.to_string())
-                    .unwrap_or_else(|| "unknown".to_string());
+                let id = resp.id.clone().unwrap_or_else(|| "unknown".to_string());
                 eprintln!(
                     "{}",
                     format!("Created custom role (ID: {id}) in profile '{profile}'.").green()
@@ -213,8 +228,14 @@ pub async fn run_create(
                 }
                 all_results.push(v);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -250,6 +271,8 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(val) => {
@@ -259,8 +282,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -287,14 +316,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Custom role {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -311,6 +348,8 @@ pub async fn run_system(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, SystemRole)> = Vec::new();
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(resp) => {
@@ -319,8 +358,14 @@ pub async fn run_system(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
                     all_items.push((profile.clone(), role));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -340,7 +385,7 @@ pub async fn run_system(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
                 .map(|(profile, role)| {
                     vec![
                         profile.clone(),
-                        role.role_id.map(|id| id.to_string()).unwrap_or_default(),
+                        role.role_id.clone().unwrap_or_default(),
                         role.display_name().to_string(),
                         role.display_description().to_string(),
                         role.permissions_count().to_string(),

--- a/src/commands/roles/mod.rs
+++ b/src/commands/roles/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{CustomRole, RolesApi, SystemRole};
 
@@ -74,24 +74,11 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, CustomRole)> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for role in resp.roles {
-                    all_json.push(custom_role_to_json(&role, include_profile, &profile));
-                    all_items.push((profile.clone(), role));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for role in resp.roles {
+            all_json.push(custom_role_to_json(&role, include_profile, &profile));
+            all_items.push((profile.clone(), role));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -154,23 +141,10 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(role) = resp.role {
-                    all_results.push(custom_role_to_json(&role, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(role) = resp.role {
+            all_results.push(custom_role_to_json(&role, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -210,32 +184,19 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                let id = resp.id.clone().unwrap_or_else(|| "unknown".to_string());
-                eprintln!(
-                    "{}",
-                    format!("Created custom role (ID: {id}) in profile '{profile}'.").green()
-                );
-                let mut v = json!({ "id": resp.id });
-                if targets.len() > 1 {
-                    if let Value::Object(ref mut m) = v {
-                        m.insert("profile".to_string(), Value::String(profile.to_string()));
-                    }
-                }
-                all_results.push(v);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+    for (profile, resp) in collect_successes(per_profile)? {
+        let id = resp.id.clone().unwrap_or_else(|| "unknown".to_string());
+        eprintln!(
+            "{}",
+            format!("Created custom role (ID: {id}) in profile '{profile}'.").green()
+        );
+        let mut v = json!({ "id": resp.id });
+        if targets.len() > 1 {
+            if let Value::Object(ref mut m) = v {
+                m.insert("profile".to_string(), Value::String(profile.to_string()));
             }
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(v);
     }
 
     match output {
@@ -271,25 +232,12 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated custom role in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated custom role in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -316,22 +264,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Custom role {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Custom role {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -348,24 +285,11 @@ pub async fn run_system(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, SystemRole)> = Vec::new();
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for role in resp.roles {
-                    all_json.push(system_role_to_json(&role, include_profile, &profile));
-                    all_items.push((profile.clone(), role));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for role in resp.roles {
+            all_json.push(system_role_to_json(&role, include_profile, &profile));
+            all_items.push((profile.clone(), role));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/roles/mod.rs
+++ b/src/commands/roles/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{CustomRole, RolesApi, SystemRole};
 
@@ -74,7 +74,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, CustomRole)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for role in resp.roles {
             all_json.push(custom_role_to_json(&role, include_profile, &profile));
             all_items.push((profile.clone(), role));
@@ -141,7 +141,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(role) = resp.role {
             all_results.push(custom_role_to_json(&role, include_profile, &profile));
         }
@@ -184,7 +184,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         let id = resp.id.clone().unwrap_or_else(|| "unknown".to_string());
         eprintln!(
             "{}",
@@ -232,7 +232,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated custom role in profile '{profile}'.").green()
@@ -264,7 +264,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Custom role {id} deleted in profile '{profile}'.").green()
@@ -285,7 +285,7 @@ pub async fn run_system(targets: &[Arc<ExecutionTarget>], output: OutputFormat) 
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, SystemRole)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for role in resp.roles {
             all_json.push(system_role_to_json(&role, include_profile, &profile));
             all_items.push((profile.clone(), role));

--- a/src/commands/roles/mod.rs
+++ b/src/commands/roles/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{CustomRole, RolesApi, SystemRole};
 
@@ -185,11 +185,7 @@ pub async fn run_create(
 
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
-        let id = resp.id.clone().unwrap_or_else(|| "unknown".to_string());
-        eprintln!(
-            "{}",
-            format!("Created custom role (ID: {id}) in profile '{profile}'.").green()
-        );
+        render::print_created("Created", "custom role", None, resp.id.as_deref(), &profile);
         let mut v = json!({ "id": resp.id });
         if targets.len() > 1 {
             if let Value::Object(ref mut m) = v {

--- a/src/commands/routers/mod.rs
+++ b/src/commands/routers/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Router, RoutersApi};
 

--- a/src/commands/routers/mod.rs
+++ b/src/commands/routers/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Router, RoutersApi};
 
@@ -57,7 +57,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Router)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for router in resp.routers {
             all_json.push(router_to_json(&router, include_profile, &profile));
             all_items.push((profile.clone(), router));
@@ -117,7 +117,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -162,7 +162,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(router) = resp.router {
             eprintln!(
                 "{}",
@@ -203,7 +203,7 @@ pub async fn run_update(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated router in profile '{profile}'.").green()
@@ -234,7 +234,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Router {id} deleted in profile '{profile}'.").green()
@@ -259,7 +259,7 @@ pub async fn run_validate_matcher(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
     match output {

--- a/src/commands/routers/mod.rs
+++ b/src/commands/routers/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -55,6 +55,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Router)> = Vec::new();
     for (profile, result) in per_profile {
@@ -65,8 +67,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), router));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -121,6 +129,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -130,8 +140,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -171,6 +187,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -187,8 +205,14 @@ pub async fn run_create(
                     all_results.push(router_to_json(&router, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -217,6 +241,8 @@ pub async fn run_update(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -227,8 +253,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -254,14 +286,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Router {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -281,12 +321,20 @@ pub async fn run_validate_matcher(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,

--- a/src/commands/routers/mod.rs
+++ b/src/commands/routers/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Router, RoutersApi};
 
@@ -55,26 +55,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Router)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for router in resp.routers {
-                    all_json.push(router_to_json(&router, include_profile, &profile));
-                    all_items.push((profile.clone(), router));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for router in resp.routers {
+            all_json.push(router_to_json(&router, include_profile, &profile));
+            all_items.push((profile.clone(), router));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -129,25 +116,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -187,32 +161,19 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(router) = resp.router {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Created router '{}' in profile '{profile}'.",
-                            router.display_name()
-                        )
-                        .green()
-                    );
-                    all_results.push(router_to_json(&router, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(router) = resp.router {
+            eprintln!(
+                "{}",
+                format!(
+                    "Created router '{}' in profile '{profile}'.",
+                    router.display_name()
+                )
+                .green()
+            );
+            all_results.push(router_to_json(&router, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -241,26 +202,13 @@ pub async fn run_update(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated router in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated router in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -286,22 +234,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Router {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Router {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -321,20 +258,9 @@ pub async fn run_validate_matcher(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,

--- a/src/commands/saml/mod.rs
+++ b/src/commands/saml/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::SamlApi;
 
@@ -45,25 +45,12 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -96,25 +83,12 @@ pub async fn run_sp_params(targets: &[Arc<ExecutionTarget>], output: OutputForma
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -153,26 +127,13 @@ pub async fn run_set_idp(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Set SAML IDP parameters in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Set SAML IDP parameters in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -201,25 +162,12 @@ pub async fn run_set_active(targets: &[Arc<ExecutionTarget>], active: bool) -> R
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => {
-                let status = if active { "activated" } else { "deactivated" };
-                eprintln!(
-                    "{}",
-                    format!("SAML {status} in profile '{profile}'.").green()
-                );
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        let status = if active { "activated" } else { "deactivated" };
+        eprintln!(
+            "{}",
+            format!("SAML {status} in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/saml/mod.rs
+++ b/src/commands/saml/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::SamlApi;
 

--- a/src/commands/saml/mod.rs
+++ b/src/commands/saml/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::SamlApi;
 
@@ -46,7 +46,7 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -84,7 +84,7 @@ pub async fn run_sp_params(targets: &[Arc<ExecutionTarget>], output: OutputForma
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -128,7 +128,7 @@ pub async fn run_set_idp(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Set SAML IDP parameters in profile '{profile}'.").green()
@@ -162,7 +162,7 @@ pub async fn run_set_active(targets: &[Arc<ExecutionTarget>], active: bool) -> R
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         let status = if active { "activated" } else { "deactivated" };
         eprintln!(
             "{}",

--- a/src/commands/saml/mod.rs
+++ b/src/commands/saml/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -45,6 +45,8 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -54,8 +56,14 @@ pub async fn run_get(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> 
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -88,6 +96,8 @@ pub async fn run_sp_params(targets: &[Arc<ExecutionTarget>], output: OutputForma
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -97,8 +107,14 @@ pub async fn run_sp_params(targets: &[Arc<ExecutionTarget>], output: OutputForma
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -137,6 +153,8 @@ pub async fn run_set_idp(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -147,8 +165,14 @@ pub async fn run_set_idp(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -177,6 +201,8 @@ pub async fn run_set_active(targets: &[Arc<ExecutionTarget>], active: bool) -> R
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => {
@@ -186,8 +212,14 @@ pub async fn run_set_active(targets: &[Arc<ExecutionTarget>], active: bool) -> R
                     format!("SAML {status} in profile '{profile}'.").green()
                 );
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/scopes/mod.rs
+++ b/src/commands/scopes/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Scope, ScopesApi};
 
@@ -188,10 +188,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(scope) = resp.scope {
             let name = scope.display_name().to_string();
-            let id = scope.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created scope '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "scope",
+                Some(&name),
+                scope.id.as_deref(),
+                &profile,
             );
             all_results.push(scope_to_json(&scope, targets.len() > 1, &profile));
         }

--- a/src/commands/scopes/mod.rs
+++ b/src/commands/scopes/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Scope, ScopesApi};
 
@@ -57,7 +57,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Scope)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for scope in resp.scopes {
             all_json.push(scope_to_json(&scope, include_profile, &profile));
             all_items.push((profile.clone(), scope));
@@ -134,7 +134,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if val.is_null() {
             eprintln!(
                 "{}",
@@ -185,7 +185,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(scope) = resp.scope {
             let name = scope.display_name().to_string();
             let id = scope.id.as_deref().unwrap_or("unknown");
@@ -227,7 +227,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated scope in profile '{profile}'.").green()
@@ -259,7 +259,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Scope {id} deleted in profile '{profile}'.").green()

--- a/src/commands/scopes/mod.rs
+++ b/src/commands/scopes/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Scope, ScopesApi};
 
@@ -55,26 +55,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Scope)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for scope in resp.scopes {
-                    all_json.push(scope_to_json(&scope, include_profile, &profile));
-                    all_items.push((profile.clone(), scope));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for scope in resp.scopes {
+            all_json.push(scope_to_json(&scope, include_profile, &profile));
+            all_items.push((profile.clone(), scope));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -146,31 +133,19 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) if val.is_null() => {
-                eprintln!(
-                    "{}",
-                    format!("Scope {id} not found in profile '{profile}'.").yellow()
-                );
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if val.is_null() {
+            eprintln!(
+                "{}",
+                format!("Scope {id} not found in profile '{profile}'.").yellow()
+            );
+        } else {
+            if include_profile {
+                render::tag_get_result(&mut val, &profile);
             }
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+            all_results.push(val);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -209,31 +184,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(scope) = resp.scope {
-                    let name = scope.display_name().to_string();
-                    let id = scope.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created scope '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(scope_to_json(&scope, targets.len() > 1, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(scope) = resp.scope {
+            let name = scope.display_name().to_string();
+            let id = scope.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created scope '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(scope_to_json(&scope, targets.len() > 1, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -265,26 +226,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated scope in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated scope in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -311,22 +259,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Scope {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Scope {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/scopes/mod.rs
+++ b/src/commands/scopes/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -55,6 +55,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Scope)> = Vec::new();
     for (profile, result) in per_profile {
@@ -65,8 +67,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), scope));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -138,6 +146,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -153,8 +163,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -193,6 +209,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -208,8 +226,14 @@ pub async fn run_create(
                     all_results.push(scope_to_json(&scope, targets.len() > 1, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -241,6 +265,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -251,8 +277,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -279,14 +311,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Scope {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/search_by_value/mod.rs
+++ b/src/commands/search_by_value/mod.rs
@@ -8,7 +8,7 @@ pub mod api;
 
 use crate::commands::dashboards::profiled_api_row_to_json;
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::SearchByValueResult;
 

--- a/src/commands/search_by_value/mod.rs
+++ b/src/commands/search_by_value/mod.rs
@@ -8,7 +8,7 @@ pub mod api;
 
 use crate::commands::dashboards::profiled_api_row_to_json;
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::SearchByValueResult;
 
@@ -30,7 +30,6 @@ pub async fn run(
     );
 
     let include_profile = targets.len() > 1;
-    let target_count = targets.len();
     let query_owned = query.to_string();
     let dataset_owned = dataset.to_string();
     let per_profile = fan_out(targets, |target| {
@@ -44,23 +43,11 @@ pub async fn run(
     })
     .await;
 
-    let mut error_count = 0usize;
     let mut all_results: Vec<(String, SearchByValueResult)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for r in resp.matches {
-                    all_results.push((profile.clone(), r));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for r in resp.matches {
+            all_results.push((profile.clone(), r));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     let json_rows: Vec<Value> = all_results

--- a/src/commands/search_by_value/mod.rs
+++ b/src/commands/search_by_value/mod.rs
@@ -8,7 +8,7 @@ pub mod api;
 
 use crate::commands::dashboards::profiled_api_row_to_json;
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::SearchByValueResult;
 
@@ -44,7 +44,7 @@ pub async fn run(
     .await;
 
     let mut all_results: Vec<(String, SearchByValueResult)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for r in resp.matches {
             all_results.push((profile.clone(), r));
         }

--- a/src/commands/search_fields/mod.rs
+++ b/src/commands/search_fields/mod.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::Value;
 
 use crate::commands::dataprime::semantic_search::{semantic_field_lookup, SemanticFieldResult};
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 
 pub async fn run(
@@ -35,24 +35,11 @@ pub async fn run(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<(String, SemanticFieldResult)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(results) => {
-                for r in results {
-                    all_results.push((profile.clone(), r));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, results) in collect_successes(per_profile)? {
+        for r in results {
+            all_results.push((profile.clone(), r));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/search_fields/mod.rs
+++ b/src/commands/search_fields/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::commands::dataprime::semantic_search::{semantic_field_lookup, SemanticFieldResult};
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 
 pub async fn run(
@@ -36,7 +36,7 @@ pub async fn run(
     .await;
 
     let mut all_results: Vec<(String, SemanticFieldResult)> = Vec::new();
-    for (profile, results) in collect_successes(per_profile)? {
+    for (profile, results) in report_errors_and_collect_successes(per_profile)? {
         for r in results {
             all_results.push((profile.clone(), r));
         }

--- a/src/commands/search_fields/mod.rs
+++ b/src/commands/search_fields/mod.rs
@@ -6,7 +6,7 @@ use serde_json::Value;
 
 use crate::commands::dataprime::semantic_search::{semantic_field_lookup, SemanticFieldResult};
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 
 pub async fn run(

--- a/src/commands/search_fields/mod.rs
+++ b/src/commands/search_fields/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::Value;
 
@@ -35,6 +35,8 @@ pub async fn run(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<(String, SemanticFieldResult)> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -43,8 +45,14 @@ pub async fn run(
                     all_results.push((profile.clone(), r));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/slos/mod.rs
+++ b/src/commands/slos/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Slo, SlosApi};
 
@@ -198,11 +198,7 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(slo) = resp.slo {
             let name = slo.display_name().to_string();
-            let id = slo.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created SLO '{name}' (ID: {id}) in profile '{profile}'.").green()
-            );
+            render::print_created("Created", "SLO", Some(&name), slo.id.as_deref(), &profile);
             all_results.push(slo_to_json(&slo, include_profile, &profile));
         } else {
             eprintln!(
@@ -249,11 +245,7 @@ pub async fn run_update(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(slo) = resp.slo {
             let name = slo.display_name().to_string();
-            let id = slo.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Updated SLO '{name}' (ID: {id}) in profile '{profile}'.").green()
-            );
+            render::print_created("Updated", "SLO", Some(&name), slo.id.as_deref(), &profile);
             all_results.push(slo_to_json(&slo, include_profile, &profile));
         } else {
             eprintln!(

--- a/src/commands/slos/mod.rs
+++ b/src/commands/slos/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -65,6 +65,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Slo)> = Vec::new();
     for (profile, result) in per_profile {
@@ -75,8 +77,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), slo));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -134,6 +142,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -143,8 +153,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -204,6 +220,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -224,8 +242,14 @@ pub async fn run_create(
                     );
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -261,6 +285,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -281,8 +307,14 @@ pub async fn run_update(
                     );
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -313,14 +345,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("SLO {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())

--- a/src/commands/slos/mod.rs
+++ b/src/commands/slos/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Slo, SlosApi};
 
@@ -65,26 +65,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Slo)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for slo in resp.slos {
-                    all_json.push(slo_to_json(&slo, include_profile, &profile));
-                    all_items.push((profile.clone(), slo));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for slo in resp.slos {
+            all_json.push(slo_to_json(&slo, include_profile, &profile));
+            all_items.push((profile.clone(), slo));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -142,25 +129,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -220,36 +194,22 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(slo) = resp.slo {
-                    let name = slo.display_name().to_string();
-                    let id = slo.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created SLO '{name}' (ID: {id}) in profile '{profile}'.").green()
-                    );
-                    all_results.push(slo_to_json(&slo, include_profile, &profile));
-                } else {
-                    eprintln!(
-                        "{}",
-                        format!("SLO created in profile '{profile}' but response was empty.")
-                            .yellow()
-                    );
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(slo) = resp.slo {
+            let name = slo.display_name().to_string();
+            let id = slo.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created SLO '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(slo_to_json(&slo, include_profile, &profile));
+        } else {
+            eprintln!(
+                "{}",
+                format!("SLO created in profile '{profile}' but response was empty.").yellow()
+            );
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -285,36 +245,22 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(slo) = resp.slo {
-                    let name = slo.display_name().to_string();
-                    let id = slo.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Updated SLO '{name}' (ID: {id}) in profile '{profile}'.").green()
-                    );
-                    all_results.push(slo_to_json(&slo, include_profile, &profile));
-                } else {
-                    eprintln!(
-                        "{}",
-                        format!("SLO updated in profile '{profile}' but response was empty.")
-                            .yellow()
-                    );
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(slo) = resp.slo {
+            let name = slo.display_name().to_string();
+            let id = slo.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Updated SLO '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(slo_to_json(&slo, include_profile, &profile));
+        } else {
+            eprintln!(
+                "{}",
+                format!("SLO updated in profile '{profile}' but response was empty.").yellow()
+            );
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -345,22 +291,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("SLO {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("SLO {id} deleted in profile '{profile}'.").green()
+        );
     }
 
     Ok(())

--- a/src/commands/slos/mod.rs
+++ b/src/commands/slos/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Slo, SlosApi};
 
@@ -67,7 +67,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Slo)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for slo in resp.slos {
             all_json.push(slo_to_json(&slo, include_profile, &profile));
             all_items.push((profile.clone(), slo));
@@ -130,7 +130,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -195,7 +195,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(slo) = resp.slo {
             let name = slo.display_name().to_string();
             let id = slo.id.as_deref().unwrap_or("unknown");
@@ -246,7 +246,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(slo) = resp.slo {
             let name = slo.display_name().to_string();
             let id = slo.id.as_deref().unwrap_or("unknown");
@@ -291,7 +291,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("SLO {id} deleted in profile '{profile}'.").green()

--- a/src/commands/suppression_rules/mod.rs
+++ b/src/commands/suppression_rules/mod.rs
@@ -69,6 +69,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, AlertSchedulerRule)> = Vec::new();
     for (profile, result) in per_profile {
@@ -79,8 +81,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), rule));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -136,6 +144,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -145,8 +155,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -184,6 +200,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -198,8 +216,14 @@ pub async fn run_create(
                     all_results.push(rule_to_json(&rule, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -235,6 +259,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -248,8 +274,14 @@ pub async fn run_update(
                     all_results.push(rule_to_json(&rule, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -283,14 +315,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], rule_id: &str) -> Resu
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Deleted rule {rule_id} in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())

--- a/src/commands/suppression_rules/mod.rs
+++ b/src/commands/suppression_rules/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{AlertSchedulerRule, AlertSchedulersApi};
 
@@ -69,26 +69,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, AlertSchedulerRule)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for rule in resp.alert_scheduler_rules {
-                    all_json.push(rule_to_json(&rule, include_profile, &profile));
-                    all_items.push((profile.clone(), rule));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for rule in resp.alert_scheduler_rules {
+            all_json.push(rule_to_json(&rule, include_profile, &profile));
+            all_items.push((profile.clone(), rule));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -144,25 +131,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -200,30 +174,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(rule) = resp.alert_scheduler_rule {
-                    let name = rule.name.as_deref().unwrap_or("<unnamed>");
-                    let id = rule.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created rule '{name}' (ID: {id}) in profile '{profile}'.").green()
-                    );
-                    all_results.push(rule_to_json(&rule, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(rule) = resp.alert_scheduler_rule {
+            let name = rule.name.as_deref().unwrap_or("<unnamed>");
+            let id = rule.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created rule '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(rule_to_json(&rule, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -259,29 +220,16 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(rule) = resp.alert_scheduler_rule {
-                    let name = rule.name.as_deref().unwrap_or("<unnamed>");
-                    eprintln!(
-                        "{}",
-                        format!("Updated rule '{name}' in profile '{profile}'.").green()
-                    );
-                    all_results.push(rule_to_json(&rule, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(rule) = resp.alert_scheduler_rule {
+            let name = rule.name.as_deref().unwrap_or("<unnamed>");
+            eprintln!(
+                "{}",
+                format!("Updated rule '{name}' in profile '{profile}'.").green()
+            );
+            all_results.push(rule_to_json(&rule, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -315,22 +263,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], rule_id: &str) -> Resu
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Deleted rule {rule_id} in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Deleted rule {rule_id} in profile '{profile}'.").green()
+        );
     }
 
     Ok(())

--- a/src/commands/suppression_rules/mod.rs
+++ b/src/commands/suppression_rules/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{AlertSchedulerRule, AlertSchedulersApi};
 
@@ -178,11 +178,7 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(rule) = resp.alert_scheduler_rule {
             let name = rule.name.as_deref().unwrap_or("<unnamed>");
-            let id = rule.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created rule '{name}' (ID: {id}) in profile '{profile}'.").green()
-            );
+            render::print_created("Created", "rule", Some(name), rule.id.as_deref(), &profile);
             all_results.push(rule_to_json(&rule, include_profile, &profile));
         }
     }

--- a/src/commands/suppression_rules/mod.rs
+++ b/src/commands/suppression_rules/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{AlertSchedulerRule, AlertSchedulersApi};
 
@@ -71,7 +71,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, AlertSchedulerRule)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for rule in resp.alert_scheduler_rules {
             all_json.push(rule_to_json(&rule, include_profile, &profile));
             all_items.push((profile.clone(), rule));
@@ -132,7 +132,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -175,7 +175,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(rule) = resp.alert_scheduler_rule {
             let name = rule.name.as_deref().unwrap_or("<unnamed>");
             let id = rule.id.as_deref().unwrap_or("unknown");
@@ -221,7 +221,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(rule) = resp.alert_scheduler_rule {
             let name = rule.name.as_deref().unwrap_or("<unnamed>");
             eprintln!(
@@ -263,7 +263,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], rule_id: &str) -> Resu
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Deleted rule {rule_id} in profile '{profile}'.").green()

--- a/src/commands/tco_policies/mod.rs
+++ b/src/commands/tco_policies/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -63,6 +63,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TcoPolicy)> = Vec::new();
     for (profile, result) in per_profile {
@@ -73,8 +75,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), policy));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -140,6 +148,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -149,8 +159,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -207,6 +223,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -222,8 +240,14 @@ pub async fn run_create(
                     all_results.push(policy_to_json(&policy, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -258,6 +282,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -273,8 +299,14 @@ pub async fn run_update(
                     all_results.push(policy_to_json(&policy, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -305,14 +337,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("TCO policy {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     Ok(())
@@ -335,6 +375,8 @@ pub async fn run_reorder(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -345,8 +387,14 @@ pub async fn run_reorder(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -379,12 +427,20 @@ pub async fn run_test(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(val) => all_results.push(val),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -415,6 +471,8 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -424,8 +482,14 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -466,6 +530,8 @@ pub async fn run_settings_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -476,8 +542,14 @@ pub async fn run_settings_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/tco_policies/mod.rs
+++ b/src/commands/tco_policies/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{TcoPoliciesApi, TcoPolicy};
 
@@ -201,10 +201,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(policy) = resp.policy {
             let name = policy.display_name().to_string();
-            let id = policy.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created TCO policy '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "TCO policy",
+                Some(&name),
+                policy.id.as_deref(),
+                &profile,
             );
             all_results.push(policy_to_json(&policy, include_profile, &profile));
         }
@@ -246,10 +248,12 @@ pub async fn run_update(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(policy) = resp.policy {
             let name = policy.display_name().to_string();
-            let id = policy.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Updated TCO policy '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Updated",
+                "TCO policy",
+                Some(&name),
+                policy.id.as_deref(),
+                &profile,
             );
             all_results.push(policy_to_json(&policy, include_profile, &profile));
         }

--- a/src/commands/tco_policies/mod.rs
+++ b/src/commands/tco_policies/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{TcoPoliciesApi, TcoPolicy};
 
@@ -63,26 +63,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TcoPolicy)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for policy in resp.policies {
-                    all_json.push(policy_to_json(&policy, include_profile, &profile));
-                    all_items.push((profile.clone(), policy));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for policy in resp.policies {
+            all_json.push(policy_to_json(&policy, include_profile, &profile));
+            all_items.push((profile.clone(), policy));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -148,25 +135,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -223,31 +197,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(policy) = resp.policy {
-                    let name = policy.display_name().to_string();
-                    let id = policy.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created TCO policy '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(policy_to_json(&policy, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(policy) = resp.policy {
+            let name = policy.display_name().to_string();
+            let id = policy.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created TCO policy '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(policy_to_json(&policy, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -282,31 +242,17 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(policy) = resp.policy {
-                    let name = policy.display_name().to_string();
-                    let id = policy.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Updated TCO policy '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(policy_to_json(&policy, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(policy) = resp.policy {
+            let name = policy.display_name().to_string();
+            let id = policy.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Updated TCO policy '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(policy_to_json(&policy, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -337,22 +283,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("TCO policy {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("TCO policy {id} deleted in profile '{profile}'.").green()
+        );
     }
 
     Ok(())
@@ -375,26 +310,13 @@ pub async fn run_reorder(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Reordered TCO policies in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Reordered TCO policies in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -427,20 +349,9 @@ pub async fn run_test(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => all_results.push(val),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (_profile, val) in collect_successes(per_profile)? {
+        all_results.push(val);
     }
 
     match output {
@@ -471,25 +382,12 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -530,26 +428,13 @@ pub async fn run_settings_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated TCO settings in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated TCO settings in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/tco_policies/mod.rs
+++ b/src/commands/tco_policies/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{TcoPoliciesApi, TcoPolicy};
 
@@ -65,7 +65,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TcoPolicy)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for policy in resp.policies {
             all_json.push(policy_to_json(&policy, include_profile, &profile));
             all_items.push((profile.clone(), policy));
@@ -136,7 +136,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -198,7 +198,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(policy) = resp.policy {
             let name = policy.display_name().to_string();
             let id = policy.id.as_deref().unwrap_or("unknown");
@@ -243,7 +243,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(policy) = resp.policy {
             let name = policy.display_name().to_string();
             let id = policy.id.as_deref().unwrap_or("unknown");
@@ -283,7 +283,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("TCO policy {id} deleted in profile '{profile}'.").green()
@@ -311,7 +311,7 @@ pub async fn run_reorder(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Reordered TCO policies in profile '{profile}'.").green()
@@ -350,7 +350,7 @@ pub async fn run_test(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (_profile, val) in collect_successes(per_profile)? {
+    for (_profile, val) in report_errors_and_collect_successes(per_profile)? {
         all_results.push(val);
     }
 
@@ -383,7 +383,7 @@ pub async fn run_settings(targets: &[Arc<ExecutionTarget>], output: OutputFormat
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -429,7 +429,7 @@ pub async fn run_settings_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated TCO settings in profile '{profile}'.").green()

--- a/src/commands/team_groups/api.rs
+++ b/src/commands/team_groups/api.rs
@@ -7,9 +7,33 @@ use crate::api_client::CxClient;
 
 // --- Response types ---
 
+/// The Team Groups API documents numeric IDs (e.g. `groupId: 101`) but some responses send
+/// them as strings; accept either so deserialization doesn't break on conforming responses.
+fn deserialize_opt_id_string<'de, D>(
+    deserializer: D,
+) -> std::result::Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum IdValue {
+        String(String),
+        Number(i64),
+    }
+
+    Ok(
+        Option::<IdValue>::deserialize(deserializer)?.map(|v| match v {
+            IdValue::String(s) => s,
+            IdValue::Number(n) => n.to_string(),
+        }),
+    )
+}
+
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeamGroup {
+    #[serde(default, deserialize_with = "deserialize_opt_id_string")]
     pub group_id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
@@ -69,6 +93,7 @@ pub struct UpdateTeamGroupResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteTeamGroupResponse {
+    #[serde(default, deserialize_with = "deserialize_opt_id_string")]
     pub group_id: Option<String>,
 }
 
@@ -223,6 +248,21 @@ mod tests {
     fn deserialize_delete_response() {
         let json = json!({ "groupId": "101" });
         let resp: DeleteTeamGroupResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.group_id, Some("101".to_string()));
+    }
+
+    #[test]
+    fn deserialize_numeric_group_ids() {
+        let json = json!({
+            "groups": [
+                { "groupId": 101, "name": "Engineering" }
+            ]
+        });
+        let resp: ListTeamGroupsResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.groups[0].group_id, Some("101".to_string()));
+
+        let delete_json = json!({ "groupId": 101 });
+        let resp: DeleteTeamGroupResponse = serde_json::from_value(delete_json).unwrap();
         assert_eq!(resp.group_id, Some("101".to_string()));
     }
 

--- a/src/commands/team_groups/api.rs
+++ b/src/commands/team_groups/api.rs
@@ -10,7 +10,7 @@ use crate::api_client::CxClient;
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TeamGroup {
-    pub group_id: Option<i64>,
+    pub group_id: Option<String>,
     pub name: Option<String>,
     pub description: Option<String>,
     pub team_id: Option<i64>,
@@ -69,7 +69,7 @@ pub struct UpdateTeamGroupResponse {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DeleteTeamGroupResponse {
-    pub group_id: Option<i64>,
+    pub group_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -147,14 +147,14 @@ mod tests {
         let json = json!({
             "groups": [
                 {
-                    "groupId": 101,
+                    "groupId": "101",
                     "name": "Engineering",
                     "description": "Eng team",
                     "teamId": 1234,
                     "createdAt": "2024-01-01T00:00:00Z"
                 },
                 {
-                    "groupId": 102,
+                    "groupId": "102",
                     "name": "DevOps"
                 }
             ],
@@ -180,7 +180,7 @@ mod tests {
     fn deserialize_get_response() {
         let json = json!({
             "group": {
-                "groupId": 101,
+                "groupId": "101",
                 "name": "Engineering",
                 "description": "Eng team"
             }
@@ -193,7 +193,7 @@ mod tests {
     fn deserialize_get_by_name_response() {
         let json = json!({
             "group": {
-                "groupId": 101,
+                "groupId": "101",
                 "name": "Engineering"
             }
         });
@@ -204,16 +204,16 @@ mod tests {
     #[test]
     fn deserialize_create_response() {
         let json = json!({
-            "group": { "groupId": 201, "name": "New Group" }
+            "group": { "groupId": "201", "name": "New Group" }
         });
         let resp: CreateTeamGroupResponse = serde_json::from_value(json).unwrap();
-        assert_eq!(resp.group.unwrap().group_id, Some(201));
+        assert_eq!(resp.group.unwrap().group_id, Some("201".to_string()));
     }
 
     #[test]
     fn deserialize_update_response() {
         let json = json!({
-            "group": { "groupId": 101, "name": "Updated Group" }
+            "group": { "groupId": "101", "name": "Updated Group" }
         });
         let resp: UpdateTeamGroupResponse = serde_json::from_value(json).unwrap();
         assert_eq!(resp.group.unwrap().display_name(), "Updated Group");
@@ -221,9 +221,9 @@ mod tests {
 
     #[test]
     fn deserialize_delete_response() {
-        let json = json!({ "groupId": 101 });
+        let json = json!({ "groupId": "101" });
         let resp: DeleteTeamGroupResponse = serde_json::from_value(json).unwrap();
-        assert_eq!(resp.group_id, Some(101));
+        assert_eq!(resp.group_id, Some("101".to_string()));
     }
 
     #[test]

--- a/src/commands/team_groups/mod.rs
+++ b/src/commands/team_groups/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{TeamGroup, TeamGroupsApi};
 
@@ -295,13 +295,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             let name = group.display_name().to_string();
-            let id = group
-                .group_id
-                .clone()
-                .unwrap_or_else(|| "unknown".to_string());
-            eprintln!(
-                "{}",
-                format!("Created team group '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "team group",
+                Some(&name),
+                group.group_id.as_deref(),
+                &profile,
             );
             all_results.push(group_to_json(&group, include_profile, &profile));
         }

--- a/src/commands/team_groups/mod.rs
+++ b/src/commands/team_groups/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -56,6 +56,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
     for (profile, result) in per_profile {
@@ -66,8 +68,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), group));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -87,7 +95,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                 .map(|(profile, group)| {
                     vec![
                         profile.clone(),
-                        group.group_id.map(|id| id.to_string()).unwrap_or_default(),
+                        group.group_id.clone().unwrap_or_default(),
                         group.display_name().to_string(),
                         String::new(), // Members count not available in list response
                         group.display_description().to_string(),
@@ -122,6 +130,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
     for (profile, result) in per_profile {
@@ -132,8 +142,14 @@ pub async fn run_get(
                     all_items.push((profile.clone(), group));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -153,7 +169,7 @@ pub async fn run_get(
                 .map(|(profile, group)| {
                     vec![
                         profile.clone(),
-                        group.group_id.map(|id| id.to_string()).unwrap_or_default(),
+                        group.group_id.clone().unwrap_or_default(),
                         group.display_name().to_string(),
                         group.display_description().to_string(),
                         group.group_type.clone().unwrap_or_default(),
@@ -191,6 +207,8 @@ pub async fn run_get_by_name(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
     for (profile, result) in per_profile {
@@ -201,8 +219,14 @@ pub async fn run_get_by_name(
                     all_items.push((profile.clone(), group));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -222,7 +246,7 @@ pub async fn run_get_by_name(
                 .map(|(profile, group)| {
                     vec![
                         profile.clone(),
-                        group.group_id.map(|id| id.to_string()).unwrap_or_default(),
+                        group.group_id.clone().unwrap_or_default(),
                         group.display_name().to_string(),
                         group.display_description().to_string(),
                         group.group_type.clone().unwrap_or_default(),
@@ -261,6 +285,8 @@ pub async fn run_users(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -270,8 +296,14 @@ pub async fn run_users(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -311,6 +343,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -319,7 +353,7 @@ pub async fn run_create(
                     let name = group.display_name().to_string();
                     let id = group
                         .group_id
-                        .map(|id| id.to_string())
+                        .clone()
                         .unwrap_or_else(|| "unknown".to_string());
                     eprintln!(
                         "{}",
@@ -329,8 +363,14 @@ pub async fn run_create(
                     all_results.push(group_to_json(&group, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -365,6 +405,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -377,8 +419,14 @@ pub async fn run_update(
                     all_results.push(group_to_json(&group, targets.len() > 1, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -405,14 +453,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], group_id: &str) -> Res
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Team group {group_id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/team_groups/mod.rs
+++ b/src/commands/team_groups/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{TeamGroup, TeamGroupsApi};
 
@@ -58,7 +58,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for group in resp.groups {
             all_json.push(group_to_json(&group, include_profile, &profile));
             all_items.push((profile.clone(), group));
@@ -119,7 +119,7 @@ pub async fn run_get(
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             all_json.push(group_to_json(&group, include_profile, &profile));
             all_items.push((profile.clone(), group));
@@ -183,7 +183,7 @@ pub async fn run_get_by_name(
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             all_json.push(group_to_json(&group, include_profile, &profile));
             all_items.push((profile.clone(), group));
@@ -247,7 +247,7 @@ pub async fn run_users(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -292,7 +292,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             let name = group.display_name().to_string();
             let id = group
@@ -340,7 +340,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(group) = resp.group {
             eprintln!(
                 "{}",
@@ -374,7 +374,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], group_id: &str) -> Res
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Team group {group_id} deleted in profile '{profile}'.").green()

--- a/src/commands/team_groups/mod.rs
+++ b/src/commands/team_groups/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{TeamGroup, TeamGroupsApi};
 
@@ -56,26 +56,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for group in resp.groups {
-                    all_json.push(group_to_json(&group, include_profile, &profile));
-                    all_items.push((profile.clone(), group));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for group in resp.groups {
+            all_json.push(group_to_json(&group, include_profile, &profile));
+            all_items.push((profile.clone(), group));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -130,26 +117,13 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(group) = resp.group {
-                    all_json.push(group_to_json(&group, include_profile, &profile));
-                    all_items.push((profile.clone(), group));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(group) = resp.group {
+            all_json.push(group_to_json(&group, include_profile, &profile));
+            all_items.push((profile.clone(), group));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -207,26 +181,13 @@ pub async fn run_get_by_name(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, TeamGroup)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(group) = resp.group {
-                    all_json.push(group_to_json(&group, include_profile, &profile));
-                    all_items.push((profile.clone(), group));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(group) = resp.group {
+            all_json.push(group_to_json(&group, include_profile, &profile));
+            all_items.push((profile.clone(), group));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -285,25 +246,12 @@ pub async fn run_users(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -343,34 +291,20 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(group) = resp.group {
-                    let name = group.display_name().to_string();
-                    let id = group
-                        .group_id
-                        .clone()
-                        .unwrap_or_else(|| "unknown".to_string());
-                    eprintln!(
-                        "{}",
-                        format!("Created team group '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(group_to_json(&group, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(group) = resp.group {
+            let name = group.display_name().to_string();
+            let id = group
+                .group_id
+                .clone()
+                .unwrap_or_else(|| "unknown".to_string());
+            eprintln!(
+                "{}",
+                format!("Created team group '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(group_to_json(&group, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -405,28 +339,15 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(group) = resp.group {
-                    eprintln!(
-                        "{}",
-                        format!("Updated team group in profile '{profile}'.").green()
-                    );
-                    all_results.push(group_to_json(&group, targets.len() > 1, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(group) = resp.group {
+            eprintln!(
+                "{}",
+                format!("Updated team group in profile '{profile}'.").green()
+            );
+            all_results.push(group_to_json(&group, targets.len() > 1, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -453,22 +374,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], group_id: &str) -> Res
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Team group {group_id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Team group {group_id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/users/mod.rs
+++ b/src/commands/users/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{User, UsersApi};
 
@@ -92,26 +92,13 @@ pub async fn run_search(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, User)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for user in resp.users {
-                    all_json.push(user_to_json(&user, include_profile, &profile));
-                    all_items.push((profile.clone(), user));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for user in resp.users {
+            all_json.push(user_to_json(&user, include_profile, &profile));
+            all_items.push((profile.clone(), user));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -169,25 +156,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -229,24 +203,11 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => {
-                eprintln!(
-                    "{}",
-                    format!("Created user(s) in profile '{profile}'.").green()
-                );
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Created user(s) in profile '{profile}'.").green()
+        );
     }
 
     match output {
@@ -274,36 +235,23 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                eprintln!(
-                    "{}",
-                    format!(
-                        "Updated {} user(s) in profile '{profile}'.",
-                        resp.user_account_ids.len()
-                    )
-                    .green()
-                );
-                let mut v = json!({ "user_account_ids": resp.user_account_ids });
-                if targets.len() > 1 {
-                    if let Value::Object(ref mut m) = v {
-                        m.insert("profile".to_string(), Value::String(profile.to_string()));
-                    }
-                }
-                all_results.push(v);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+    for (profile, resp) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!(
+                "Updated {} user(s) in profile '{profile}'.",
+                resp.user_account_ids.len()
+            )
+            .green()
+        );
+        let mut v = json!({ "user_account_ids": resp.user_account_ids });
+        if targets.len() > 1 {
+            if let Value::Object(ref mut m) = v {
+                m.insert("profile".to_string(), Value::String(profile.to_string()));
             }
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(v);
     }
 
     match output {
@@ -345,22 +293,11 @@ pub async fn run_set_status(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Updated user status in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated user status in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/users/mod.rs
+++ b/src/commands/users/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -92,6 +92,8 @@ pub async fn run_search(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, User)> = Vec::new();
     for (profile, result) in per_profile {
@@ -102,8 +104,14 @@ pub async fn run_search(
                     all_items.push((profile.clone(), user));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -161,6 +169,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -170,8 +180,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -213,6 +229,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => {
@@ -221,8 +239,14 @@ pub async fn run_create(
                     format!("Created user(s) in profile '{profile}'.").green()
                 );
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -250,6 +274,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -270,8 +296,14 @@ pub async fn run_update(
                 }
                 all_results.push(v);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -313,14 +345,22 @@ pub async fn run_set_status(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Updated user status in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/users/mod.rs
+++ b/src/commands/users/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{User, UsersApi};
 

--- a/src/commands/users/mod.rs
+++ b/src/commands/users/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{User, UsersApi};
 
@@ -94,7 +94,7 @@ pub async fn run_search(
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, User)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for user in resp.users {
             all_json.push(user_to_json(&user, include_profile, &profile));
             all_items.push((profile.clone(), user));
@@ -157,7 +157,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -203,7 +203,7 @@ pub async fn run_create(
     })
     .await;
 
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Created user(s) in profile '{profile}'.").green()
@@ -236,7 +236,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!(
@@ -293,7 +293,7 @@ pub async fn run_set_status(
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated user status in profile '{profile}'.").green()

--- a/src/commands/views/mod.rs
+++ b/src/commands/views/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -65,6 +65,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
         Ok(api.list().await?)
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, View)> = Vec::new();
     for (profile, result) in per_profile {
@@ -75,8 +77,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), view));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -124,6 +132,8 @@ pub async fn run_get(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -133,8 +143,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -171,6 +187,8 @@ pub async fn run_create(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -187,8 +205,14 @@ pub async fn run_create(
                     all_results.push(view_to_json(&view, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -220,6 +244,8 @@ pub async fn run_update(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -230,8 +256,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -257,14 +289,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("View {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -282,6 +322,8 @@ pub async fn run_folders_list(
         Ok(api.list_folders().await?)
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, ViewFolder)> = Vec::new();
     for (profile, result) in per_profile {
@@ -292,8 +334,14 @@ pub async fn run_folders_list(
                     all_items.push((profile.clone(), folder));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -340,6 +388,8 @@ pub async fn run_folders_get(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -349,8 +399,14 @@ pub async fn run_folders_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -387,6 +443,8 @@ pub async fn run_folders_create(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -403,8 +461,14 @@ pub async fn run_folders_create(
                     all_results.push(folder_to_json(&folder, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -436,6 +500,8 @@ pub async fn run_folders_update(
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -446,8 +512,14 @@ pub async fn run_folders_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -473,14 +545,22 @@ pub async fn run_folders_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> R
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Folder {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }

--- a/src/commands/views/mod.rs
+++ b/src/commands/views/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{View, ViewFolder, ViewsApi};
 

--- a/src/commands/views/mod.rs
+++ b/src/commands/views/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{View, ViewFolder, ViewsApi};
 
@@ -67,7 +67,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     .await;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, View)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for view in resp.views {
             all_json.push(view_to_json(&view, include_profile, &profile));
             all_items.push((profile.clone(), view));
@@ -120,7 +120,7 @@ pub async fn run_get(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -162,7 +162,7 @@ pub async fn run_create(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(view) = resp.view {
             eprintln!(
                 "{}",
@@ -206,7 +206,7 @@ pub async fn run_update(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated view in profile '{profile}'.").green()
@@ -237,7 +237,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("View {id} deleted in profile '{profile}'.").green()
@@ -261,7 +261,7 @@ pub async fn run_folders_list(
     .await;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, ViewFolder)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for folder in resp.folders {
             all_json.push(folder_to_json(&folder, include_profile, &profile));
             all_items.push((profile.clone(), folder));
@@ -313,7 +313,7 @@ pub async fn run_folders_get(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -355,7 +355,7 @@ pub async fn run_folders_create(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(folder) = resp.folder {
             eprintln!(
                 "{}",
@@ -399,7 +399,7 @@ pub async fn run_folders_update(
     })
     .await;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated folder in profile '{profile}'.").green()
@@ -430,7 +430,7 @@ pub async fn run_folders_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> R
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Folder {id} deleted in profile '{profile}'.").green()

--- a/src/commands/views/mod.rs
+++ b/src/commands/views/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{View, ViewFolder, ViewsApi};
 
@@ -65,26 +65,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
         Ok(api.list().await?)
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, View)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for view in resp.views {
-                    all_json.push(view_to_json(&view, include_profile, &profile));
-                    all_items.push((profile.clone(), view));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for view in resp.views {
+            all_json.push(view_to_json(&view, include_profile, &profile));
+            all_items.push((profile.clone(), view));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -132,25 +119,12 @@ pub async fn run_get(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -187,32 +161,19 @@ pub async fn run_create(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(view) = resp.view {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Created view '{}' in profile '{profile}'.",
-                            view.display_name()
-                        )
-                        .green()
-                    );
-                    all_results.push(view_to_json(&view, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(view) = resp.view {
+            eprintln!(
+                "{}",
+                format!(
+                    "Created view '{}' in profile '{profile}'.",
+                    view.display_name()
+                )
+                .green()
+            );
+            all_results.push(view_to_json(&view, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -244,26 +205,13 @@ pub async fn run_update(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated view in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated view in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -289,22 +237,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("View {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("View {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -322,26 +259,13 @@ pub async fn run_folders_list(
         Ok(api.list_folders().await?)
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, ViewFolder)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for folder in resp.folders {
-                    all_json.push(folder_to_json(&folder, include_profile, &profile));
-                    all_items.push((profile.clone(), folder));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for folder in resp.folders {
+            all_json.push(folder_to_json(&folder, include_profile, &profile));
+            all_items.push((profile.clone(), folder));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json(&all_json)?,
@@ -388,25 +312,12 @@ pub async fn run_folders_get(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -443,32 +354,19 @@ pub async fn run_folders_create(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(folder) = resp.folder {
-                    eprintln!(
-                        "{}",
-                        format!(
-                            "Created folder '{}' in profile '{profile}'.",
-                            folder.display_name()
-                        )
-                        .green()
-                    );
-                    all_results.push(folder_to_json(&folder, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(folder) = resp.folder {
+            eprintln!(
+                "{}",
+                format!(
+                    "Created folder '{}' in profile '{profile}'.",
+                    folder.display_name()
+                )
+                .green()
+            );
+            all_results.push(folder_to_json(&folder, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -500,26 +398,13 @@ pub async fn run_folders_update(
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated folder in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated folder in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
     match output {
         OutputFormat::Json => render::render_json_auto(&all_results)?,
@@ -545,22 +430,11 @@ pub async fn run_folders_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> R
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Folder {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Folder {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }

--- a/src/commands/webhooks/mod.rs
+++ b/src/commands/webhooks/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 use api::{Webhook, WebhooksApi};
 
@@ -166,10 +166,12 @@ pub async fn run_create(
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(webhook) = resp.webhook {
             let name = webhook.name.clone().unwrap_or_default();
-            let id = webhook.id.as_deref().unwrap_or("unknown");
-            eprintln!(
-                "{}",
-                format!("Created webhook '{name}' (ID: {id}) in profile '{profile}'.").green()
+            render::print_created(
+                "Created",
+                "webhook",
+                Some(&name),
+                webhook.id.as_deref(),
+                &profile,
             );
             all_results.push(webhook_to_json(&webhook, include_profile, &profile));
         }

--- a/src/commands/webhooks/mod.rs
+++ b/src/commands/webhooks/mod.rs
@@ -2,7 +2,7 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -55,6 +55,8 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Webhook)> = Vec::new();
     for (profile, result) in per_profile {
@@ -65,8 +67,14 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
                     all_items.push((profile.clone(), webhook));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -122,6 +130,8 @@ pub async fn run_get(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -131,8 +141,14 @@ pub async fn run_get(
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -172,6 +188,8 @@ pub async fn run_create(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -187,8 +205,14 @@ pub async fn run_create(
                     all_results.push(webhook_to_json(&webhook, include_profile, &profile));
                 }
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -223,6 +247,8 @@ pub async fn run_update(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -233,8 +259,14 @@ pub async fn run_update(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -261,14 +293,22 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(()) => eprintln!(
                 "{}",
                 format!("Webhook {id} deleted in profile '{profile}'.").green()
             ),
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
     Ok(())
 }
@@ -290,6 +330,8 @@ pub async fn run_test(
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -300,8 +342,14 @@ pub async fn run_test(
                 );
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -330,6 +378,8 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
 
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
     for (profile, result) in per_profile {
         match result {
@@ -339,8 +389,14 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
                 }
                 all_results.push(val);
             }
-            Err(e) => eprintln!("{}", format!("error from profile '{profile}': {e:#}").red()),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
     }
 
     match output {

--- a/src/commands/webhooks/mod.rs
+++ b/src/commands/webhooks/mod.rs
@@ -2,13 +2,13 @@ pub mod api;
 
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::Result;
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Webhook, WebhooksApi};
 
@@ -55,26 +55,13 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Webhook)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for webhook in resp.deployed {
-                    all_json.push(webhook_to_json(&webhook, include_profile, &profile));
-                    all_items.push((profile.clone(), webhook));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        for webhook in resp.deployed {
+            all_json.push(webhook_to_json(&webhook, include_profile, &profile));
+            all_items.push((profile.clone(), webhook));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -130,25 +117,12 @@ pub async fn run_get(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {
@@ -188,31 +162,17 @@ pub async fn run_create(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                if let Some(webhook) = resp.webhook {
-                    let name = webhook.name.clone().unwrap_or_default();
-                    let id = webhook.id.as_deref().unwrap_or("unknown");
-                    eprintln!(
-                        "{}",
-                        format!("Created webhook '{name}' (ID: {id}) in profile '{profile}'.")
-                            .green()
-                    );
-                    all_results.push(webhook_to_json(&webhook, include_profile, &profile));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, resp) in collect_successes(per_profile)? {
+        if let Some(webhook) = resp.webhook {
+            let name = webhook.name.clone().unwrap_or_default();
+            let id = webhook.id.as_deref().unwrap_or("unknown");
+            eprintln!(
+                "{}",
+                format!("Created webhook '{name}' (ID: {id}) in profile '{profile}'.").green()
+            );
+            all_results.push(webhook_to_json(&webhook, include_profile, &profile));
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -247,26 +207,13 @@ pub async fn run_update(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Updated webhook {id} in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Updated webhook {id} in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -293,22 +240,11 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    for (profile, result) in per_profile {
-        match result {
-            Ok(()) => eprintln!(
-                "{}",
-                format!("Webhook {id} deleted in profile '{profile}'.").green()
-            ),
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, ()) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Webhook {id} deleted in profile '{profile}'.").green()
+        );
     }
     Ok(())
 }
@@ -330,26 +266,13 @@ pub async fn run_test(
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(val) => {
-                eprintln!(
-                    "{}",
-                    format!("Test completed in profile '{profile}'.").green()
-                );
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    for (profile, val) in collect_successes(per_profile)? {
+        eprintln!(
+            "{}",
+            format!("Test completed in profile '{profile}'.").green()
+        );
+        all_results.push(val);
     }
 
     match output {
@@ -378,25 +301,12 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(mut val) => {
-                if include_profile {
-                    render::tag_get_result(&mut val, &profile);
-                }
-                all_results.push(val);
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+    for (profile, mut val) in collect_successes(per_profile)? {
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+        all_results.push(val);
     }
 
     match output {

--- a/src/commands/webhooks/mod.rs
+++ b/src/commands/webhooks/mod.rs
@@ -8,7 +8,7 @@ use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
 
 use crate::config::OutputFormat;
-use crate::execution::{collect_successes, fan_out, ExecutionTarget};
+use crate::execution::{report_errors_and_collect_successes, fan_out, ExecutionTarget};
 use crate::render;
 use api::{Webhook, WebhooksApi};
 
@@ -57,7 +57,7 @@ pub async fn run_list(targets: &[Arc<ExecutionTarget>], output: OutputFormat) ->
 
     let mut all_json: Vec<Value> = Vec::new();
     let mut all_items: Vec<(String, Webhook)> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         for webhook in resp.deployed {
             all_json.push(webhook_to_json(&webhook, include_profile, &profile));
             all_items.push((profile.clone(), webhook));
@@ -118,7 +118,7 @@ pub async fn run_get(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }
@@ -163,7 +163,7 @@ pub async fn run_create(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in collect_successes(per_profile)? {
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         if let Some(webhook) = resp.webhook {
             let name = webhook.name.clone().unwrap_or_default();
             let id = webhook.id.as_deref().unwrap_or("unknown");
@@ -208,7 +208,7 @@ pub async fn run_update(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Updated webhook {id} in profile '{profile}'.").green()
@@ -240,7 +240,7 @@ pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()
         }
     })
     .await;
-    for (profile, ()) in collect_successes(per_profile)? {
+    for (profile, ()) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Webhook {id} deleted in profile '{profile}'.").green()
@@ -267,7 +267,7 @@ pub async fn run_test(
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, val) in collect_successes(per_profile)? {
+    for (profile, val) in report_errors_and_collect_successes(per_profile)? {
         eprintln!(
             "{}",
             format!("Test completed in profile '{profile}'.").green()
@@ -302,7 +302,7 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     .await;
 
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, mut val) in collect_successes(per_profile)? {
+    for (profile, mut val) in report_errors_and_collect_successes(per_profile)? {
         if include_profile {
             render::tag_get_result(&mut val, &profile);
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,9 @@ pub enum CxError {
 
     #[error("I/O error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("Query stream error: {0}")]
+    QueryStream(String),
 }
 
 pub type Result<T> = std::result::Result<T, CxError>;

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -83,16 +83,34 @@ pub fn report_errors_and_collect_successes<T>(
 ) -> Result<Vec<(String, T)>> {
     let target_count = per_profile.len();
     let mut successes = Vec::with_capacity(target_count);
+    let mut errors: Vec<(String, anyhow::Error)> = Vec::new();
     for (profile, result) in per_profile {
         match result {
             Ok(v) => successes.push((profile, v)),
-            Err(e) => {
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
+            Err(e) => errors.push((profile, e)),
         }
     }
+
+    // Total failure: surface as an error instead of a silently empty result
+    // (FORGE-482).
     if successes.is_empty() && target_count > 0 {
-        bail!("all profiles returned errors");
+        // With a single target there is nothing to aggregate - propagate its
+        // actual error so the user sees the real cause, not a generic
+        // "all profiles failed" line stacked on top of the printed error.
+        if let [_] = errors.as_slice() {
+            let (profile, e) = errors.into_iter().next().expect("one error present");
+            return Err(e.context(format!("profile '{profile}' failed")));
+        }
+        for (profile, e) in &errors {
+            eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+        }
+        bail!("all {target_count} profiles returned errors");
+    }
+
+    // Partial failure: report the failed profiles and return the survivors,
+    // per docs/multi-profile.md.
+    for (profile, e) in errors {
+        eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
     }
     Ok(successes)
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -8,9 +8,9 @@
 use std::future::Future;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
+use colored::Colorize;
 use futures::future::join_all;
-use serde_json::Value;
 
 use crate::api_client::CxClient;
 use crate::config::ResolvedConfig;
@@ -68,43 +68,33 @@ where
     join_all(futures).await
 }
 
-// ── Row tagging ───────────────────────────────────────────────────────────────
+// ── Error collection ──────────────────────────────────────────────────────────
 
-/// Inject a `"profile"` key into each JSON object row when `include_profile` is true.
+/// Drain per-profile fan-out results: print every failure to stderr in the
+/// standard red format, and return the successful `(profile, value)` pairs in
+/// input order.
 ///
-/// Non-object values are passed through unchanged so callers don't need to
-/// guard against unexpected shapes.
-pub fn tag_rows(rows: Vec<Value>, profile: &str, include_profile: bool) -> Vec<Value> {
-    if !include_profile {
-        return rows;
-    }
-    rows.into_iter()
-        .map(|mut row| {
-            if let Value::Object(ref mut m) = row {
-                m.insert("profile".to_string(), Value::String(profile.to_string()));
-            }
-            row
-        })
-        .collect()
-}
-
-/// Merge per-profile results into a single flat list of optionally tagged rows.
-///
-/// Errors are printed to stderr; successful results are tagged with
-/// their source `profile_name` (when `include_profile` is true) and appended
-/// in profile order.
-pub fn merge_tagged_results(
-    per_profile: Vec<(String, Result<Vec<Value>>)>,
-    include_profile: bool,
-) -> Vec<Value> {
-    let mut all: Vec<Value> = Vec::new();
+/// Bails when there was at least one target and *all* of them failed, so a
+/// total failure surfaces as an error instead of rendering as a silently
+/// empty result (FORGE-482). Partial failure (some targets ok) returns `Ok`
+/// with the survivors - behavior per docs/multi-profile.md is unchanged.
+pub fn collect_successes<T>(per_profile: Vec<(String, Result<T>)>) -> Result<Vec<(String, T)>> {
+    let target_count = per_profile.len();
+    let mut successes = Vec::with_capacity(target_count);
+    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
-            Ok(rows) => all.extend(tag_rows(rows, &profile, include_profile)),
-            Err(e) => eprintln!("error from profile '{profile}': {e:#}"),
+            Ok(v) => successes.push((profile, v)),
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
         }
     }
-    all
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
+    }
+    Ok(successes)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -112,81 +102,49 @@ pub fn merge_tagged_results(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
 
     #[test]
-    fn tag_rows_injects_profile_key_when_enabled() {
-        let rows = vec![
-            json!({"timestamp": "2024-01-01T00:00:00Z", "message": "hello"}),
-            json!({"timestamp": "2024-01-01T00:00:01Z", "message": "world"}),
-        ];
-        let tagged = tag_rows(rows, "prod", true);
-        for row in &tagged {
-            assert_eq!(row["profile"], json!("prod"));
-        }
+    fn collect_successes_returns_all_when_none_fail() {
+        let per_profile: Vec<(String, Result<i32>)> =
+            vec![("prod".to_string(), Ok(1)), ("staging".to_string(), Ok(2))];
+        let successes = collect_successes(per_profile).expect("should not bail");
+        assert_eq!(
+            successes,
+            vec![("prod".to_string(), 1), ("staging".to_string(), 2)]
+        );
     }
 
     #[test]
-    fn tag_rows_skips_profile_when_disabled() {
-        let rows = vec![json!({"timestamp": "2024-01-01T00:00:00Z", "message": "hello"})];
-        let tagged = tag_rows(rows.clone(), "prod", false);
-        assert!(tagged[0].get("profile").is_none());
-        assert_eq!(tagged[0]["message"], json!("hello"));
-    }
-
-    #[test]
-    fn tag_rows_passes_non_object_values_through() {
-        let rows = vec![json!("plain string"), json!(42)];
-        let tagged = tag_rows(rows.clone(), "p", true);
-        assert_eq!(tagged[0], json!("plain string"));
-        assert_eq!(tagged[1], json!(42));
-    }
-
-    #[test]
-    fn merge_tagged_results_combines_rows_with_profile_when_enabled() {
-        let per_profile = vec![
-            (
-                "prod".to_string(),
-                Ok(vec![json!({"a": 1}), json!({"a": 2})]),
-            ),
-            ("staging".to_string(), Ok(vec![json!({"a": 3})])),
-        ];
-        let merged = merge_tagged_results(per_profile, true);
-
-        assert_eq!(merged.len(), 3);
-        assert_eq!(merged[0]["profile"], json!("prod"));
-        assert_eq!(merged[1]["profile"], json!("prod"));
-        assert_eq!(merged[2]["profile"], json!("staging"));
-    }
-
-    #[test]
-    fn merge_tagged_results_omits_profile_when_disabled() {
-        let per_profile = vec![("prod".to_string(), Ok(vec![json!({"a": 1})]))];
-        let merged = merge_tagged_results(per_profile, false);
-
-        assert_eq!(merged.len(), 1);
-        assert!(merged[0].get("profile").is_none());
-        assert_eq!(merged[0]["a"], json!(1));
-    }
-
-    #[test]
-    fn merge_tagged_results_skips_errored_profiles() {
-        let per_profile: Vec<(String, Result<Vec<Value>>)> = vec![
-            ("good".to_string(), Ok(vec![json!({"a": 1})])),
+    fn collect_successes_skips_errored_profiles_on_partial_failure() {
+        let per_profile: Vec<(String, Result<i32>)> = vec![
+            ("good".to_string(), Ok(1)),
             ("bad".to_string(), Err(anyhow::anyhow!("simulated error"))),
-            ("also-good".to_string(), Ok(vec![json!({"a": 2})])),
+            ("also-good".to_string(), Ok(2)),
         ];
-        let merged = merge_tagged_results(per_profile, true);
-
-        assert_eq!(merged.len(), 2);
-        assert_eq!(merged[0]["profile"], json!("good"));
-        assert_eq!(merged[1]["profile"], json!("also-good"));
+        let successes = collect_successes(per_profile).expect("partial failure should not bail");
+        assert_eq!(
+            successes,
+            vec![("good".to_string(), 1), ("also-good".to_string(), 2)]
+        );
     }
 
     #[test]
-    fn tag_rows_overwrites_existing_profile_key() {
-        let rows = vec![json!({"profile": "old", "data": "x"})];
-        let tagged = tag_rows(rows, "new", true);
-        assert_eq!(tagged[0]["profile"], json!("new"));
+    fn collect_successes_bails_when_every_target_fails() {
+        let per_profile: Vec<(String, Result<i32>)> = vec![
+            ("a".to_string(), Err(anyhow::anyhow!("boom"))),
+            ("b".to_string(), Err(anyhow::anyhow!("boom"))),
+        ];
+        let result = collect_successes(per_profile);
+        assert!(
+            result.is_err(),
+            "a total failure must surface as an error, not a silent empty result"
+        );
+    }
+
+    #[test]
+    fn collect_successes_does_not_bail_on_empty_input() {
+        let per_profile: Vec<(String, Result<i32>)> = vec![];
+        let successes = collect_successes(per_profile).expect("empty fan-out is not a failure");
+        assert!(successes.is_empty());
     }
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -78,7 +78,7 @@ where
 /// total failure surfaces as an error instead of rendering as a silently
 /// empty result (FORGE-482). Partial failure (some targets ok) returns `Ok`
 /// with the survivors - behavior per docs/multi-profile.md is unchanged.
-pub fn collect_successes<T>(per_profile: Vec<(String, Result<T>)>) -> Result<Vec<(String, T)>> {
+pub fn report_errors_and_collect_successes<T>(per_profile: Vec<(String, Result<T>)>) -> Result<Vec<(String, T)>> {
     let target_count = per_profile.len();
     let mut successes = Vec::with_capacity(target_count);
     let mut error_count = 0usize;
@@ -107,7 +107,7 @@ mod tests {
     fn collect_successes_returns_all_when_none_fail() {
         let per_profile: Vec<(String, Result<i32>)> =
             vec![("prod".to_string(), Ok(1)), ("staging".to_string(), Ok(2))];
-        let successes = collect_successes(per_profile).expect("should not bail");
+        let successes = report_errors_and_collect_successes(per_profile).expect("should not bail");
         assert_eq!(
             successes,
             vec![("prod".to_string(), 1), ("staging".to_string(), 2)]
@@ -121,7 +121,7 @@ mod tests {
             ("bad".to_string(), Err(anyhow::anyhow!("simulated error"))),
             ("also-good".to_string(), Ok(2)),
         ];
-        let successes = collect_successes(per_profile).expect("partial failure should not bail");
+        let successes = report_errors_and_collect_successes(per_profile).expect("partial failure should not bail");
         assert_eq!(
             successes,
             vec![("good".to_string(), 1), ("also-good".to_string(), 2)]
@@ -134,7 +134,7 @@ mod tests {
             ("a".to_string(), Err(anyhow::anyhow!("boom"))),
             ("b".to_string(), Err(anyhow::anyhow!("boom"))),
         ];
-        let result = collect_successes(per_profile);
+        let result = report_errors_and_collect_successes(per_profile);
         assert!(
             result.is_err(),
             "a total failure must surface as an error, not a silent empty result"
@@ -144,7 +144,7 @@ mod tests {
     #[test]
     fn collect_successes_does_not_bail_on_empty_input() {
         let per_profile: Vec<(String, Result<i32>)> = vec![];
-        let successes = collect_successes(per_profile).expect("empty fan-out is not a failure");
+        let successes = report_errors_and_collect_successes(per_profile).expect("empty fan-out is not a failure");
         assert!(successes.is_empty());
     }
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -81,18 +81,16 @@ where
 pub fn report_errors_and_collect_successes<T>(per_profile: Vec<(String, Result<T>)>) -> Result<Vec<(String, T)>> {
     let target_count = per_profile.len();
     let mut successes = Vec::with_capacity(target_count);
-    let mut error_count = 0usize;
     for (profile, result) in per_profile {
         match result {
             Ok(v) => successes.push((profile, v)),
             Err(e) => {
-                error_count += 1;
                 eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
             }
         }
     }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
+    if successes.is_empty() && target_count > 0 {
+        bail!("all profiles returned errors");
     }
     Ok(successes)
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -78,7 +78,9 @@ where
 /// total failure surfaces as an error instead of rendering as a silently
 /// empty result (FORGE-482). Partial failure (some targets ok) returns `Ok`
 /// with the survivors - behavior per docs/multi-profile.md is unchanged.
-pub fn report_errors_and_collect_successes<T>(per_profile: Vec<(String, Result<T>)>) -> Result<Vec<(String, T)>> {
+pub fn report_errors_and_collect_successes<T>(
+    per_profile: Vec<(String, Result<T>)>,
+) -> Result<Vec<(String, T)>> {
     let target_count = per_profile.len();
     let mut successes = Vec::with_capacity(target_count);
     for (profile, result) in per_profile {
@@ -119,7 +121,8 @@ mod tests {
             ("bad".to_string(), Err(anyhow::anyhow!("simulated error"))),
             ("also-good".to_string(), Ok(2)),
         ];
-        let successes = report_errors_and_collect_successes(per_profile).expect("partial failure should not bail");
+        let successes = report_errors_and_collect_successes(per_profile)
+            .expect("partial failure should not bail");
         assert_eq!(
             successes,
             vec![("good".to_string(), 1), ("also-good".to_string(), 2)]
@@ -142,7 +145,8 @@ mod tests {
     #[test]
     fn collect_successes_does_not_bail_on_empty_input() {
         let per_profile: Vec<(String, Result<i32>)> = vec![];
-        let successes = report_errors_and_collect_successes(per_profile).expect("empty fan-out is not a failure");
+        let successes = report_errors_and_collect_successes(per_profile)
+            .expect("empty fan-out is not a failure");
         assert!(successes.is_empty());
     }
 }

--- a/src/render.rs
+++ b/src/render.rs
@@ -5,9 +5,10 @@
 //!
 //! ## Profile key convention
 //!
-//! List commands inject a `"profile"` key into JSON rows via `execution::tag_rows`.
-//! Get commands use `"_profile"` (underscore-prefixed) as a rendering hint that
-//! should not appear in user-facing JSON output - see [`tag_get_result`].
+//! List commands inject a `"profile"` key into JSON rows inline while merging
+//! `execution::collect_successes` results. Get commands use `"_profile"`
+//! (underscore-prefixed) as a rendering hint that should not appear in
+//! user-facing JSON output - see [`tag_get_result`].
 
 use anyhow::Result;
 use colored::Colorize;

--- a/src/render.rs
+++ b/src/render.rs
@@ -73,6 +73,35 @@ pub fn bool_display(v: Option<bool>) -> String {
     }
 }
 
+/// Print a create/update success line to stderr.
+///
+/// Prints green with the ID when the API response included one. Otherwise
+/// prints a yellow warning rather than fabricating a placeholder ID - a
+/// missing ID from an otherwise-successful response is unusual enough to
+/// flag, not paper over.
+///
+/// `name` is `None` for resources that have no display name of their own
+/// (e.g. a bare integration or role ID).
+pub fn print_created(verb: &str, kind: &str, name: Option<&str>, id: Option<&str>, profile: &str) {
+    let subject = match name {
+        Some(name) => format!("{kind} '{name}'"),
+        None => kind.to_string(),
+    };
+    match id {
+        Some(id) => eprintln!(
+            "{}",
+            format!("{verb} {subject} (ID: {id}) in profile '{profile}'.").green()
+        ),
+        None => eprintln!(
+            "{}",
+            format!(
+                "{verb} {subject} in profile '{profile}', but the response did not include an ID."
+            )
+            .yellow()
+        ),
+    }
+}
+
 // ── Text tables ──────────────────────────────────────────────────────────────
 
 /// Build a text table string with an optional "Profile" column.

--- a/src/render.rs
+++ b/src/render.rs
@@ -6,7 +6,7 @@
 //! ## Profile key convention
 //!
 //! List commands inject a `"profile"` key into JSON rows inline while merging
-//! `execution::collect_successes` results. Get commands use `"_profile"`
+//! `execution::report_errors_and_collect_successes` results. Get commands use `"_profile"`
 //! (underscore-prefixed) as a rendering hint that should not appear in
 //! user-facing JSON output - see [`tag_get_result`].
 

--- a/tests/dataprime/query.rs
+++ b/tests/dataprime/query.rs
@@ -233,3 +233,163 @@ async fn multi_profile_fan_out_tags_rows() {
     .await
     .expect("multi-profile fan-out should succeed");
 }
+
+#[tokio::test]
+async fn dataprime_query_all_profiles_failing_returns_err() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(500).set_body_string(
+            r#"{"message":"Query execution failed: java.lang.OutOfMemoryError: Java heap space"}"#,
+        ))
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    let result = run_query(
+        &targets,
+        "source logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Some(Tier::FrequentSearch),
+        OutputFormat::Text,
+        None,
+        "/tmp",
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a total query failure must surface as an error, not a silent empty result"
+    );
+}
+
+#[tokio::test]
+async fn dataprime_query_ndjson_unrecognized_envelope_returns_err() {
+    let server = MockServer::start().await;
+
+    // Simulates a backend that dies mid-stream (e.g. a real OOM) and emits an
+    // envelope this client doesn't recognize, after already sending a 200.
+    let ndjson = [
+        r#"{"queryId":{"queryId":"test-query-id"}}"#,
+        r#"{"error":{"message":"engine out of memory"}}"#,
+    ]
+    .join("\n");
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    let result = run_query(
+        &targets,
+        "source logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Some(Tier::FrequentSearch),
+        OutputFormat::Text,
+        None,
+        "/tmp",
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a mid-stream NDJSON error envelope must surface as an error, not a silent empty result"
+    );
+}
+
+#[tokio::test]
+async fn dataprime_query_non_completed_statistics_status_returns_err() {
+    let server = MockServer::start().await;
+
+    // Real Coralogix behavior (discovered via live reproduction): every query
+    // ends with a `statistics` envelope; a non-"COMPLETED" status is how the
+    // engine reports a failure that happens after the 200 has already been
+    // sent (e.g. a real OOM mid-execution).
+    let ndjson = [
+        r#"{"queryId":{"queryId":"test-query-id"}}"#,
+        r#"{"statistics":{"status":"FAILED","outputRowCount":"0"}}"#,
+    ]
+    .join("\n");
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    let result = run_query(
+        &targets,
+        "source logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Some(Tier::FrequentSearch),
+        OutputFormat::Text,
+        None,
+        "/tmp",
+        None,
+    )
+    .await;
+
+    assert!(
+        result.is_err(),
+        "a non-COMPLETED statistics status must surface as an error, not a silent empty result"
+    );
+}
+
+#[tokio::test]
+async fn dataprime_query_completed_statistics_with_zero_rows_succeeds() {
+    let server = MockServer::start().await;
+
+    // A query that legitimately matches nothing still ends with a COMPLETED
+    // statistics line and no `result` line - must NOT be treated as an error.
+    let ndjson = [
+        r#"{"queryId":{"queryId":"test-query-id"}}"#,
+        r#"{"statistics":{"status":"COMPLETED","outputRowCount":"0"}}"#,
+    ]
+    .join("\n");
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/dataprime/query"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(&ndjson))
+        .mount(&server)
+        .await;
+
+    let target = common::test_target("test-profile", &server.uri());
+    let targets = vec![target];
+
+    run_query(
+        &targets,
+        "source logs",
+        "logs",
+        "2024-06-22T00:00:00Z",
+        "2024-06-22T23:59:59Z",
+        100,
+        Some(Tier::FrequentSearch),
+        OutputFormat::Text,
+        None,
+        "/tmp",
+        None,
+    )
+    .await
+    .expect("a legitimately empty result with COMPLETED status must still succeed");
+}


### PR DESCRIPTION
## Context
When every profile in a fan-out failed, `cx` commands printed "No results found." with exit 0 instead of surfacing the failure. Reproduced live against the real API: a DataPrime query on the `archive` tier that dies mid-execution (e.g. engine OOM) still gets a `200` response with a terminal NDJSON `statistics` envelope reporting the real failure - `cx` was silently dropping that envelope and reporting a clean empty result instead of an error.

## Linked Issues
FORGE-482

## Design
Two layers were fixed:

1. **NDJSON parsing** (`src/commands/dataprime/api.rs::parse_ndjson_response`): every DataPrime query stream ends with a `statistics` envelope; `status` there is the authoritative outcome. The parser now checks it - a non-`COMPLETED` status (or any other unrecognized envelope) returns a new `CxError::QueryStream` instead of being silently ignored. A `COMPLETED` status with zero rows is still treated as a legitimate empty result.
2. **Fan-out error collection** (`src/execution.rs`): replaced `merge_tagged_results`/`tag_rows` (which had no production callers) with a single `collect_successes<T>` helper that drains per-profile `Result<T>` pairs, prints every failure to stderr in the existing red format, and bails with an error when *all* targets in the fan-out failed. Partial failure (some profiles ok) still returns the survivors unchanged, per `docs/multi-profile.md`.

`collect_successes` was then wired into every fan-out command's merge loop (36 files) so the "all profiles failed -> bail" behavior is centralized instead of hand-rolled per command.

## Key Decisions
- **Bail only on total failure, not partial failure.** A fan-out across N profiles where some succeed and some don't should still return the survivors' data - that's documented, intentional multi-profile behavior. Only the "zero successes out of N targets" case was ever silently mis-reported as success, so that's the only case that now errors.
- **Centralize in one helper rather than fix each of the ~35 call sites by hand.** The initial commit (9a7edd4) did fix every call site directly; the follow-up (863056f) refactored all of them onto `execution::collect_successes` once the pattern was proven, so the "all failed -> bail" logic exists in exactly one place going forward.
- **`QueryStream` as its own `CxError` variant** rather than reusing `Api`/`Http`, since this failure is detected client-side from a `200` response body, not from an HTTP status or transport error.

## Changes
- `cx logs` / `cx spans` / `cx dataprime query` (and any DataPrime-backed command) now exit non-zero and print an error when a query fails mid-stream (engine error, OOM, etc.) instead of printing "No results found."
- Every fan-out command (alerts, dashboards, iam, webhooks, tco, usage, archive, integrations, slos, views, notifications, parsing-rules, enrichments, e2m, recording-rules, cases, ai-center, ...) now exits non-zero when *all* profiles in a `--profile` fan-out fail, instead of silently rendering an empty/successful result.
- Fixes two pre-existing bugs this exposed: `cx iam roles` and `cx iam team-groups` deserialized `roleId`/`groupId` as `i64`, but the real API returns them as strings - those commands were silently failing (and thus swallowed by the old error-hiding behavior) in production. Now typed as `Option<String>`.
- Removed `execution::tag_rows` / `execution::merge_tagged_results` (dead code, no production callers).

## Testing
- `cargo build` - clean.
- `cargo test --lib` - 427 passed, including new unit tests in `dataprime/api.rs` for the NDJSON parsing changes (`ndjson_non_completed_statistics_status_returns_query_stream_err`, `ndjson_unrecognized_envelope_with_message_returns_query_stream_err`, `ndjson_completed_statistics_line_on_zero_rows_is_not_an_error`, etc.) and `execution.rs` (`collect_successes_bails_when_every_target_fails`, `collect_successes_skips_errored_profiles_on_partial_failure`, `collect_successes_does_not_bail_on_empty_input`).
- `cargo test --test dataprime` - 52 passed, including new wiremock-backed integration tests that simulate the exact failure (`dataprime_query_non_completed_statistics_status_returns_err`, `dataprime_query_ndjson_unrecognized_envelope_returns_err`, `dataprime_query_all_profiles_failing_returns_err`, `dataprime_query_completed_statistics_with_zero_rows_succeeds`).
- Live manual repro against the real API (`default` profile, eu2), using an isolated `git worktree` checked out to `master` for a clean before/after:
  - `cx logs 'aggregate collect($d) as everything' --tier archive --start now-90d` (forces an engine-side mid-stream failure): on `master` prints `No results found.` with exit 0; on this branch prints `Query stream error: Failed to run the query ...` and exits non-zero.
  - Original ticket repro, `cx logs 'groupby $m.logid aggregate any_value($d) as data' --tier archive`, still returns 100 real rows on this branch - confirms the normal success path is unaffected.

## Risks & Rollout
Behavioral change: any script currently depending on a failed fan-out silently exiting 0 with empty output will now see a non-zero exit and an error message on stderr. This is the intended fix - the prior behavior was masking real failures - but it's worth flagging as user-visible. No data migrations, no config changes, no feature flag; revert is a straight `git revert` of both commits if needed.

## Out of Scope / Follow-ups
N/A - the roles/team_groups `i64` -> `String` fix was folded in here because it was directly exposed by (and discovered via) this bug's root-cause investigation, not a separate scope creep.