### PR TITLE
docs(skills): document notification router creation in cx-observability-setup (FORGE-505)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -73,3 +73,4 @@ Once installed, your agent uses the relevant skill automatically. Example querie
 - "Set up parsing rules for our new service"
 - "Who has access to production?"
 - "Configure Slack notifications for critical alerts"
+- "Add a route for the Checkout Service Errors alert"

--- a/skills/cx-observability-setup/SKILL.md
+++ b/skills/cx-observability-setup/SKILL.md
@@ -10,9 +10,11 @@ description: >
   "create notification connector", "set up email alerts", "configure PagerDuty",
   "notification routing", "deploy extension", "test webhook",
   "notification preset", "test notification", "webhook actions",
+  "add a route", "route an alert", "route alert to Slack", "create a router",
+  "routing rule", "route alerts by label",
   or wants to set up, configure, or manage the observability stack for a service or team.
 metadata:
-  version: "0.1.0"
+  version: "0.2.0"
 ---
 
 # Observability Setup Skill
@@ -142,11 +144,39 @@ cx notifications connectors create --from-file slack-connector.json
 
 ### 3. Configure Notification Routing
 
-Route alerts to the right channels:
+Route alerts to the right channels. A router matches requests by **routing labels**, then its
+ordered **rules** decide the destinations. See **`references/notification-routing.md`** for the full
+payload schema, condition syntax, and gotchas before building `router.json`.
 
 ```bash
 cx notifications routers create --from-file router.json
 ```
+
+Minimal router that sends one specific alert to a Slack connector (default preset):
+
+```json
+{
+  "router": {
+    "name": "[otel-demo] Checkout Service Errors",
+    "routingLabels": { "service": "otel-demo", "team": "knowledge-base-demo" },
+    "rules": [
+      {
+        "name": "Checkout Service Errors",
+        "entityType": "ALERTS",
+        "condition": "alertDef.name == \"[otel-demo] Checkout Service Errors\"",
+        "targets": [ { "connectorId": "<connector-id>" } ]
+      }
+    ]
+  }
+}
+```
+
+**Two things that trip agents up (details in the reference file):**
+- `entityType` in a **create request** is the bare form `"ALERTS"` — NOT the `"ENTITY_TYPE_ALERTS"`
+  form that `get`/`list` return. Don't paste a `get` response into a create.
+- A router's `routingLabels` map to the alert's `routing.*` `entityLabels`
+  (`service`→`routing.service`, `team`→`routing.team`). Declare only labels the alert actually
+  carries, or the router won't match. Label matching is automatic — no alert edit needed.
 
 ### 4. Set Up Webhooks
 
@@ -196,11 +226,16 @@ cx notifications connectors create --from-file connector.json
 
 ### 3. Create a Router
 
+See **`references/notification-routing.md`** for the router schema and condition syntax.
+
 ```bash
 cx notifications routers create --from-file router.json
 ```
 
 ### 4. Assign or Create a Preset
