### PR TITLE
docs: add AI Center commands to the Commands table

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Connect your agents to live logs, traces, metrics, dashboards, and alerts so the
 ## Features
 
 - DataPrime and PromQL at the terminal-Coralogix's proprietary query languages work end-to-end without leaving the shell.
-- 28 commands across 9 domains-from querying signals to managing IAM, notifications, TCO, and archiving-all in one binary.
+- 29 commands across 10 domains-from querying signals to managing IAM, notifications, TCO, AI Center, and archiving-all in one binary.
 - Multi-profile fan-out with `-p prod-eu -p prod-us <command>`-run one command across multiple accounts or regions in a single invocation, with rows tagged by profile.
 - `agents` output format-token-efficient JSON that auto-spills to a temp file once the serialized payload exceeds 100 KiB, so AI agents get a path instead of a flooded context window.
 - `cx schema`-outputs the full command tree as structured JSON, purpose-built for agent discovery with no help-text parsing required.
@@ -137,6 +137,12 @@ Commands are grouped by domain. Run `cx --help` for the full organized listing, 
 | `cx dashboards` | Manage or search dashboards and folders |
 | `cx views` | Manage saved views and view folders |
 | `cx slos` | Manage SLO definitions |
+
+**AI Center**
+
+| Command | Purpose |
+|---|---|
+| `cx ai-center` (risky) | Manage AI Center applications, evaluations, policies, and pricing: `applications`, `evaluations`, `custom-evaluations`, `coverage`, `model-pricing` |
 
 **Detect & Respond**
 


### PR DESCRIPTION
## Summary

The `cx ai-center` command family (AI v3 / AI Center configuration) is shipped in `src/commands/ai_center/` and appears in `cx --help` and `cx schema`, but the README `Commands` table never listed it. This adds it so the published CLI docs (synced into coralogix/documentation from this README) stay in sync with the binary.

## Changes

- Add an **AI Center** group to the `Commands` table with a single `cx ai-center` (risky) row, listing its subcommands inline (`applications`, `evaluations`, `custom-evaluations`, `coverage`, `model-pricing`) — matching the existing per-command style.
- Bump the Features line from "28 commands across 9 domains" to "29 commands across 10 domains" and add AI Center to the domain list.

Command descriptions are taken verbatim from the clap `about` strings in `src/main.rs` (`AiCenterCmd`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)