+
+`presetId` is optional on a routing target — omit it to use the connector's default preset. To
+customize formatting instead:
 
 ```bash
 cx notifications presets list -o json
@@ -256,6 +291,14 @@ cx webhooks actions reorder --from-file order.json
 - **Use `--from-file`** for complex JSON payloads - pipe from stdin or use a file
 - **Template from existing** - `cx <command> get <id> -o json > template.json` before creating
 - **Check connector types first** - `cx notifications connectors types` and `cx webhooks types` before creating
+
+---
+
+## Additional resources
+
+### Reference files
+
+- **`references/notification-routing.md`** - Full Notification Center router schema (GlobalRouter, RoutingRule, RoutingTarget, routingLabels), the `entityType` request-vs-response enum gotcha, routing-label ↔ alert `entityLabels` mapping, Tera condition variables and examples, a worked "route one alert to Slack" example, and troubleshooting.
 
 ---
 

--- a/skills/cx-observability-setup/references/notification-routing.md
+++ b/skills/cx-observability-setup/references/notification-routing.md
@@ -1,0 +1,195 @@
+# Notification Routing Reference
+
+Complete schema and gotchas for **Notification Center routers** (`cx notifications routers …`).
+A router matches incoming notification requests (from alerts, cases, etc.) by **routing labels**,
+then evaluates ordered **rules**; the first rule whose **condition** passes delivers to that rule's
+**targets** (connector + optional preset). Unmatched requests fall through to `fallbackTargets`.
+
+CLI → API mapping (all under `/mgmt/openapi/5/notifications/notification-center/v1`):
+
+| Command | Method + path |
+|---|---|
+| `cx notifications routers list` | `GET /routers` |
+| `cx notifications routers get <id>` | `GET /routers/{id}` |
+| `cx notifications routers create --from-file` | `POST /routers` — **requires `--yes`** |
+| `cx notifications routers update --from-file` | `PUT /routers` (full replace; include `id`) — **requires `--yes`** |
+| `cx notifications routers delete <id>` | `DELETE /routers/{id}` — **requires `--yes`** |
+| `cx notifications routers validate-matcher --from-file` | `POST /routers/matcher/validate` |
+| `cx notifications test routing-condition --from-file` | `POST /routers:testCondition` |
+
+---
+
+## Router create/replace payload
+
+The top-level object is wrapped in `router`:
+
+```json
+{
+  "router": {
+    "name": "My router",
+    "description": "optional",
+    "routingLabels": { "service": "otel-demo", "team": "knowledge-base-demo" },
+    "disabled": false,
+    "rules": [
+      {
+        "name": "Rule name",
+        "entityType": "ALERTS",
+        "condition": "alertDef.name == \"[otel-demo] Checkout Service Errors\"",
+        "targets": [
+          { "connectorId": "4da1c0f5-7fc5-489e-99ea-b0c9cfee7a3f", "presetId": "optional-preset-id" }
+        ]
+      }
+    ],
+    "fallbackTargets": [
+      { "entityType": "ALERTS", "target": { "connectorId": "4da1c0f5-..." } }
+    ]
+  }
+}
+```
+
+### `router` (GlobalRouter) fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Router display name. |
+| `description` | string | Optional. |
+| `routingLabels` | object | `{ service?, team?, environment? }` — see label matching below. |
+| `disabled` | bool | Optional; `true` = router does not evaluate. |
+| `rules` | array | Ordered `RoutingRule`s; first matching rule wins. |
+| `fallbackTargets` | array | `{ entityType, target: RoutingTarget }` used when no rule matches. On a **regular (labeled) router the fallback target references a connector only** (no preset). |
+| `entityType` | enum | **Reserved for the default router (`router_default`)** — do NOT set it on a regular labeled router. Set `entityType` per-rule instead. |
+| `id` | string | Set only on `update` (full replace). |
+
+### `RoutingRule` fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `name` | string | Rule name. |
+| `entityType` | enum | `ALERTS` \| `CASES` \| `TEST_NOTIFICATIONS` \| `ENTITY_TYPE_UNSPECIFIED`. |
+| `condition` | string | Tera/expression string, evaluated per event. Empty/omitted = always matches. See conditions below. |
+| `targets` | array | One or more `RoutingTarget` (connector + optional preset). |
+| `customDetails` | object | Optional `{string: string}`. |
+
+### `RoutingTarget` fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `connectorId` | string | Connector UUID. Get via `cx notifications connectors list -o json`. |
+| `presetId` | string | **Optional** — omit to use the connector's default preset for the entity type. |
+| `customDetails` | object | Optional `{string: string}`. |
+| `id` | string | Server-assigned; do not set on create. |
+
+---
+
+## ⚠️ Gotcha: `entityType` enum value differs between request and response
+
+- **In create/replace requests** use the bare form: `"ALERTS"`, `"CASES"`, `"TEST_NOTIFICATIONS"`, `"ENTITY_TYPE_UNSPECIFIED"`.
+- **In `get`/`list` responses** the same field comes back prefixed: `"ENTITY_TYPE_ALERTS"`.
+
+Sending `"ENTITY_TYPE_ALERTS"` on create fails with:
+`400 Bad Request: invalid value for enum field entityType: "ENTITY_TYPE_ALERTS"`.
+Do **not** copy a `get` response straight into a create — strip the `ENTITY_TYPE_` prefix first.
+
+---
+
+## Routing labels ↔ alert entity labels
+
+A router only sees a notification request if **all** of the router's `routingLabels` are present on
+the source entity. Alerts carry these as `entityLabels` with a `routing.` prefix:
+
+| Router `routingLabels` key | Alert `entityLabels` key |
+|---|---|
+| `service` | `routing.service` |
+| `team` | `routing.team` |
+| `environment` | `routing.environment` |
+
+Example: an alert with `entityLabels: { "routing.service": "otel-demo", "routing.team": "knowledge-base-demo" }`
+is matched by a router whose `routingLabels` are `{ "service": "otel-demo", "team": "knowledge-base-demo" }`.
+Only declare labels the source actually carries — declaring `environment` when the alert has no
+`routing.environment` label means the router won't match. Inspect an alert's labels with
+`cx alerts get <id> -o json` (look at `alertDef.alertDefProperties.entityLabels`).
+
+Because label matching is automatic, **no edit to the alert definition is required** to route it —
+just create a router whose labels match. (An alert can alternatively point at a specific router via
+`alertDef.alertDefProperties.notificationGroup.router.id`.)
+
+---
+
+## Conditions (Tera expressions)
+
+`condition` is a boolean expression string (no surrounding `{% if %}`). Common variables:
+
+| Variable | Meaning |
+|---|---|
+| `alertDef.name` | Alert definition name |
+| `alertDef.priority` | Configured priority, e.g. `"P1"` |
+| `alert.highestPriority` | Runtime highest priority, e.g. `"P1"`, `"P3"` |
+| `alert.status` | Alert status |
+| `alert.groups[N].keyValues` | Group-by key/value pairs |
+| `_context.entityLabels` | Source entity labels |
+| `_context.system.name` | Team/system identifier |
+
+Examples:
+
+```text
+alertDef.name == "[otel-demo] Checkout Service Errors"   # route one specific alert
+alertDef.priority == "P1"                                 # route by priority
+```
+
+Leave `condition` empty to match every request the router's labels select.
+
+Validate before/after creating with `cx notifications test routing-condition --from-file <file>`.
+
+---
+
+## Worked example: route one alert to a Slack connector
+
+Route only `[otel-demo] Checkout Service Errors` to the `knowledge-base-otel-demo` Slack connector,
+using its default preset.
+
+1. Find the connector id:
+   ```bash
+   cx notifications connectors list -o json
+   # → "knowledge-base-otel-demo" = 4da1c0f5-7fc5-489e-99ea-b0c9cfee7a3f
+   ```
+2. Confirm the alert's routing labels:
+   ```bash
+   cx alerts get <alert-id> -o json | jq '.alertDef.alertDefProperties.entityLabels'
+   # → { "routing.service": "otel-demo", "routing.team": "knowledge-base-demo" }
+   ```
+3. Write `router.json`:
+   ```json
+   {
+     "router": {
+       "name": "[otel-demo] Checkout Service Errors",
+       "description": "Routes the Checkout Service Errors alert to the knowledge-base-otel-demo Slack connector.",
+       "routingLabels": { "service": "otel-demo", "team": "knowledge-base-demo" },
+       "rules": [
+         {
+           "name": "Checkout Service Errors",
+           "entityType": "ALERTS",
+           "condition": "alertDef.name == \"[otel-demo] Checkout Service Errors\"",
+           "targets": [ { "connectorId": "4da1c0f5-7fc5-489e-99ea-b0c9cfee7a3f" } ]
+         }
+       ]
+     }
+   }
+   ```
+4. Create and verify:
+   ```bash
+   cx notifications routers create --from-file router.json --yes -o json
+   cx notifications routers get <new-router-id> -o json   # confirm rules/targets persisted
+   ```
+
+---
+
+## Troubleshooting
+
+- **`create`/`update`/`delete` do nothing / prompt** — these are write operations and need `--yes`.
+- **`cx notifications connectors entity-types` returns `404 … Connector with id entity-types not found`**
+  and **`cx notifications presets list` returns `404 … Preset with id summaries not found`** on some
+  backends: these list endpoints use custom-method paths that not every tenant/version routes.
+  Work around it by reading ids from what you already have — connector ids from
+  `cx notifications connectors list -o json`, and omit `presetId` to use the default preset.
+- **`invalid value for enum field entityType`** — you sent the `ENTITY_TYPE_`-prefixed form; use the
+  bare form (`ALERTS`) in requests. See the gotcha above.

--- a/skills/cx-observability-setup/references/notification-routing.md
+++ b/skills/cx-observability-setup/references/notification-routing.md
@@ -2,8 +2,10 @@
 
 Complete schema and gotchas for **Notification Center routers** (`cx notifications routers …`).
 A router matches incoming notification requests (from alerts, cases, etc.) by **routing labels**,
-then evaluates ordered **rules**; the first rule whose **condition** passes delivers to that rule's
-**targets** (connector + optional preset). Unmatched requests fall through to `fallbackTargets`.
+then evaluates its **rules**. **Every** rule whose **condition** passes delivers to that rule's
+**targets** (connector + optional preset) — evaluation does not stop at the first match, so multiple
+rules can fire for the same request. `fallbackTargets` are used only when the router matches (by
+labels) but **no** rule condition passes; if no router matches at all, the request is dropped.
 
 CLI → API mapping (all under `/mgmt/openapi/5/notifications/notification-center/v1`):
 
@@ -55,8 +57,8 @@ The top-level object is wrapped in `router`:
 | `description` | string | Optional. |
 | `routingLabels` | object | `{ service?, team?, environment? }` — see label matching below. |
 | `disabled` | bool | Optional; `true` = router does not evaluate. |
-| `rules` | array | Ordered `RoutingRule`s; first matching rule wins. |
-| `fallbackTargets` | array | `{ entityType, target: RoutingTarget }` used when no rule matches. On a **regular (labeled) router the fallback target references a connector only** (no preset). |
+| `rules` | array | `RoutingRule`s; **every** rule whose condition passes sends to its targets (no first-match short-circuit). |
+| `fallbackTargets` | array | `{ entityType, target: RoutingTarget }` used only when the router matches but **no** rule condition passes. On a **regular (labeled) router the fallback target references a connector only** (no preset). |
 | `entityType` | enum | **Reserved for the default router (`router_default`)** — do NOT set it on a regular labeled router. Set `entityType` per-rule instead. |
 | `id` | string | Set only on `update` (full replace). |
 


### PR DESCRIPTION
## Context
Creating a Notification Center router via `cx notifications routers create` was harder than it should be: the `cx-observability-setup` skill listed the command but shipped no payload schema. An agent had to reverse-engineer the `GlobalRouter` JSON from the CLI source and the management SDK, and still hit a `400` from the `entityType` enum mismatch (`get`/`list` return `ENTITY_TYPE_ALERTS`, but create expects the bare `ALERTS`). This PR documents the router schema, condition syntax, and the known gotchas so routing works on the first try. (FORGE-505)

## Linked Issues
FORGE-505. JIRA: N/A — tracked via the FORGE ticket. Linear: N/A — cx-cli repo.

## Design
Documentation-only change to the shipped `cx-observability-setup` skill. The dense schema/enum material goes into a new `references/notification-routing.md` (per `contributing/adding-a-skill.md`: schema references >100 lines live in `references/`), while `SKILL.md` stays the concise entry point with a minimal inline example and pointers into the reference. No CLI or runtime behavior changes.

## Key Decisions
- Full schema, enum catalog, and condition reference placed in `references/notification-routing.md` rather than bloating `SKILL.md`, following the repo's reference-file convention.
- The two highest-cost gotchas (the `entityType` request-vs-response enum form, and the `routingLabels` ↔ alert `entityLabels` mapping) are surfaced inline in `SKILL.md` because they block first-time success.
- Every documented field is grounded in the CLI source (`src/commands/routers`) and the management-SDK `GlobalRouter` model, and validated with a live `create` — not written from prose docs.

## Changes
- New `skills/cx-observability-setup/references/notification-routing.md`: `GlobalRouter` / `RoutingRule` / `RoutingTarget` / `routingLabels` / `fallbackTargets` field tables, CLI→API endpoint map, the `entityType` enum gotcha, `routingLabels`↔alert `entityLabels` mapping, Tera condition variables + examples, a worked "route one alert to Slack" example, and troubleshooting.
- `skills/cx-observability-setup/SKILL.md`: added trigger phrases ("add a route", "route an alert", "create a router", "routing rule", …); added a minimal router JSON example; noted `--yes` on write ops and optional `presetId`; linked the reference file; bumped `metadata.version` `0.1.0` → `0.2.0`.
- `skills/README.md`: added an "Add a route…" usage example.

No interface, endpoint, or behavioral changes to the CLI itself.

## Testing
- `bash scripts/verify-skills.sh` → `cx-observability-setup` **PASS** (33 triggers, 311 lines). The suite's single failure (`cx-ai-center` → `ai-center` command not found in cx schema) is pre-existing and unrelated to this branch.
- Validated the documented payload live: `cx notifications routers create` successfully created a router routing `[otel-demo] Checkout Service Errors` to a Slack connector, and `cx notifications routers get` confirmed the rules/targets/labels persisted. This exercise is what surfaced the `entityType` enum gotcha now documented.

## Risks & Rollout
N/A — documentation only; no code or CLI behavior changes. Rollback is a straight revert of the commit.

## Out of Scope / Follow-ups
- Does not fix the `cx notifications connectors entity-types` / `cx notifications presets list` 404s observed on some backends — captured as troubleshooting guidance only.
- Does not address the pre-existing `cx-ai-center` `verify-skills.sh` failure.
