### PR TITLE
Issue-170: add new infra command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Rust toolchain is pinned to **1.96.1** via `rust-toolchain.toml`.
 
 ## Command Hierarchy
 
-The CLI is organized into 28 commands grouped by domain. `cx --help` shows this layout:
+The CLI is organized into 30 commands grouped by domain. `cx --help` shows this layout:
 
 ```
 Query:
@@ -39,6 +39,7 @@ Observe:
   dashboards         Manage dashboards and dashboard folders
   views              Manage saved views and view folders
   slos               Manage SLO definitions
+  infra              Query infrastructure resources and their data
 
 AI:
   ai-center (risky)  Manage AI Center applications, evaluations, policies, and pricing
@@ -147,7 +148,7 @@ Config lives in `~/.cx/`. Environment variables `CX_PROFILE`, `CX_API_KEY`, `CX_
 
 ### Skills
 
-`skills/` contains Claude Code skill plugins for AI-driven observability investigation. Nine skills cover all CLI commands: `cx-telemetry-querying` (logs, spans, metrics, RUM, DataPrime — gateway with pillar-specific reference files), `cx-alerts`, `cx-cases`, `cx-slos`, `cx-dashboards`, `cx-cost-optimization`, `cx-data-pipeline`, `cx-observability-setup`, and `cx-platform-admin`. Shared reference files (DataPrime syntax, PromQL guidelines, telemetry-pillar how-tos) live in `skills/shared/` and are distributed to consuming skills via `scripts/sync-shared-references.sh`.
+`skills/` contains Claude Code skill plugins for AI-driven observability investigation. Ten skills cover all CLI commands: `cx-telemetry-querying` (logs, spans, metrics, RUM, DataPrime — gateway with pillar-specific reference files), `cx-alerts`, `cx-cases`, `cx-slos`, `cx-dashboards`, `cx-infra`, `cx-cost-optimization`, `cx-data-pipeline`, `cx-observability-setup`, and `cx-platform-admin`. Shared reference files (DataPrime syntax, PromQL guidelines, telemetry-pillar how-tos) live in `skills/shared/` and are distributed to consuming skills via `scripts/sync-shared-references.sh`.
 
 ### Documentation
 
@@ -202,6 +203,7 @@ Which CLI commands have user-facing skills in `skills/`:
 | `cx integrations` | `cx-observability-setup` | Covered |
 | `cx schema` | `cx-telemetry-querying` | Covered (via gateway) |
 | `cx olly` | `cx-olly` | Covered |
+| `cx infra` | `cx-infra` | Covered |
 | `cx profiles` | - | Local command |
 | `cx cleanup` | - | Local command |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ Rust toolchain is pinned to **1.96.1** via `rust-toolchain.toml`.
 
 ## Command Hierarchy
 
-The CLI is organized into 30 commands grouped by domain. `cx --help` shows this layout:
+The CLI is organized into 29 commands grouped by domain. `cx --help` shows this layout:
 
 ```
 Query:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -34,6 +34,10 @@
 **/ai_center/                          @coralogix/team-cxai
 /skills/cx-ai-center/                  @coralogix/team-cxai
 
+# === infrastructure (cloud resources catalog) ===
+**/infra/                              @coralogix/team-lumos
+/skills/cx-infra/                      @coralogix/team-lumos
+
 # === config-surface (alerts, dashboards) ===
 **/alerts/                             @coralogix/team-cxai
 **/dashboards/                         @coralogix/team-cxai

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -377,6 +377,7 @@ dependencies = [
  "inquire",
  "keyring",
  "open",
+ "percent-encoding",
  "rand",
  "regex",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,9 @@ serde_json = "1"
 serde_yaml = "0.9"
 toml = "1.1"
 
+# URL path-segment encoding (infra resource ids contain reserved characters)
+percent-encoding = "2"
+
 # Error handling
 anyhow = "1"
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -132,11 +132,12 @@ Commands are grouped by domain. Run `cx --help` for the full organized listing, 
 
 **Observe**
 
-| Command | Purpose |
-|---|---|
-| `cx dashboards` | Manage or search dashboards and folders |
-| `cx views` | Manage saved views and view folders |
-| `cx slos` | Manage SLO definitions |
+| Command         | Purpose                                                                |
+|-----------------|------------------------------------------------------------------------|
+| `cx dashboards` | Manage or search dashboards and folders                                |
+| `cx views`      | Manage saved views and view folders                                    |
+| `cx slos`       | Manage SLO definitions                                                 |
+| `cx infra`      | Get infrastructure data: `types`, `list`, `health-history`, `raw-data` |
 
 **AI Center**
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,13 +8,14 @@ Supports Claude Code, Cursor, Codex, OpenCode, and [other supported agents](http
 
 ### Investigation
 
-| Skill | Description |
-|---|---|
-| `cx-olly` | Interact with Coralogix's Observability Agent (Olly) - chat, follow-up questions, retrieve generated artifacts |
+| Skill | Description                                                                                                                                       |
+|---|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| `cx-olly` | Interact with Coralogix's Observability Agent (Olly) - chat, follow-up questions, retrieve generated artifacts                                    |
 | `cx-telemetry-querying` | Gateway for all telemetry investigation - logs, spans, metrics, RUM, and DataPrime queries. Loads pillar-specific reference files per query type. |
-| `coralogix-docs` | Search and fetch official Coralogix product documentation (`cx docs search`, `cx docs fetch`) — not live tenant data |
-| `cx-alerts` | Manage Coralogix alert definitions - list, inspect, create, enable/disable via `cx alerts` |
-| `cx-dashboards` | Build and deploy Coralogix dashboards - telemetry discovery, PromQL/DataPrime verification, JSON generation |
+| `coralogix-docs` | Search and fetch official Coralogix product documentation (`cx docs search`, `cx docs fetch`) — not live tenant data                              |
+| `cx-alerts` | Manage Coralogix alert definitions - list, inspect, create, enable/disable via `cx alerts`                                                        |
+| `cx-dashboards` | Build and deploy Coralogix dashboards - telemetry discovery, PromQL/DataPrime verification, JSON generation                                       |
+| `cx-infra` | Explore infrastructure resources - discover monitored resource types, list resources, check per-resource data                                     |
 
 ### Workflow
 
@@ -68,6 +69,7 @@ Once installed, your agent uses the relevant skill automatically. Example querie
 - "What was the p99 latency over the last 24h?"
 - "Why is the checkout page slow for users?"
 - "Debug the 500 errors on the payment endpoint"
+- "Which of our EC2 instances were unhealthy this week?"
 - "How can we reduce our Coralogix costs?"
 - "Help me triage this case"
 - "Set up parsing rules for our new service"

--- a/skills/cx-infra/SKILL.md
+++ b/skills/cx-infra/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: cx-infra
+description: >
+  Query Coralogix infrastructure resources with the `cx infra` CLI — discover
+  monitored resource types, list resources, check per-resource data. Use when the user asks
+  to "show resource types", "list infrastructure resources", "what resources of this kind are monitored",
+  "list resources of this kind", "is this resource healthy",
+  "resource health history", "when did this resource go critical",
+  "get raw resource data", "infrastructure inventory", "find resources by name",
+  "filter resources by service or environment", or wants to explore
+  infrastructure resources and their data.
+metadata:
+  version: "0.1.0"
+---
+
+# Infrastructure Resources Skill
+
+Use this skill to discover and inspect **infrastructure resources** — what exists, whether it
+is healthy, and what its raw data contains.
+
+## CLI Commands
+
+| Command | Purpose | Key flags |
+|---|---|---|
+| `cx infra resources types` | List available resource types (category/type pairs) | - |
+| `cx infra resources list` | List resources of one category/type | `--category`, `--type` (required); `--name-filter`, `--scope key=value`, `--start-row`, `--end-row` |
+| `cx infra resources health-history <resource-id>` | Daily health samples for one resource, oldest first | - |
+| `cx infra resources raw-data <resource-id>` | Raw resource document as JSON | - |
+
+- All commands are **read-only** and support `-o json` / `-o agents` for
+  structured output and `-p <profile>` (repeatable) for multi-profile fan-out.
+- `--scope` is repeatable; allowed keys are `service`, `environment`, `team`
+  (e.g. `--scope environment=prod --scope service=checkout`).
+- Pagination: `--start-row` / `--end-row` define a row window; the default is
+  the first 100 rows. Page through large fleets in windows (0-100, 100-200, …).
+- Pass resource IDs **exactly as returned by `list`** (quote them — they contain
+  `:` and `=`); the CLI percent-encodes them for you.
+
+## Workflow
+
+1. **Discover what exists** — categories and types are dynamic, so never guess:
+
+   ```bash
+   cx infra resources types -o json
+   ```
+
+2. **List resources** of the category/type you care about, narrowing with
+   name and scope filters:
+
+   ```bash
+   cx infra resources list --category Hosts --type EC2_Instances \
+     --name-filter web --scope environment=prod -o json
+   ```
+
+   ```bash
+   # Just the ids and names
+   cx infra resources list --category Hosts --type EC2_Instances -o json \
+     | jq '[.[] | {resource_id, name}]'
+   ```
+
+3. **Check health** for a specific resource. Statuses are `Healthy`,
+   `Critical`, or `Unmonitored`, one sample per day, oldest first:
+
+   ```bash
+   cx infra resources health-history "1001234:host_id=i-abc123" -o json
+
+   # Only the days it was Critical
+   cx infra resources health-history "1001234:host_id=i-abc123" -o json \
+     | jq '[.[] | select(.status == "Critical")]'
+   ```
+
+4. **Inspect the raw document** when you need source-specific detail
+   (tags, instance metadata, configuration):
+
+   ```bash
+   cx infra resources raw-data "1001234:host_id=i-abc123" -o json
+   ```
+
+5. **Pivot to other domains by name, never by resource id** — `resource_id` is
+   infra-specific and no other command understands it. The interoperable keys
+   are the resource **`name`** and the **`service`** scope value:
+
+   ```bash
+   # Discover which log/span fields contain the resource name
+   cx search-fields "web-server-1" -s value --dataset logs
+
+   # Query logs for the service the resource belongs to
+   cx logs "filter \$l.subsystemname == 'checkout'"
+
+   # Alert definitions mentioning the resource or its service
+   cx alerts list --name "web-server-1"
+
+   # Dashboards covering the resource or its service
+   cx dashboards search "web-server-1 host health"
+   ```
+
+## Key Principles
+
+- **Discover before listing** — `--category` and `--type` are required;
+  always start from `cx infra resources types`.
+- **Quote resource IDs and pass them verbatim** — they embed `:`, `|`, and `=`;
+  the CLI handles URL encoding.
+- **Scope keys are a fixed set** (`service`, `environment`, `team`) — unknown
+  keys are rejected client-side before any request is made.
+- **A missing raw document is not an error** — `raw-data` reports "no raw data"
+  on stderr and emits nothing; treat it as a cleanly absent document.
+- **Use `-o json` with `jq`** for filtering; use `-o agents` for token-efficient
+  output in agent contexts.
+- **Multi-profile fan-out** with `-p <profile>` (repeatable) tags each row with
+  its profile so fleets can be compared across accounts.
+- **Infra health is its own concept** — the `Healthy`/`Critical`/`Unmonitored`
+  statuses are computed by the infrastructure domain and are not the same as
+  Service Catalog health. Correlate them with telemetry signals;
+  do not treat them as interchangeable.
+- **`resource_id` never leaves this skill** — pass it only to `health-history`
+  and `raw-data`. For every other command, pivot on the resource `name` or the
+  `service` scope value.
+
+## Related Skills
+
+Bridge to these skills using the resource **name** or the **service** scope
+value — never the resource id, which only this skill understands:
+
+- **`cx-telemetry-querying`** — `cx search-fields "<name>" -s value` discovers
+  which log/span fields contain the resource name; `cx logs "filter
+  $l.subsystemname == '<service>'"` queries the service's telemetry. Correlate a
+  `Critical` health day with error logs or CPU metrics.
+- **`cx-alerts`** — `cx alerts list --name "<name-or-service>"` finds alert
+  definitions matching the resource or its service by substring.
+- **`cx-dashboards`** — `cx dashboards search "<name-or-service> ..."` and
+  `cx dashboards query-search --description "..."` find dashboards semantically;
+  pair with `search-fields -s value` to then `query-search --field` the exact
+  field holding the resource name.

--- a/skills/cx-infra/SKILL.md
+++ b/skills/cx-infra/SKILL.md
@@ -33,6 +33,13 @@ is healthy, and what its raw data contains.
   (e.g. `--scope environment=prod --scope service=checkout`).
 - Pagination: `--start-row` / `--end-row` define a row window; the default is
   the first 100 rows. Page through large fleets in windows (0-100, 100-200, …).
+  **`list` never pages for you** — fleets can run to hundreds of thousands of
+  resources, so it returns one window and reports the total.
+- `list` wraps its rows in an envelope (`total_count`, `returned_count`,
+  `resources`) — the other subcommands return bare arrays. `total_count` is the
+  fleet-wide match count, always present and independent of the window, so use it
+  as the stop condition: keep paging while `start_row + returned_count <
+  total_count`.
 - Pass resource IDs **exactly as returned by `list`** (quote them — they contain
   `:` and `=`); the CLI percent-encodes them for you.
 
@@ -53,9 +60,19 @@ is healthy, and what its raw data contains.
    ```
 
    ```bash
-   # Just the ids and names
+   # Just the ids and names — note rows live under .resources
    cx infra resources list --category Hosts --type EC2_Instances -o json \
-     | jq '[.[] | {resource_id, name}]'
+     | jq '[.resources[] | {resource_id, name}]'
+   ```
+
+   ```bash
+   # How big is the fleet, and did this window cover it?
+   cx infra resources list --category Hosts --type EC2_Instances -o json \
+     | jq '{total_count, returned_count}'
+
+   # Next window, if there is one
+   cx infra resources list --category Hosts --type EC2_Instances \
+     --start-row 100 --end-row 200 -o json
    ```
 
 3. **Check health** for a specific resource. Statuses are `Healthy`,
@@ -107,7 +124,9 @@ is healthy, and what its raw data contains.
 - **Use `-o json` with `jq`** for filtering; use `-o agents` for token-efficient
   output in agent contexts.
 - **Multi-profile fan-out** with `-p <profile>` (repeatable) tags each row with
-  its profile so fleets can be compared across accounts.
+  its profile so fleets can be compared across accounts. The row window applies
+  per profile, so `list` adds a `counts_by_profile` breakdown — page each profile
+  against its own `total_count`, not the aggregate.
 - **Infra health is its own concept** — the `Healthy`/`Critical`/`Unmonitored`
   statuses are computed by the infrastructure domain and are not the same as
   Service Catalog health. Correlate them with telemetry signals;

--- a/skills/cx-infra/SKILL.md
+++ b/skills/cx-infra/SKILL.md
@@ -53,7 +53,11 @@ is healthy, and what its raw data contains.
 - Pass resource IDs **exactly as returned by `list`** (quote them — they contain
   `:` and `=`); the CLI percent-encodes them for you.
 
-## Workflow
+## Inspection Workflow
+
+Three steps, and only because each one supplies an input the next one requires:
+`types` gives the mandatory `--category`/`--type`, `list` gives the `resource_id`.
+Answering "is `web-server-1` healthy?" is these three calls — nothing more.
 
 1. **Discover what exists** — categories and types are dynamic, so never guess:
 
@@ -61,65 +65,58 @@ is healthy, and what its raw data contains.
    cx infra resources types -o json
    ```
 
-2. **List resources** of the category/type you care about, narrowing with
-   name and scope filters:
+2. **List resources** of that category/type, narrowing with name and scope filters:
 
    ```bash
    cx infra resources list --category Hosts --type EC2_Instances \
      --name-filter web --scope environment=prod -o json
    ```
 
-   ```bash
-   # Just the ids and names — note rows live under .resources
-   cx infra resources list --category Hosts --type EC2_Instances -o json \
-     | jq '[.resources[] | {resource_id, name}]'
-   ```
-
-   ```bash
-   # How big is the fleet, and did this window cover it?
-   cx infra resources list --category Hosts --type EC2_Instances -o json \
-     | jq '{total_count, returned_count}'
-
-   # Next window, if there is one
-   cx infra resources list --category Hosts --type EC2_Instances \
-     --start-row 100 --end-row 200 -o json
-   ```
-
-3. **Check health** for a specific resource. Statuses are `Healthy`,
-   `Critical`, or `Unmonitored`, one sample per day, oldest first:
+3. **Inspect one resource** using a `resource_id` from step 2. Statuses are
+   `Healthy`, `Critical`, or `Unmonitored`, one sample per day, oldest first:
 
    ```bash
    cx infra resources health-history "1001234:host_id=i-abc123" -o json
-
-   # Only the days it was Critical
-   cx infra resources health-history "1001234:host_id=i-abc123" -o json \
-     | jq '[.[] | select(.status == "Critical")]'
    ```
 
-4. **Inspect the raw document** when you need source-specific detail
-   (tags, instance metadata, configuration):
+   `raw-data` is the **alternative** to this step, not a follow-on — use it
+   instead when you need source-specific detail rather than health.
 
-   ```bash
-   cx infra resources raw-data "1001234:host_id=i-abc123" -o json
-   ```
+## Examples
 
-5. **Pivot to other domains by name, never by resource id** — `resource_id` is
-   infra-specific and no other command understands it. The interoperable keys
-   are the resource **`name`** and the **`service`** scope value:
+### Just the ids and names
 
-   ```bash
-   # Discover which log/span fields contain the resource name
-   cx search-fields "web-server-1" -s value --dataset logs
+```bash
+# Rows live under .resources — `list` returns an envelope
+cx infra resources list --category Hosts --type EC2_Instances -o json \
+  | jq '[.resources[] | {resource_id, name}]'
+```
 
-   # Query logs for the service the resource belongs to
-   cx logs "filter \$l.subsystemname == 'checkout'"
+### Check fleet size, and whether one window covered it
 
-   # Alert definitions mentioning the resource or its service
-   cx alerts list --name "web-server-1"
+```bash
+cx infra resources list --category Hosts --type EC2_Instances -o json \
+  | jq '{total_count, returned_count}'
 
-   # Dashboards covering the resource or its service
-   cx dashboards search "web-server-1 host health"
-   ```
+# Next window, if there is one
+cx infra resources list --category Hosts --type EC2_Instances \
+  --start-row 100 --end-row 200 -o json
+```
+
+### Find when a resource went critical
+
+```bash
+# health-history returns a bare array, so no .resources here
+cx infra resources health-history "1001234:host_id=i-abc123" -o json \
+  | jq '[.[] | select(.status == "Critical")]'
+```
+
+### Read the raw resource document
+
+```bash
+# Source-specific detail: tags, instance metadata, configuration
+cx infra resources raw-data "1001234:host_id=i-abc123" -o json
+```
 
 ## Key Principles
 
@@ -129,8 +126,11 @@ is healthy, and what its raw data contains.
   the CLI handles URL encoding.
 - **Scope keys are a fixed set** (`service`, `environment`, `team`) — unknown
   keys are rejected client-side before any request is made.
-- **A missing raw document is not an error** — `raw-data` reports "no raw data"
-  on stderr and emits nothing; treat it as a cleanly absent document.
+- **A missing raw document is not an error** — `raw-data` exits 0 and emits an
+  *empty result* on **stdout**: `[]` in `json`, `[0]:` in `agents`, and
+  `No raw data found.` in text. Only the per-profile note (`no raw data for this
+  resource in profile '<name>'`) goes to stderr. Parse the empty stdout result as
+  a cleanly absent document, not a failure — and do not expect stdout to be blank.
 - **Use `-o json` with `jq`** for filtering; use `-o agents` for token-efficient
   output in agent contexts.
 - **Multi-profile fan-out** with `-p <profile>` (repeatable) tags each row with

--- a/skills/cx-infra/SKILL.md
+++ b/skills/cx-infra/SKILL.md
@@ -35,15 +35,21 @@ is healthy, and what its raw data contains.
   accepts a single value and may be given **at most once**; repeating one (e.g.
   `--scope service=a --scope service=b`) is rejected. To cover several values for one key, run one query per
   value and combine the results.
-- Pagination: `--start-row` / `--end-row` define a row window; the default is
-  the first 100 rows. Page through large fleets in windows (0-100, 100-200, …).
-  **`list` never pages for you** — fleets can run to hundreds of thousands of
-  resources, so it returns one window and reports the total.
+- Pagination: `--start-row` / `--end-row` define a row window (`--end-row` is
+  **exclusive**); the default is the first 100 rows, and omitting only `--end-row`
+  gives 100 rows from `--start-row`. Page through large fleets in windows
+  (0-100, 100-200, …). **`list` never pages for you** — fleets can run to hundreds
+  of thousands of resources, so it returns one window and reports the total.
+- **The window cannot reach past row 10,000.** The API rejects any request whose
+  `start-row + rows` exceeds 10,000, so paging cannot enumerate a fleet larger
+  than that even though `total_count` reports its true size. In any case,
+  narrow with `--name-filter` or `--scope` and page within each subset rather
+  than trying to walk the whole list.
 - `list` wraps its rows in an envelope (`total_count`, `returned_count`,
   `resources`) — the other subcommands return bare arrays. `total_count` is the
   fleet-wide match count, always present and independent of the window, so use it
   as the stop condition: keep paging while `start_row + returned_count <
-  total_count`.
+  total_count`, subject to the 10,000-row ceiling above.
 - Pass resource IDs **exactly as returned by `list`** (quote them — they contain
   `:` and `=`); the CLI percent-encodes them for you.
 

--- a/skills/cx-infra/SKILL.md
+++ b/skills/cx-infra/SKILL.md
@@ -29,8 +29,12 @@ is healthy, and what its raw data contains.
 
 - All commands are **read-only** and support `-o json` / `-o agents` for
   structured output and `-p <profile>` (repeatable) for multi-profile fan-out.
-- `--scope` is repeatable; allowed keys are `service`, `environment`, `team`
-  (e.g. `--scope environment=prod --scope service=checkout`).
+- `--scope` is repeatable across **different** keys; allowed keys are `service`,
+  `environment`, `team` (e.g. `--scope environment=prod --scope service=checkout`).
+  Multiple keys combine with **AND** — a resource must match all of them. Each key
+  accepts a single value and may be given **at most once**; repeating one (e.g.
+  `--scope service=a --scope service=b`) is rejected. To cover several values for one key, run one query per
+  value and combine the results.
 - Pagination: `--start-row` / `--end-row` define a row window; the default is
   the first 100 rows. Page through large fleets in windows (0-100, 100-200, …).
   **`list` never pages for you** — fleets can run to hundreds of thousands of

--- a/skills/cx-infra/SKILL.md
+++ b/skills/cx-infra/SKILL.md
@@ -28,7 +28,11 @@ is healthy, and what its raw data contains.
 | `cx infra resources raw-data <resource-id>` | Raw resource document as JSON | - |
 
 - All commands are **read-only** and support `-o json` / `-o agents` for
-  structured output and `-p <profile>` (repeatable) for multi-profile fan-out.
+  structured output.
+- **Multi-profile fan-out applies to `types` and `list` only.** Repeat
+  `-p <profile>` on those to compare fleets across accounts. `health-history` and
+  `raw-data` take a resource id, which is scoped to one team, so they **reject**
+  more than one `-p` — run them once per profile instead.
 - `--scope` is repeatable across **different** keys; allowed keys are `service`,
   `environment`, `team` (e.g. `--scope environment=prod --scope service=checkout`).
   Multiple keys combine with **AND** — a resource must match all of them. Each key
@@ -128,15 +132,20 @@ cx infra resources raw-data "1001234:host_id=i-abc123" -o json
   keys are rejected client-side before any request is made.
 - **A missing raw document is not an error** — `raw-data` exits 0 and emits an
   *empty result* on **stdout**: `[]` in `json`, `[0]:` in `agents`, and
-  `No raw data found.` in text. Only the per-profile note (`no raw data for this
-  resource in profile '<name>'`) goes to stderr. Parse the empty stdout result as
-  a cleanly absent document, not a failure — and do not expect stdout to be blank.
+  `No raw data found.` in text. Only the note `no raw data for this resource` goes
+  to stderr. Parse the empty stdout result as a cleanly absent document, not a
+  failure — and do not expect stdout to be blank.
 - **Use `-o json` with `jq`** for filtering; use `-o agents` for token-efficient
   output in agent contexts.
-- **Multi-profile fan-out** with `-p <profile>` (repeatable) tags each row with
-  its profile so fleets can be compared across accounts. The row window applies
-  per profile, so `list` adds a `counts_by_profile` breakdown — page each profile
-  against its own `total_count`, not the aggregate.
+- **Multi-profile fan-out is for `types` and `list` only** — repeating
+  `-p <profile>` tags each row with its profile so fleets can be compared across
+  accounts. The row window applies per profile, so `list` adds a
+  `counts_by_profile` breakdown — page each profile against its own `total_count`,
+  not the aggregate. `health-history` and `raw-data` error on a second `-p`.
+- **A resource id never crosses profiles** — it embeds the team id
+  (`1001234:host_id=…`), so an id from one account cannot resolve in another. When
+  a multi-profile `list` turns up something worth inspecting, note its `profile`
+  field and query that single profile for its health or raw data.
 - **Infra health is its own concept** — the `Healthy`/`Critical`/`Unmonitored`
   statuses are computed by the infrastructure domain and are not the same as
   Service Catalog health. Correlate them with telemetry signals;

--- a/src/commands/infra/api.rs
+++ b/src/commands/infra/api.rs
@@ -7,6 +7,8 @@ use serde_json::Value;
 use crate::api_client::CxClient;
 use crate::error::Result;
 
+const BASE_PATH: &str = "/mgmt/api/infrastructure/resources/v1";
+
 // ── Response types ─────────────────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -82,8 +84,6 @@ pub struct ListResourcesParams<'p> {
 }
 
 // ── API ────────────────────────────────────────────────────────────────────────
-
-const BASE_PATH: &str = "/infrastructure/resources/v1";
 
 /// Resource ids embed reserved characters (`:`, `|`, `=`) and travel as a URL
 /// path segment, so encode everything except RFC 3986 unreserved characters.

--- a/src/commands/infra/api.rs
+++ b/src/commands/infra/api.rs
@@ -1,0 +1,103 @@
+use serde::Deserialize;
+
+use crate::api_client::CxClient;
+use crate::error::Result;
+
+// ── Response types ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetAvailableResourceTypesResponse {
+    #[serde(default)]
+    pub resource_types: Vec<ResourceTypeMapping>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceTypeMapping {
+    pub category_type: Option<CategoryType>,
+    pub resource_type: Option<String>,
+    pub label: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CategoryType {
+    pub category: Option<String>,
+    #[serde(rename = "type")]
+    pub type_name: Option<String>,
+}
+
+// ── API ────────────────────────────────────────────────────────────────────────
+
+const BASE_PATH: &str = "/infrastructure/resources/v1";
+
+pub struct InfraApi<'a> {
+    client: &'a CxClient,
+}
+
+impl<'a> InfraApi<'a> {
+    pub fn new(client: &'a CxClient) -> Self {
+        Self { client }
+    }
+
+    /// List the available resource type mappings (category/type pairs).
+    pub async fn available_types(&self) -> Result<GetAvailableResourceTypesResponse> {
+        let path = format!("{BASE_PATH}/types");
+        self.client.get(&path, &[]).await
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn deserialize_available_types_response() {
+        let json = json!({
+            "resourceTypes": [
+                {
+                    "categoryType": { "category": "Hosts", "type": "EC2_Instances" },
+                    "resourceType": "aws_ec2_instance",
+                    "label": "EC2 Instances"
+                },
+                {
+                    "categoryType": { "category": "Hosts", "type": "Azure_VMs" },
+                    "resourceType": "azure_vm",
+                    "label": "Azure Virtual Machines"
+                }
+            ]
+        });
+
+        let resp: GetAvailableResourceTypesResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.resource_types.len(), 2);
+        let first = &resp.resource_types[0];
+        let category_type = first.category_type.as_ref().unwrap();
+        assert_eq!(category_type.category.as_deref(), Some("Hosts"));
+        assert_eq!(category_type.type_name.as_deref(), Some("EC2_Instances"));
+        assert_eq!(first.resource_type.as_deref(), Some("aws_ec2_instance"));
+        assert_eq!(first.label.as_deref(), Some("EC2 Instances"));
+    }
+
+    #[test]
+    fn deserialize_empty_types_response() {
+        let json = json!({});
+        let resp: GetAvailableResourceTypesResponse = serde_json::from_value(json).unwrap();
+        assert!(resp.resource_types.is_empty());
+    }
+
+    #[test]
+    fn deserialize_types_response_with_missing_fields() {
+        let json = json!({
+            "resourceTypes": [
+                { "resourceType": "aws_ec2_instance" }
+            ]
+        });
+        let resp: GetAvailableResourceTypesResponse = serde_json::from_value(json).unwrap();
+        let first = &resp.resource_types[0];
+        assert!(first.category_type.is_none());
+        assert!(first.label.is_none());
+    }
+}

--- a/src/commands/infra/api.rs
+++ b/src/commands/infra/api.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use serde::Deserialize;
 
 use crate::api_client::CxClient;
@@ -27,6 +29,34 @@ pub struct CategoryType {
     pub type_name: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetResourcesResponse {
+    #[serde(default)]
+    pub resources: Vec<ResourceData>,
+    pub total_count: Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResourceData {
+    pub resource_id: Option<String>,
+    pub name: Option<String>,
+    #[serde(default)]
+    pub columns: HashMap<String, String>,
+}
+
+/// Query parameters for [`InfraApi::list`]. Scope filters are sent as flat
+/// `scopeFilter.{key}` query parameters, matching the API contract.
+pub struct ListResourcesParams<'p> {
+    pub category: &'p str,
+    pub resource_type: &'p str,
+    pub name_filter: Option<&'p str>,
+    pub scope_filters: &'p [(String, String)],
+    pub start_row: Option<i64>,
+    pub end_row: Option<i64>,
+}
+
 // ── API ────────────────────────────────────────────────────────────────────────
 
 const BASE_PATH: &str = "/infrastructure/resources/v1";
@@ -44,6 +74,32 @@ impl<'a> InfraApi<'a> {
     pub async fn available_types(&self) -> Result<GetAvailableResourceTypesResponse> {
         let path = format!("{BASE_PATH}/types");
         self.client.get(&path, &[]).await
+    }
+
+    /// List resources of a given category and type, with optional name filter,
+    /// scope filters, and a `startRow`/`endRow` page window.
+    pub async fn list(&self, params: &ListResourcesParams<'_>) -> Result<GetResourcesResponse> {
+        let mut query: Vec<(String, String)> = vec![
+            ("category".to_string(), params.category.to_string()),
+            ("type".to_string(), params.resource_type.to_string()),
+        ];
+        if let Some(name) = params.name_filter {
+            query.push(("nameFilter".to_string(), name.to_string()));
+        }
+        for (key, value) in params.scope_filters {
+            query.push((format!("scopeFilter.{key}"), value.clone()));
+        }
+        if let Some(start) = params.start_row {
+            query.push(("startRow".to_string(), start.to_string()));
+        }
+        if let Some(end) = params.end_row {
+            query.push(("endRow".to_string(), end.to_string()));
+        }
+        let query_refs: Vec<(&str, &str)> = query
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+        self.client.get(BASE_PATH, &query_refs).await
     }
 }
 
@@ -99,5 +155,57 @@ mod tests {
         let first = &resp.resource_types[0];
         assert!(first.category_type.is_none());
         assert!(first.label.is_none());
+    }
+
+    #[test]
+    fn deserialize_resources_response() {
+        let json = json!({
+            "resources": [
+                {
+                    "resourceId": "1001234:host_id=i-abc123",
+                    "name": "web-server-1",
+                    "columns": { "region": "us-east-1", "instance_type": "m5.large" }
+                },
+                {
+                    "resourceId": "1001234:host_id=i-def456",
+                    "name": "web-server-2",
+                    "columns": {}
+                }
+            ],
+            "totalCount": 42
+        });
+
+        let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.resources.len(), 2);
+        assert_eq!(resp.total_count, Some(42));
+        let first = &resp.resources[0];
+        assert_eq!(
+            first.resource_id.as_deref(),
+            Some("1001234:host_id=i-abc123")
+        );
+        assert_eq!(first.name.as_deref(), Some("web-server-1"));
+        assert_eq!(
+            first.columns.get("region").map(String::as_str),
+            Some("us-east-1")
+        );
+        assert!(resp.resources[1].columns.is_empty());
+    }
+
+    #[test]
+    fn deserialize_empty_resources_response() {
+        let json = json!({});
+        let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();
+        assert!(resp.resources.is_empty());
+        assert_eq!(resp.total_count, None);
+    }
+
+    #[test]
+    fn deserialize_resource_with_missing_columns() {
+        let json = json!({
+            "resources": [{ "resourceId": "1001234:host_id=i-abc123", "name": "web-server-1" }],
+            "totalCount": 1
+        });
+        let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();
+        assert!(resp.resources[0].columns.is_empty());
     }
 }

--- a/src/commands/infra/api.rs
+++ b/src/commands/infra/api.rs
@@ -1,6 +1,8 @@
 use std::collections::HashMap;
 
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use serde::Deserialize;
+use serde_json::Value;
 
 use crate::api_client::CxClient;
 use crate::error::Result;
@@ -46,6 +48,28 @@ pub struct ResourceData {
     pub columns: HashMap<String, String>,
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetHealthHistoryResponse {
+    #[serde(default)]
+    pub health_history: Vec<HealthHistoryEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct HealthHistoryEntry {
+    /// RFC 3339 timestamp of the daily sample.
+    pub timestamp: Option<String>,
+    /// `Healthy`, `Critical`, or `Unmonitored`.
+    pub status: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GetRawDataResponse {
+    /// The raw resource document; `null` when the document is cleanly missing.
+    pub raw_data: Option<Value>,
+}
+
 /// Query parameters for [`InfraApi::list`]. Scope filters are sent as flat
 /// `scopeFilter.{key}` query parameters, matching the API contract.
 pub struct ListResourcesParams<'p> {
@@ -60,6 +84,20 @@ pub struct ListResourcesParams<'p> {
 // ── API ────────────────────────────────────────────────────────────────────────
 
 const BASE_PATH: &str = "/infrastructure/resources/v1";
+
+/// Resource ids embed reserved characters (`:`, `|`, `=`) and travel as a URL
+/// path segment, so encode everything except RFC 3986 unreserved characters.
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+/// Percent-encodes a resource id for use as a URL path segment, so users can
+/// pass ids exactly as returned by `list`.
+pub fn encode_resource_id(resource_id: &str) -> String {
+    utf8_percent_encode(resource_id, PATH_SEGMENT_ENCODE_SET).to_string()
+}
 
 pub struct InfraApi<'a> {
     client: &'a CxClient,
@@ -100,6 +138,21 @@ impl<'a> InfraApi<'a> {
             .map(|(k, v)| (k.as_str(), v.as_str()))
             .collect();
         self.client.get(BASE_PATH, &query_refs).await
+    }
+
+    /// Get the daily health status history for one resource, oldest first.
+    pub async fn health_history(&self, resource_id: &str) -> Result<GetHealthHistoryResponse> {
+        let path = format!(
+            "{BASE_PATH}/{}/health-history",
+            encode_resource_id(resource_id)
+        );
+        self.client.get(&path, &[]).await
+    }
+
+    /// Get the raw resource document for one resource.
+    pub async fn raw_data(&self, resource_id: &str) -> Result<GetRawDataResponse> {
+        let path = format!("{BASE_PATH}/{}/raw-data", encode_resource_id(resource_id));
+        self.client.get(&path, &[]).await
     }
 }
 
@@ -207,5 +260,58 @@ mod tests {
         });
         let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();
         assert!(resp.resources[0].columns.is_empty());
+    }
+
+    #[test]
+    fn deserialize_health_history_response() {
+        let json = json!({
+            "healthHistory": [
+                { "timestamp": "2026-07-01T00:00:00Z", "status": "Healthy" },
+                { "timestamp": "2026-07-02T00:00:00Z", "status": "Critical" },
+                { "timestamp": "2026-07-03T00:00:00Z", "status": "Unmonitored" }
+            ]
+        });
+
+        let resp: GetHealthHistoryResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.health_history.len(), 3);
+        assert_eq!(
+            resp.health_history[0].timestamp.as_deref(),
+            Some("2026-07-01T00:00:00Z")
+        );
+        assert_eq!(resp.health_history[1].status.as_deref(), Some("Critical"));
+    }
+
+    #[test]
+    fn deserialize_empty_health_history_response() {
+        let json = json!({});
+        let resp: GetHealthHistoryResponse = serde_json::from_value(json).unwrap();
+        assert!(resp.health_history.is_empty());
+    }
+
+    #[test]
+    fn deserialize_raw_data_response() {
+        let json = json!({
+            "rawData": { "host_id": "i-abc123", "tags": { "env": "prod" } }
+        });
+        let resp: GetRawDataResponse = serde_json::from_value(json).unwrap();
+        let doc = resp.raw_data.unwrap();
+        assert_eq!(doc["host_id"], "i-abc123");
+        assert_eq!(doc["tags"]["env"], "prod");
+    }
+
+    #[test]
+    fn deserialize_null_raw_data_response() {
+        let json = json!({ "rawData": null });
+        let resp: GetRawDataResponse = serde_json::from_value(json).unwrap();
+        assert!(resp.raw_data.is_none());
+    }
+
+    #[test]
+    fn encode_resource_id_escapes_reserved_characters() {
+        assert_eq!(
+            encode_resource_id("1001234:host_id=i-abc|123"),
+            "1001234%3Ahost_id%3Di-abc%7C123"
+        );
+        assert_eq!(encode_resource_id("plain-id_1.2~3"), "plain-id_1.2~3");
     }
 }

--- a/src/commands/infra/api.rs
+++ b/src/commands/infra/api.rs
@@ -18,11 +18,13 @@ pub struct GetAvailableResourceTypesResponse {
     pub resource_types: Vec<ResourceTypeMapping>,
 }
 
+/// The API also returns `resourceType`, which the CLI deliberately does not
+/// surface in any output format. This is intentional and will be added later on
+/// when the CLI will offer other commands that support it.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResourceTypeMapping {
     pub category_type: Option<CategoryType>,
-    pub resource_type: Option<String>,
     pub label: Option<String>,
 }
 
@@ -181,14 +183,42 @@ mod tests {
             ]
         });
 
+        // The payload deliberately still carries `resourceType`: the API sends it
+        // and the CLI must parse the rest without it.
         let resp: GetAvailableResourceTypesResponse = serde_json::from_value(json).unwrap();
         assert_eq!(resp.resource_types.len(), 2);
         let first = &resp.resource_types[0];
         let category_type = first.category_type.as_ref().unwrap();
         assert_eq!(category_type.category.as_deref(), Some("Hosts"));
         assert_eq!(category_type.type_name.as_deref(), Some("EC2_Instances"));
-        assert_eq!(first.resource_type.as_deref(), Some("aws_ec2_instance"));
         assert_eq!(first.label.as_deref(), Some("EC2 Instances"));
+    }
+
+    /// `resourceType` is not surfaced in any output format, so it is left out of
+    /// [`ResourceTypeMapping`] entirely. The API keeps sending it, so deserializing
+    /// must ignore it rather than fail - this guards the absence of
+    /// `deny_unknown_fields`, which would turn the extra key into a hard error.
+    #[test]
+    fn deserialize_types_response_ignores_resource_type() {
+        let json = json!({
+            "resourceTypes": [
+                {
+                    "categoryType": { "category": "Hosts", "type": "EC2_Instances" },
+                    "resourceType": "aws_ec2_instance",
+                    "label": "EC2 Instances",
+                    "someFutureField": 42
+                }
+            ]
+        });
+
+        let resp: GetAvailableResourceTypesResponse =
+            serde_json::from_value(json).expect("unknown keys must be ignored, not rejected");
+        let first = &resp.resource_types[0];
+        assert_eq!(first.label.as_deref(), Some("EC2 Instances"));
+        assert_eq!(
+            first.category_type.as_ref().unwrap().type_name.as_deref(),
+            Some("EC2_Instances")
+        );
     }
 
     #[test]

--- a/src/commands/infra/api.rs
+++ b/src/commands/infra/api.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
 use serde::Deserialize;
@@ -46,8 +46,9 @@ pub struct GetResourcesResponse {
 pub struct ResourceData {
     pub resource_id: Option<String>,
     pub name: Option<String>,
+    /// `BTreeMap` so that `serde_json` maintains column order.
     #[serde(default)]
-    pub columns: HashMap<String, String>,
+    pub columns: BTreeMap<String, String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -304,6 +305,36 @@ mod tests {
         let json = json!({ "rawData": null });
         let resp: GetRawDataResponse = serde_json::from_value(json).unwrap();
         assert!(resp.raw_data.is_none());
+    }
+
+    /// a `HashMap` would emit its keys in randomized iteration order - identical
+    /// invocations producing different output. `BTreeMap` pins it to sorted order.
+    #[test]
+    fn resource_columns_serialize_in_stable_sorted_order() {
+        let json = json!({
+            "resources": [{
+                "resourceId": "1001234:host_id=i-abc123",
+                "name": "web-server-1",
+                "columns": {
+                    "region": "us-east-1",
+                    "instance_type": "m5.large",
+                    "availability_zone": "us-east-1a",
+                    "state": "running"
+                }
+            }]
+        });
+
+        let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();
+        let columns = &resp.resources[0].columns;
+
+        assert_eq!(
+            columns.keys().collect::<Vec<_>>(),
+            vec!["availability_zone", "instance_type", "region", "state"]
+        );
+        assert_eq!(
+            serde_json::to_string(columns).unwrap(),
+            r#"{"availability_zone":"us-east-1a","instance_type":"m5.large","region":"us-east-1","state":"running"}"#
+        );
     }
 
     #[test]

--- a/src/commands/infra/api.rs
+++ b/src/commands/infra/api.rs
@@ -38,7 +38,7 @@ pub struct CategoryType {
 pub struct GetResourcesResponse {
     #[serde(default)]
     pub resources: Vec<ResourceData>,
-    pub total_count: Option<i64>,
+    pub total_count: i64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -231,7 +231,7 @@ mod tests {
 
         let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();
         assert_eq!(resp.resources.len(), 2);
-        assert_eq!(resp.total_count, Some(42));
+        assert_eq!(resp.total_count, 42);
         let first = &resp.resources[0];
         assert_eq!(
             first.resource_id.as_deref(),
@@ -247,10 +247,25 @@ mod tests {
 
     #[test]
     fn deserialize_empty_resources_response() {
-        let json = json!({});
+        let json = json!({ "totalCount": 0 });
         let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();
         assert!(resp.resources.is_empty());
-        assert_eq!(resp.total_count, None);
+        assert_eq!(resp.total_count, 0);
+    }
+
+    /// `totalCount` is the caller's only stop condition when paging, so a
+    /// response missing it must fail loudly rather than default to `0` - which
+    /// would report an empty fleet while returning rows.
+    #[test]
+    fn deserialize_resources_response_requires_total_count() {
+        let json = json!({
+            "resources": [{ "resourceId": "1001234:host_id=i-abc123", "name": "web-server-1" }]
+        });
+        let err = serde_json::from_value::<GetResourcesResponse>(json).unwrap_err();
+        assert!(
+            err.to_string().contains("totalCount"),
+            "error should name the missing field, got: {err}"
+        );
     }
 
     #[test]
@@ -321,7 +336,8 @@ mod tests {
                     "availability_zone": "us-east-1a",
                     "state": "running"
                 }
-            }]
+            }],
+            "totalCount": 1
         });
 
         let resp: GetResourcesResponse = serde_json::from_value(json).unwrap();

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 
 pub mod api;
 
-use api::{InfraApi, ResourceTypeMapping};
+use api::{InfraApi, ListResourcesParams, ResourceData, ResourceTypeMapping};
 
 use crate::config::OutputFormat;
 use crate::execution::{fan_out, ExecutionTarget};
@@ -14,6 +14,10 @@ use crate::render;
 
 /// JSON key for the source profile when merging multi-profile infra REST rows.
 const JSON_KEY_PROFILE: &str = "profile";
+
+/// Scope filter keys accepted by the infrastructure resources API. Validated
+/// client-side so a typo fails fast instead of round-tripping for a 400.
+const ALLOWED_SCOPE_KEYS: [&str; 3] = ["service", "environment", "team"];
 
 // ── Subcommand runners ────────────────────────────────────────────────────────
 
@@ -29,25 +33,7 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
 
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    let mut merged: Vec<(String, ResourceTypeMapping)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for mapping in resp.resource_types {
-                    merged.push((profile.clone(), mapping));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
-    }
+    let merged = merge_fan_out(per_profile, |resp| resp.resource_types)?;
 
     match output {
         OutputFormat::Json | OutputFormat::Agents => {
@@ -55,11 +41,7 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
                 .iter()
                 .map(|(profile, m)| type_mapping_to_json(m, include_profile, profile))
                 .collect();
-            if output == OutputFormat::Json {
-                render::render_json(&rows)?;
-            } else {
-                render::render_agents(&rows)?;
-            }
+            render_machine_rows(output, &rows)?;
         }
         OutputFormat::Text => {
             if merged.is_empty() {
@@ -95,19 +77,169 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     Ok(())
 }
 
+/// `cx infra resources list` - list resources of a given category and type.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_list(
+    targets: &[Arc<ExecutionTarget>],
+    category: &str,
+    resource_type: &str,
+    name_filter: Option<&str>,
+    scope: &[String],
+    start_row: Option<i64>,
+    end_row: Option<i64>,
+    output: OutputFormat,
+) -> Result<()> {
+    let scope_filters = parse_scope_filters(scope)?;
+
+    eprintln!("{}", "Fetching resources...".dimmed());
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |target| {
+        let scope_filters = scope_filters.clone();
+        let category = category.to_string();
+        let resource_type = resource_type.to_string();
+        let name_filter = name_filter.map(String::from);
+        async move {
+            let api = InfraApi::new(&target.client);
+            let params = ListResourcesParams {
+                category: &category,
+                resource_type: &resource_type,
+                name_filter: name_filter.as_deref(),
+                scope_filters: &scope_filters,
+                start_row,
+                end_row,
+            };
+            Ok(api.list(&params).await?)
+        }
+    })
+    .await;
+
+    let mut total_count: i64 = 0;
+    let merged = merge_fan_out(per_profile, |resp| {
+        total_count += resp.total_count.unwrap_or(resp.resources.len() as i64);
+        resp.resources
+    })?;
+
+    match output {
+        OutputFormat::Json | OutputFormat::Agents => {
+            let rows: Vec<Value> = merged
+                .iter()
+                .map(|(profile, r)| resource_to_json(r, include_profile, profile))
+                .collect();
+            render_machine_rows(output, &rows)?;
+        }
+        OutputFormat::Text => {
+            if merged.is_empty() {
+                render::print_no_results("No resources found.");
+                return Ok(());
+            }
+            let rows: Vec<Vec<String>> = merged
+                .iter()
+                .map(|(profile, r)| {
+                    vec![
+                        profile.clone(),
+                        display_or_dash(r.resource_id.as_deref()),
+                        display_or_dash(r.name.as_deref()),
+                    ]
+                })
+                .collect();
+            render::render_table(&["Resource ID", "Name"], rows, include_profile);
+            eprintln!(
+                "{}",
+                format!(
+                    "Showing {} of {} total resources",
+                    merged.len(),
+                    total_count
+                )
+                .dimmed()
+            );
+        }
+    }
+
+    Ok(())
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Builds one resource-type row as JSON for `json` / `agents` output after fan-out.
-///
-/// When `include_profile` is true (multiple `--profile`), injects the profile key so
-/// merged arrays stay attributable per account; text mode uses a separate table path.
-fn type_mapping_to_json(item: &ResourceTypeMapping, include_profile: bool, profile: &str) -> Value {
-    let mut v = json!({
-        "category": item.category_type.as_ref().and_then(|c| c.category.clone()),
-        "type": item.category_type.as_ref().and_then(|c| c.type_name.clone()),
-        "resource_type": item.resource_type,
-        "label": item.label,
+/// Flattens fan-out results into `(profile, item)` pairs, printing per-profile
+/// errors to stderr (non-fatal) and erroring only when **all** profiles fail,
+/// so CI/scripts see a non-zero exit when nothing succeeded.
+fn merge_fan_out<R, T>(
+    per_profile: Vec<(String, Result<R>)>,
+    mut extract: impl FnMut(R) -> Vec<T>,
+) -> Result<Vec<(String, T)>> {
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
+    let mut merged: Vec<(String, T)> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            Ok(resp) => {
+                for item in extract(resp) {
+                    merged.push((profile.clone(), item));
+                }
+            }
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
+        }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
+    }
+    Ok(merged)
+}
+
+/// Renders merged JSON rows for the two machine formats. Callers handle
+/// `OutputFormat::Text` themselves, so it is rejected here.
+fn render_machine_rows(output: OutputFormat, rows: &[Value]) -> Result<()> {
+    match output {
+        OutputFormat::Json => render::render_json(rows),
+        OutputFormat::Agents => render::render_agents(rows),
+        OutputFormat::Text => bail!("render_machine_rows called with text output"),
+    }
+}
+
+/// Parses repeatable `--scope key=value` flags and validates keys against
+/// [`ALLOWED_SCOPE_KEYS`].
+fn parse_scope_filters(scope: &[String]) -> Result<Vec<(String, String)>> {
+    scope
+        .iter()
+        .map(|raw| {
+            let Some((key, value)) = raw.split_once('=') else {
+                bail!("invalid --scope '{raw}': expected key=value");
+            };
+            let key = key.trim();
+            let value = value.trim();
+            if !ALLOWED_SCOPE_KEYS.contains(&key) {
+                bail!(
+                    "unknown --scope key '{key}'; allowed keys: {}",
+                    ALLOWED_SCOPE_KEYS.join(", ")
+                );
+            }
+            if value.is_empty() {
+                bail!("invalid --scope '{raw}': value must be non-empty");
+            }
+            Ok((key.to_string(), value.to_string()))
+        })
+        .collect()
+}
+
+/// Builds one resource row as JSON for `json` / `agents` output after fan-out.
+fn resource_to_json(item: &ResourceData, include_profile: bool, profile: &str) -> Value {
+    let v = json!({
+        "resource_id": item.resource_id,
+        "name": item.name,
+        "columns": item.columns,
     });
+    tag_profile(v, include_profile, profile)
+}
+
+/// Injects the profile key into a JSON row when `include_profile` is true
+/// (multiple `--profile`), so merged arrays stay attributable per account;
+/// text mode uses a separate table path.
+fn tag_profile(mut v: Value, include_profile: bool, profile: &str) -> Value {
     if include_profile {
         if let Value::Object(ref mut m) = v {
             m.insert(
@@ -117,6 +249,17 @@ fn type_mapping_to_json(item: &ResourceTypeMapping, include_profile: bool, profi
         }
     }
     v
+}
+
+/// Builds one resource-type row as JSON for `json` / `agents` output after fan-out.
+fn type_mapping_to_json(item: &ResourceTypeMapping, include_profile: bool, profile: &str) -> Value {
+    let v = json!({
+        "category": item.category_type.as_ref().and_then(|c| c.category.clone()),
+        "type": item.category_type.as_ref().and_then(|c| c.type_name.clone()),
+        "resource_type": item.resource_type,
+        "label": item.label,
+    });
+    tag_profile(v, include_profile, profile)
 }
 
 fn display_or_dash(value: Option<&str>) -> String {

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -9,7 +9,7 @@ pub mod api;
 use api::{HealthHistoryEntry, InfraApi, ListResourcesParams, ResourceData, ResourceTypeMapping};
 
 use crate::config::OutputFormat;
-use crate::execution::{fan_out, ExecutionTarget};
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
 use crate::render;
 
 /// JSON key for the source profile when merging multi-profile infra REST rows.
@@ -33,7 +33,12 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
     })
     .await;
 
-    let merged = merge_fan_out(per_profile, |resp| resp.resource_types)?;
+    let mut merged: Vec<(String, ResourceTypeMapping)> = Vec::new();
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
+        for mapping in resp.resource_types {
+            merged.push((profile.clone(), mapping));
+        }
+    }
 
     match output {
         OutputFormat::Json | OutputFormat::Agents => {
@@ -119,10 +124,13 @@ pub async fn run_list(
     .await;
 
     let mut total_count: i64 = 0;
-    let merged = merge_fan_out(per_profile, |resp| {
+    let mut merged: Vec<(String, ResourceData)> = Vec::new();
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
         total_count += resp.total_count.unwrap_or(resp.resources.len() as i64);
-        resp.resources
-    })?;
+        for resource in resp.resources {
+            merged.push((profile.clone(), resource));
+        }
+    }
 
     match output {
         OutputFormat::Json | OutputFormat::Agents => {
@@ -189,7 +197,12 @@ pub async fn run_health_history(
     })
     .await;
 
-    let merged = merge_fan_out(per_profile, |resp| resp.health_history)?;
+    let mut merged: Vec<(String, HealthHistoryEntry)> = Vec::new();
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
+        for entry in resp.health_history {
+            merged.push((profile.clone(), entry));
+        }
+    }
 
     match output {
         OutputFormat::Json | OutputFormat::Agents => {
@@ -248,31 +261,20 @@ pub async fn run_raw_data(
 
     // Merge - one document per profile; a 200 with null raw data means the
     // document is cleanly missing, so note it on stderr and move on.
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
     let mut all_results: Vec<Value> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => match resp.raw_data {
-                Some(mut doc) => {
-                    if include_profile {
-                        render::tag_get_result(&mut doc, &profile);
-                    }
-                    all_results.push(doc);
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
+        match resp.raw_data {
+            Some(mut doc) => {
+                if include_profile {
+                    render::tag_get_result(&mut doc, &profile);
                 }
-                None => eprintln!(
-                    "{}",
-                    format!("no raw data for this resource in profile '{profile}'").yellow()
-                ),
-            },
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+                all_results.push(doc);
             }
+            None => eprintln!(
+                "{}",
+                format!("no raw data for this resource in profile '{profile}'").yellow()
+            ),
         }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
     }
 
     match output {
@@ -287,35 +289,6 @@ pub async fn run_raw_data(
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-/// Flattens fan-out results into `(profile, item)` pairs, printing per-profile
-/// errors to stderr (non-fatal) and erroring only when **all** profiles fail,
-/// so CI/scripts see a non-zero exit when nothing succeeded.
-fn merge_fan_out<R, T>(
-    per_profile: Vec<(String, Result<R>)>,
-    mut extract: impl FnMut(R) -> Vec<T>,
-) -> Result<Vec<(String, T)>> {
-    let target_count = per_profile.len();
-    let mut error_count = 0usize;
-    let mut merged: Vec<(String, T)> = Vec::new();
-    for (profile, result) in per_profile {
-        match result {
-            Ok(resp) => {
-                for item in extract(resp) {
-                    merged.push((profile.clone(), item));
-                }
-            }
-            Err(e) => {
-                error_count += 1;
-                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
-            }
-        }
-    }
-    if target_count > 0 && error_count == target_count {
-        bail!("all profiles returned errors; see above for details");
-    }
-    Ok(merged)
-}
 
 /// Renders merged JSON rows for the two machine formats. Callers handle
 /// `OutputFormat::Text` themselves, so it is rejected here.

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -293,13 +293,17 @@ pub async fn run_raw_data(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Renders merged JSON rows for the two machine formats. Callers handle
-/// `OutputFormat::Text` themselves, so it is rejected here.
+/// Renders merged JSON rows for the two machine formats.
+///
+/// Every caller peels `OutputFormat::Text` off first and renders its own table,
+/// so reaching here with `Text` is a bug in this module rather than bad input.
 fn render_machine_rows(output: OutputFormat, rows: &[Value]) -> Result<()> {
     match output {
         OutputFormat::Json => render::render_json(rows),
         OutputFormat::Agents => render::render_agents(rows),
-        OutputFormat::Text => bail!("render_machine_rows called with text output"),
+        OutputFormat::Text => {
+            unreachable!("callers render text themselves; only Json/Agents reach here")
+        }
     }
 }
 
@@ -360,7 +364,8 @@ fn build_list_envelope(
     Value::Object(envelope)
 }
 
-/// Renders the `list` envelope for the two machine formats.
+/// Renders the `list` envelope for the two machine formats. `Text` is unreachable
+/// for the same reason as in [`render_machine_rows`].
 fn render_machine_envelope(output: OutputFormat, envelope: &Value) -> Result<()> {
     match output {
         OutputFormat::Json => render::render_json_auto(std::slice::from_ref(envelope)),
@@ -370,7 +375,9 @@ fn render_machine_envelope(output: OutputFormat, envelope: &Value) -> Result<()>
             println!("{encoded}");
             Ok(())
         }
-        OutputFormat::Text => bail!("render_machine_envelope called with text output"),
+        OutputFormat::Text => {
+            unreachable!("callers render text themselves; only Json/Agents reach here")
+        }
     }
 }
 

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -1,0 +1,124 @@
+use std::sync::Arc;
+
+use anyhow::{bail, Result};
+use colored::Colorize;
+use serde_json::{json, Value};
+
+pub mod api;
+
+use api::{InfraApi, ResourceTypeMapping};
+
+use crate::config::OutputFormat;
+use crate::execution::{fan_out, ExecutionTarget};
+use crate::render;
+
+/// JSON key for the source profile when merging multi-profile infra REST rows.
+const JSON_KEY_PROFILE: &str = "profile";
+
+// ── Subcommand runners ────────────────────────────────────────────────────────
+
+/// `cx infra resources types` - list the available resource type mappings.
+pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -> Result<()> {
+    eprintln!("{}", "Fetching available resource types...".dimmed());
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |target| async move {
+        let api = InfraApi::new(&target.client);
+        Ok(api.available_types().await?)
+    })
+    .await;
+
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
+    let mut merged: Vec<(String, ResourceTypeMapping)> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            Ok(resp) => {
+                for mapping in resp.resource_types {
+                    merged.push((profile.clone(), mapping));
+                }
+            }
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
+        }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
+    }
+
+    match output {
+        OutputFormat::Json | OutputFormat::Agents => {
+            let rows: Vec<Value> = merged
+                .iter()
+                .map(|(profile, m)| type_mapping_to_json(m, include_profile, profile))
+                .collect();
+            if output == OutputFormat::Json {
+                render::render_json(&rows)?;
+            } else {
+                render::render_agents(&rows)?;
+            }
+        }
+        OutputFormat::Text => {
+            if merged.is_empty() {
+                render::print_no_results("No resource types found.");
+                return Ok(());
+            }
+            let rows: Vec<Vec<String>> = merged
+                .iter()
+                .map(|(profile, m)| {
+                    vec![
+                        profile.clone(),
+                        display_or_dash(
+                            m.category_type.as_ref().and_then(|c| c.category.as_deref()),
+                        ),
+                        display_or_dash(
+                            m.category_type
+                                .as_ref()
+                                .and_then(|c| c.type_name.as_deref()),
+                        ),
+                        display_or_dash(m.resource_type.as_deref()),
+                        display_or_dash(m.label.as_deref()),
+                    ]
+                })
+                .collect();
+            render::render_table(
+                &["Category", "Type", "Resource Type", "Label"],
+                rows,
+                include_profile,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// Builds one resource-type row as JSON for `json` / `agents` output after fan-out.
+///
+/// When `include_profile` is true (multiple `--profile`), injects the profile key so
+/// merged arrays stay attributable per account; text mode uses a separate table path.
+fn type_mapping_to_json(item: &ResourceTypeMapping, include_profile: bool, profile: &str) -> Value {
+    let mut v = json!({
+        "category": item.category_type.as_ref().and_then(|c| c.category.clone()),
+        "type": item.category_type.as_ref().and_then(|c| c.type_name.clone()),
+        "resource_type": item.resource_type,
+        "label": item.label,
+    });
+    if include_profile {
+        if let Value::Object(ref mut m) = v {
+            m.insert(
+                JSON_KEY_PROFILE.to_string(),
+                Value::String(profile.to_string()),
+            );
+        }
+    }
+    v
+}
+
+fn display_or_dash(value: Option<&str>) -> String {
+    value.filter(|s| !s.is_empty()).unwrap_or("-").to_string()
+}

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -89,6 +89,9 @@ pub async fn run_list(
     end_row: Option<i64>,
     output: OutputFormat,
 ) -> Result<()> {
+    let category = require_non_empty(category, "--category")?;
+    let resource_type = require_non_empty(resource_type, "--type")?;
+    let name_filter = name_filter.map(str::trim).filter(|s| !s.is_empty());
     let scope_filters = parse_scope_filters(scope)?;
 
     eprintln!("{}", "Fetching resources...".dimmed());
@@ -167,7 +170,12 @@ pub async fn run_health_history(
     resource_id: &str,
     output: OutputFormat,
 ) -> Result<()> {
-    eprintln!("{}", "Fetching health history...".dimmed());
+    let resource_id = require_non_empty(resource_id, "resource id")?;
+
+    eprintln!(
+        "{}",
+        format!("Fetching health history for '{resource_id}'...").dimmed()
+    );
 
     let include_profile = targets.len() > 1;
     let id = resource_id.to_string();
@@ -219,7 +227,12 @@ pub async fn run_raw_data(
     resource_id: &str,
     output: OutputFormat,
 ) -> Result<()> {
-    eprintln!("{}", "Fetching raw resource data...".dimmed());
+    let resource_id = require_non_empty(resource_id, "resource id")?;
+
+    eprintln!(
+        "{}",
+        format!("Fetching raw resource data for '{resource_id}'...").dimmed()
+    );
 
     let include_profile = targets.len() > 1;
     let id = resource_id.to_string();
@@ -314,6 +327,17 @@ fn render_machine_rows(output: OutputFormat, rows: &[Value]) -> Result<()> {
     }
 }
 
+/// Trims a required string input and rejects it when nothing remains, so an
+/// empty `--category ""` fails fast instead of sending an empty query
+/// parameter to the API.
+fn require_non_empty<'v>(value: &'v str, field_name: &str) -> Result<&'v str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{field_name} must not be empty");
+    }
+    Ok(trimmed)
+}
+
 /// Parses repeatable `--scope key=value` flags and validates keys against
 /// [`ALLOWED_SCOPE_KEYS`].
 fn parse_scope_filters(scope: &[String]) -> Result<Vec<(String, String)>> {
@@ -332,7 +356,7 @@ fn parse_scope_filters(scope: &[String]) -> Result<Vec<(String, String)>> {
                 );
             }
             if value.is_empty() {
-                bail!("invalid --scope '{raw}': value must be non-empty");
+                bail!("invalid --scope '{raw}': value must not be empty");
             }
             Ok((key.to_string(), value.to_string()))
         })
@@ -395,6 +419,20 @@ mod tests {
     use super::*;
 
     #[test]
+    fn require_non_empty_trims_and_accepts_values() {
+        assert_eq!(require_non_empty(" Hosts ", "--category").unwrap(), "Hosts");
+    }
+
+    #[test]
+    fn require_non_empty_rejects_empty_and_whitespace() {
+        let err = require_non_empty("", "--category").unwrap_err();
+        assert!(err.to_string().contains("--category must not be empty"));
+
+        let err = require_non_empty("   ", "resource id").unwrap_err();
+        assert!(err.to_string().contains("resource id must not be empty"));
+    }
+
+    #[test]
     fn parse_scope_filters_accepts_allowed_keys() {
         let scope = vec![
             "service=checkout".to_string(),
@@ -439,7 +477,7 @@ mod tests {
     #[test]
     fn parse_scope_filters_rejects_empty_value() {
         let err = parse_scope_filters(&["service=".to_string()]).unwrap_err();
-        assert!(err.to_string().contains("must be non-empty"));
+        assert!(err.to_string().contains("must not be empty"));
     }
 
     #[test]

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -6,7 +6,7 @@ use serde_json::{json, Value};
 
 pub mod api;
 
-use api::{InfraApi, ListResourcesParams, ResourceData, ResourceTypeMapping};
+use api::{HealthHistoryEntry, InfraApi, ListResourcesParams, ResourceData, ResourceTypeMapping};
 
 use crate::config::OutputFormat;
 use crate::execution::{fan_out, ExecutionTarget};
@@ -160,6 +160,119 @@ pub async fn run_list(
     Ok(())
 }
 
+/// `cx infra resources health-history <resource-id>` - daily health status samples,
+/// oldest first.
+pub async fn run_health_history(
+    targets: &[Arc<ExecutionTarget>],
+    resource_id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", "Fetching health history...".dimmed());
+
+    let include_profile = targets.len() > 1;
+    let id = resource_id.to_string();
+
+    let per_profile = fan_out(targets, |target| {
+        let id = id.clone();
+        async move {
+            let api = InfraApi::new(&target.client);
+            Ok(api.health_history(&id).await?)
+        }
+    })
+    .await;
+
+    let merged = merge_fan_out(per_profile, |resp| resp.health_history)?;
+
+    match output {
+        OutputFormat::Json | OutputFormat::Agents => {
+            let rows: Vec<Value> = merged
+                .iter()
+                .map(|(profile, entry)| health_entry_to_json(entry, include_profile, profile))
+                .collect();
+            render_machine_rows(output, &rows)?;
+        }
+        OutputFormat::Text => {
+            if merged.is_empty() {
+                render::print_no_results("No health history found.");
+                return Ok(());
+            }
+            let rows: Vec<Vec<String>> = merged
+                .iter()
+                .map(|(profile, entry)| {
+                    vec![
+                        profile.clone(),
+                        display_or_dash(entry.timestamp.as_deref()),
+                        display_or_dash(entry.status.as_deref()),
+                    ]
+                })
+                .collect();
+            render::render_table(&["Timestamp", "Status"], rows, include_profile);
+        }
+    }
+
+    Ok(())
+}
+
+/// `cx infra resources raw-data <resource-id>` - the raw resource document.
+pub async fn run_raw_data(
+    targets: &[Arc<ExecutionTarget>],
+    resource_id: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", "Fetching raw resource data...".dimmed());
+
+    let include_profile = targets.len() > 1;
+    let id = resource_id.to_string();
+
+    let per_profile = fan_out(targets, |target| {
+        let id = id.clone();
+        async move {
+            let api = InfraApi::new(&target.client);
+            Ok(api.raw_data(&id).await?)
+        }
+    })
+    .await;
+
+    // Merge - one document per profile; a 200 with null raw data means the
+    // document is cleanly missing, so note it on stderr and move on.
+    let target_count = per_profile.len();
+    let mut error_count = 0usize;
+    let mut all_results: Vec<Value> = Vec::new();
+    for (profile, result) in per_profile {
+        match result {
+            Ok(resp) => match resp.raw_data {
+                Some(mut doc) => {
+                    if include_profile {
+                        render::tag_get_result(&mut doc, &profile);
+                    }
+                    all_results.push(doc);
+                }
+                None => eprintln!(
+                    "{}",
+                    format!("no raw data for this resource in profile '{profile}'").yellow()
+                ),
+            },
+            Err(e) => {
+                error_count += 1;
+                eprintln!("{}", format!("error from profile '{profile}': {e:#}").red());
+            }
+        }
+    }
+    if target_count > 0 && error_count == target_count {
+        bail!("all profiles returned errors; see above for details");
+    }
+
+    match output {
+        OutputFormat::Json => render::render_json_auto(&all_results)?,
+        OutputFormat::Agents => render::render_agents(&all_results)?,
+        OutputFormat::Text => {
+            render::render_get_text(&all_results, include_profile, "No raw data found.", None)?;
+        }
+    }
+
+    Ok(())
+}
+
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Flattens fan-out results into `(profile, item)` pairs, printing per-profile
@@ -249,6 +362,15 @@ fn tag_profile(mut v: Value, include_profile: bool, profile: &str) -> Value {
         }
     }
     v
+}
+
+/// Builds one health-history row as JSON for `json` / `agents` output after fan-out.
+fn health_entry_to_json(item: &HealthHistoryEntry, include_profile: bool, profile: &str) -> Value {
+    let v = json!({
+        "timestamp": item.timestamp,
+        "status": item.status,
+    });
+    tag_profile(v, include_profile, profile)
 }
 
 /// Builds one resource-type row as JSON for `json` / `agents` output after fan-out.

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -67,16 +67,11 @@ pub async fn run_types(targets: &[Arc<ExecutionTarget>], output: OutputFormat) -
                                 .as_ref()
                                 .and_then(|c| c.type_name.as_deref()),
                         ),
-                        display_or_dash(m.resource_type.as_deref()),
                         display_or_dash(m.label.as_deref()),
                     ]
                 })
                 .collect();
-            render::render_table(
-                &["Category", "Type", "Resource Type", "Label"],
-                rows,
-                include_profile,
-            );
+            render::render_table(&["Category", "Type", "Label"], rows, include_profile);
         }
     }
 
@@ -532,7 +527,6 @@ fn type_mapping_to_json(item: &ResourceTypeMapping, include_profile: bool, profi
     let v = json!({
         "category": item.category_type.as_ref().and_then(|c| c.category.clone()),
         "type": item.category_type.as_ref().and_then(|c| c.type_name.clone()),
-        "resource_type": item.resource_type,
         "label": item.label,
     });
     tag_profile(v, include_profile, profile)

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
+use toon_format::encode_default as toon_encode;
 
 pub mod api;
 
@@ -123,14 +124,19 @@ pub async fn run_list(
     })
     .await;
 
-    let mut total_count: i64 = 0;
+    let mut counts: Vec<ProfileCounts> = Vec::new();
     let mut merged: Vec<(String, ResourceData)> = Vec::new();
     for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
-        total_count += resp.total_count.unwrap_or(resp.resources.len() as i64);
+        counts.push(ProfileCounts {
+            profile: profile.clone(),
+            total_count: resp.total_count,
+            returned_count: resp.resources.len(),
+        });
         for resource in resp.resources {
             merged.push((profile.clone(), resource));
         }
     }
+    let total_count = aggregate_total(&counts);
 
     match output {
         OutputFormat::Json | OutputFormat::Agents => {
@@ -138,7 +144,8 @@ pub async fn run_list(
                 .iter()
                 .map(|(profile, r)| resource_to_json(r, include_profile, profile))
                 .collect();
-            render_machine_rows(output, &rows)?;
+            let envelope = build_list_envelope(total_count, rows, &counts, include_profile);
+            render_machine_envelope(output, &envelope)?;
         }
         OutputFormat::Text => {
             if merged.is_empty() {
@@ -158,12 +165,7 @@ pub async fn run_list(
             render::render_table(&["Resource ID", "Name"], rows, include_profile);
             eprintln!(
                 "{}",
-                format!(
-                    "Showing {} of {} total resources",
-                    merged.len(),
-                    total_count
-                )
-                .dimmed()
+                format_count_summary(merged.len(), total_count, &counts, include_profile).dimmed()
             );
         }
     }
@@ -298,6 +300,101 @@ fn render_machine_rows(output: OutputFormat, rows: &[Value]) -> Result<()> {
         OutputFormat::Agents => render::render_agents(rows),
         OutputFormat::Text => bail!("render_machine_rows called with text output"),
     }
+}
+
+/// Per-profile row counts for one `list` invocation. `total_count` is the
+/// profile's fleet-wide match count, independent of the page window.
+struct ProfileCounts {
+    profile: String,
+    total_count: i64,
+    returned_count: usize,
+}
+
+/// Sums the per-profile totals. Saturating: a fan-out across profiles whose
+/// totals sum past `i64::MAX` should clamp rather than wrap into a negative.
+fn aggregate_total(counts: &[ProfileCounts]) -> i64 {
+    counts
+        .iter()
+        .fold(0i64, |acc, c| acc.saturating_add(c.total_count))
+}
+
+/// Builds the `list` result envelope.
+///
+/// `list` is the only infra subcommand that wraps its rows instead of emitting a
+/// bare array, because `--start-row`/`--end-row` make the caller responsible for
+/// paging and `total_count` is the only stop condition available to them. Fleets
+/// can run to hundreds of thousands of resources, so the CLI deliberately does
+/// not page on the caller's behalf - it just reports the total.
+///
+/// `total_count` counts every resource matching the query, not just the rows in
+/// this window, so it is normally larger than `returned_count`.
+///
+/// Key order is meaningful: the counts precede `resources` so a consumer reading
+/// a truncated stream still sees the stop condition before the row payload.
+fn build_list_envelope(
+    total_count: i64,
+    rows: Vec<Value>,
+    counts: &[ProfileCounts],
+    include_profile: bool,
+) -> Value {
+    let mut envelope = serde_json::Map::new();
+    envelope.insert("total_count".to_string(), json!(total_count));
+    envelope.insert("returned_count".to_string(), json!(rows.len()));
+
+    if include_profile {
+        let per_profile: Vec<Value> = counts
+            .iter()
+            .map(|c| {
+                json!({
+                    JSON_KEY_PROFILE: c.profile,
+                    "total_count": c.total_count,
+                    "returned_count": c.returned_count,
+                })
+            })
+            .collect();
+        envelope.insert("counts_by_profile".to_string(), Value::Array(per_profile));
+    }
+
+    envelope.insert("resources".to_string(), Value::Array(rows));
+    Value::Object(envelope)
+}
+
+/// Renders the `list` envelope for the two machine formats.
+fn render_machine_envelope(output: OutputFormat, envelope: &Value) -> Result<()> {
+    match output {
+        OutputFormat::Json => render::render_json_auto(std::slice::from_ref(envelope)),
+        OutputFormat::Agents => {
+            let encoded =
+                toon_encode(envelope).map_err(|e| anyhow!("TOON encoding failed: {e}"))?;
+            println!("{encoded}");
+            Ok(())
+        }
+        OutputFormat::Text => bail!("render_machine_envelope called with text output"),
+    }
+}
+
+/// Formats the dimmed stderr summary line under the text-mode table. When fanning
+/// out, the per-profile lines show each profile's own returned-vs-total figures -
+/// the window applies per profile, so each is paged against its own total, not
+/// the sum.
+fn format_count_summary(
+    returned: usize,
+    total: i64,
+    counts: &[ProfileCounts],
+    include_profile: bool,
+) -> String {
+    let mut out = format!("Showing {returned} of {total} total resources");
+
+    if include_profile {
+        for c in counts {
+            out.push_str(&format!(
+                "\n  {}: {} of {}",
+                c.profile, c.returned_count, c.total_count
+            ));
+        }
+    }
+
+    out
 }
 
 /// Trims a required string input and rejects it when nothing remains, so an
@@ -467,10 +564,153 @@ mod tests {
         assert!(untagged.get("profile").is_none());
     }
 
+    // ── aggregate_total ──────────────────────────────────────────────────────
+
+    #[test]
+    fn aggregate_total_sums_profile_totals() {
+        let counts = counts(&[("prod", 150, 100), ("staging", 90, 90)]);
+        assert_eq!(aggregate_total(&counts), 240);
+    }
+
+    #[test]
+    fn aggregate_total_of_no_profiles_is_zero() {
+        assert_eq!(aggregate_total(&[]), 0);
+    }
+
+    /// Saturating rather than wrapping: a fan-out whose totals exceed `i64::MAX`
+    /// must clamp, not flip to a negative "total".
+    #[test]
+    fn aggregate_total_saturates_instead_of_overflowing() {
+        let counts = counts(&[("a", i64::MAX, 1), ("b", 1, 1)]);
+        assert_eq!(aggregate_total(&counts), i64::MAX);
+    }
+
+    // ── build_list_envelope ──────────────────────────────────────────────────
+
+    #[test]
+    fn envelope_reports_total_and_returned_counts() {
+        let counts = counts(&[("prod", 512_000, 100)]);
+        let envelope = build_list_envelope(512_000, rows(100), &counts, false);
+
+        assert_eq!(envelope["total_count"], 512_000);
+        assert_eq!(envelope["returned_count"], 100);
+        assert_eq!(envelope["resources"].as_array().unwrap().len(), 100);
+    }
+
+    /// The counts must precede `resources` so a consumer reading a truncated
+    /// stream still sees its stop condition before the row payload.
+    #[test]
+    fn envelope_orders_counts_before_resources() {
+        let counts = counts(&[("prod", 5, 5)]);
+        let envelope = build_list_envelope(5, rows(5), &counts, false);
+        let keys: Vec<&str> = envelope
+            .as_object()
+            .unwrap()
+            .keys()
+            .map(String::as_str)
+            .collect();
+        assert_eq!(keys, vec!["total_count", "returned_count", "resources"]);
+    }
+
+    /// `returned_count` tracks the rows actually emitted, so a caller can tell a
+    /// partial window from a complete one by comparing it against `total_count`.
+    #[test]
+    fn envelope_distinguishes_a_partial_window_from_the_fleet_total() {
+        let counts = counts(&[("prod", 512_000, 100)]);
+        let envelope = build_list_envelope(512_000, rows(100), &counts, false);
+
+        assert_ne!(envelope["total_count"], envelope["returned_count"]);
+        assert_eq!(envelope["total_count"], 512_000);
+        assert_eq!(envelope["returned_count"], 100);
+    }
+
+    /// `returned_count` must reflect the rows actually emitted, not a per-profile
+    /// figure - under fan-out it is the merged row count across all profiles.
+    #[test]
+    fn envelope_returned_count_matches_the_emitted_row_count() {
+        let counts = counts(&[("prod", 150, 100), ("staging", 90, 90)]);
+        let envelope = build_list_envelope(240, rows(190), &counts, true);
+
+        assert_eq!(envelope["returned_count"], 190);
+        assert_eq!(
+            envelope["returned_count"].as_u64().unwrap() as usize,
+            envelope["resources"].as_array().unwrap().len()
+        );
+    }
+
+    #[test]
+    fn envelope_omits_per_profile_counts_for_a_single_profile() {
+        let counts = counts(&[("prod", 150, 100)]);
+        let envelope = build_list_envelope(150, rows(100), &counts, false);
+        assert!(envelope.get("counts_by_profile").is_none());
+    }
+
+    /// The page window applies per profile, so a summed total alone cannot tell
+    /// a caller which profile still has rows pending.
+    #[test]
+    fn envelope_breaks_counts_down_per_profile_when_fanning_out() {
+        let counts = counts(&[("prod", 150, 100), ("staging", 90, 90)]);
+        let envelope = build_list_envelope(240, rows(190), &counts, true);
+
+        let per_profile = envelope["counts_by_profile"].as_array().unwrap();
+        assert_eq!(per_profile.len(), 2);
+        assert_eq!(per_profile[0]["profile"], "prod");
+        assert_eq!(per_profile[0]["total_count"], 150);
+        assert_eq!(per_profile[0]["returned_count"], 100);
+        assert_eq!(per_profile[1]["profile"], "staging");
+        assert_eq!(per_profile[1]["total_count"], 90);
+        assert_eq!(per_profile[1]["returned_count"], 90);
+    }
+
+    #[test]
+    fn envelope_for_no_results_still_reports_counts() {
+        let envelope = build_list_envelope(0, rows(0), &counts(&[("prod", 0, 0)]), false);
+        assert_eq!(envelope["total_count"], 0);
+        assert_eq!(envelope["returned_count"], 0);
+        assert!(envelope["resources"].as_array().unwrap().is_empty());
+    }
+
+    // ── format_count_summary ─────────────────────────────────────────────────
+
+    #[test]
+    fn count_summary_reports_the_total() {
+        let counts = counts(&[("prod", 512_000, 100)]);
+        assert_eq!(
+            format_count_summary(100, 512_000, &counts, false),
+            "Showing 100 of 512000 total resources"
+        );
+    }
+
+    #[test]
+    fn count_summary_breaks_down_per_profile_when_fanning_out() {
+        let counts = counts(&[("prod", 150, 100), ("staging", 90, 90)]);
+        assert_eq!(
+            format_count_summary(190, 240, &counts, true),
+            "Showing 190 of 240 total resources\n  prod: 100 of 150\n  staging: 90 of 90"
+        );
+    }
+
     #[test]
     fn display_or_dash_falls_back_on_none_and_empty() {
         assert_eq!(display_or_dash(Some("value")), "value");
         assert_eq!(display_or_dash(Some("")), "-");
         assert_eq!(display_or_dash(None), "-");
+    }
+
+    fn counts(entries: &[(&str, i64, usize)]) -> Vec<ProfileCounts> {
+        entries
+            .iter()
+            .map(|(profile, total_count, returned_count)| ProfileCounts {
+                profile: profile.to_string(),
+                total_count: *total_count,
+                returned_count: *returned_count,
+            })
+            .collect()
+    }
+
+    fn rows(n: usize) -> Vec<Value> {
+        (0..n)
+            .map(|i| json!({ "resource_id": format!("id-{i}") }))
+            .collect()
     }
 }

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -410,27 +410,42 @@ fn require_non_empty<'v>(value: &'v str, field_name: &str) -> Result<&'v str> {
 
 /// Parses repeatable `--scope key=value` flags and validates keys against
 /// [`ALLOWED_SCOPE_KEYS`].
+///
+/// Distinct keys are combined by the API with AND ("when more than one field is
+/// set, a resource must match all of them"). A key given twice is rejected: each
+/// scope field holds a single value server-side, so repeating one cannot express
+/// "either value".
+/// Failing here makes that intent explicit instead of quietly answering a
+/// different question.
 fn parse_scope_filters(scope: &[String]) -> Result<Vec<(String, String)>> {
-    scope
-        .iter()
-        .map(|raw| {
-            let Some((key, value)) = raw.split_once('=') else {
-                bail!("invalid --scope '{raw}': expected key=value");
-            };
-            let key = key.trim();
-            let value = value.trim();
-            if !ALLOWED_SCOPE_KEYS.contains(&key) {
-                bail!(
-                    "unknown --scope key '{key}'; allowed keys: {}",
-                    ALLOWED_SCOPE_KEYS.join(", ")
-                );
-            }
-            if value.is_empty() {
-                bail!("invalid --scope '{raw}': value must not be empty");
-            }
-            Ok((key.to_string(), value.to_string()))
-        })
-        .collect()
+    let mut filters: Vec<(String, String)> = Vec::new();
+
+    for raw in scope {
+        let Some((key, value)) = raw.split_once('=') else {
+            bail!("invalid --scope '{raw}': expected key=value");
+        };
+        let key = key.trim();
+        let value = value.trim();
+        if !ALLOWED_SCOPE_KEYS.contains(&key) {
+            bail!(
+                "unknown --scope key '{key}'; allowed keys: {}",
+                ALLOWED_SCOPE_KEYS.join(", ")
+            );
+        }
+        if value.is_empty() {
+            bail!("invalid --scope '{raw}': value must not be empty");
+        }
+        if let Some((_, existing)) = filters.iter().find(|(k, _)| k == key) {
+            bail!(
+                "--scope key '{key}' given more than once ('{existing}' then '{value}'); \
+                 each scope key accepts a single value and different keys combine with AND, \
+                 so repeating one cannot match either value - run one query per value"
+            );
+        }
+        filters.push((key.to_string(), value.to_string()));
+    }
+
+    Ok(filters)
 }
 
 /// Builds one resource row as JSON for `json` / `agents` output after fan-out.
@@ -553,6 +568,49 @@ mod tests {
     #[test]
     fn parse_scope_filters_empty_input_yields_no_filters() {
         assert!(parse_scope_filters(&[]).unwrap().is_empty());
+    }
+
+    /// Each scope field holds one value server-side and distinct keys AND
+    /// together, so a repeated key cannot mean "either". The service collapses
+    /// the query string into a `HashMap`, silently keeping only the last value -
+    /// so this must fail here rather than quietly filter on `b` alone.
+    #[test]
+    fn parse_scope_filters_rejects_a_repeated_key() {
+        let err =
+            parse_scope_filters(&["service=a".to_string(), "service=b".to_string()]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("'service' given more than once"), "got: {msg}");
+        assert!(msg.contains('a') && msg.contains('b'), "got: {msg}");
+    }
+
+    /// Rejected uniformly - "at most once per key" is a simpler rule to rely on
+    /// than one that quietly tolerates exact repeats.
+    #[test]
+    fn parse_scope_filters_rejects_a_repeated_key_even_with_the_same_value() {
+        let err =
+            parse_scope_filters(&["service=a".to_string(), "service=a".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("given more than once"));
+    }
+
+    #[test]
+    fn parse_scope_filters_detects_a_repeat_after_trimming() {
+        let err = parse_scope_filters(&[" service = a ".to_string(), "service=b".to_string()])
+            .unwrap_err();
+        assert!(err.to_string().contains("given more than once"));
+    }
+
+    /// The repeat check must not reject distinct keys that share a value.
+    #[test]
+    fn parse_scope_filters_allows_distinct_keys_sharing_a_value() {
+        let filters =
+            parse_scope_filters(&["service=core".to_string(), "team=core".to_string()]).unwrap();
+        assert_eq!(
+            filters,
+            vec![
+                ("service".to_string(), "core".to_string()),
+                ("team".to_string(), "core".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use colored::Colorize;
 use serde_json::{json, Value};
 use toon_format::encode_default as toon_encode;
@@ -176,61 +176,50 @@ pub async fn run_list(
 
 /// `cx infra resources health-history <resource-id>` - daily health status samples,
 /// oldest first.
+///
+/// Single-profile by construction (see [`single_target`]), so this issues one
+/// request and renders the response directly - no fan-out, no merge, and no
+/// profile tagging.
 pub async fn run_health_history(
     targets: &[Arc<ExecutionTarget>],
     resource_id: &str,
     output: OutputFormat,
 ) -> Result<()> {
     let resource_id = require_non_empty(resource_id, "resource id")?;
+    let target = single_target(targets, "health-history")?;
 
     eprintln!(
         "{}",
         format!("Fetching health history for '{resource_id}'...").dimmed()
     );
 
-    let include_profile = targets.len() > 1;
-    let id = resource_id.to_string();
-
-    let per_profile = fan_out(targets, |target| {
-        let id = id.clone();
-        async move {
-            let api = InfraApi::new(&target.client);
-            Ok(api.health_history(&id).await?)
-        }
-    })
-    .await;
-
-    let mut merged: Vec<(String, HealthHistoryEntry)> = Vec::new();
-    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
-        for entry in resp.health_history {
-            merged.push((profile.clone(), entry));
-        }
-    }
+    let resp = InfraApi::new(&target.client)
+        .health_history(resource_id)
+        .await
+        .with_context(|| format!("profile '{}' failed", target.profile_name))?;
+    let history = resp.health_history;
 
     match output {
         OutputFormat::Json | OutputFormat::Agents => {
-            let rows: Vec<Value> = merged
-                .iter()
-                .map(|(profile, entry)| health_entry_to_json(entry, include_profile, profile))
-                .collect();
+            let rows: Vec<Value> = history.iter().map(health_entry_to_json).collect();
             render_machine_rows(output, &rows)?;
         }
         OutputFormat::Text => {
-            if merged.is_empty() {
+            if history.is_empty() {
                 render::print_no_results("No health history found.");
                 return Ok(());
             }
-            let rows: Vec<Vec<String>> = merged
+            let rows: Vec<Vec<String>> = history
                 .iter()
-                .map(|(profile, entry)| {
+                .map(|entry| {
                     vec![
-                        profile.clone(),
+                        target.profile_name.clone(),
                         display_or_dash(entry.timestamp.as_deref()),
                         display_or_dash(entry.status.as_deref()),
                     ]
                 })
                 .collect();
-            render::render_table(&["Timestamp", "Status"], rows, include_profile);
+            render::render_table(&["Timestamp", "Status"], rows, false);
         }
     }
 
@@ -238,53 +227,43 @@ pub async fn run_health_history(
 }
 
 /// `cx infra resources raw-data <resource-id>` - the raw resource document.
+///
+/// Single-profile by construction (see [`single_target`]), so this issues one
+/// request and renders the response directly - no fan-out, no merge, and no
+/// profile tagging.
 pub async fn run_raw_data(
     targets: &[Arc<ExecutionTarget>],
     resource_id: &str,
     output: OutputFormat,
 ) -> Result<()> {
     let resource_id = require_non_empty(resource_id, "resource id")?;
+    let target = single_target(targets, "raw-data")?;
 
     eprintln!(
         "{}",
         format!("Fetching raw resource data for '{resource_id}'...").dimmed()
     );
 
-    let include_profile = targets.len() > 1;
-    let id = resource_id.to_string();
+    let resp = InfraApi::new(&target.client)
+        .raw_data(resource_id)
+        .await
+        .with_context(|| format!("profile '{}' failed", target.profile_name))?;
 
-    let per_profile = fan_out(targets, |target| {
-        let id = id.clone();
-        async move {
-            let api = InfraApi::new(&target.client);
-            Ok(api.raw_data(&id).await?)
+    // A 200 with null raw data means the document is cleanly missing, so note it
+    // on stderr and render an empty result rather than failing.
+    let results: Vec<Value> = match resp.raw_data {
+        Some(doc) => vec![doc],
+        None => {
+            eprintln!("{}", "no raw data for this resource".yellow());
+            Vec::new()
         }
-    })
-    .await;
-
-    // Merge - one document per profile; a 200 with null raw data means the
-    // document is cleanly missing, so note it on stderr and move on.
-    let mut all_results: Vec<Value> = Vec::new();
-    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
-        match resp.raw_data {
-            Some(mut doc) => {
-                if include_profile {
-                    render::tag_get_result(&mut doc, &profile);
-                }
-                all_results.push(doc);
-            }
-            None => eprintln!(
-                "{}",
-                format!("no raw data for this resource in profile '{profile}'").yellow()
-            ),
-        }
-    }
+    };
 
     match output {
-        OutputFormat::Json => render::render_json_auto(&all_results)?,
-        OutputFormat::Agents => render::render_agents(&all_results)?,
+        OutputFormat::Json => render::render_json_auto(&results)?,
+        OutputFormat::Agents => render::render_agents(&results)?,
         OutputFormat::Text => {
-            render::render_get_text(&all_results, include_profile, "No raw data found.", None)?;
+            render::render_get_text(&results, false, "No raw data found.", None)?;
         }
     }
 
@@ -416,6 +395,28 @@ fn require_non_empty<'v>(value: &'v str, field_name: &str) -> Result<&'v str> {
     Ok(trimmed)
 }
 
+/// Resolves the single target the `resource_id` subcommands operate on.
+///
+/// Resource ids are scoped to a single team, so an id
+/// resolved in one profile cannot exist in another.
+/// Fanning out would query every profile with an id that only one of
+/// them can answer, so refuse it outright.
+fn single_target<'t>(
+    targets: &'t [Arc<ExecutionTarget>],
+    subcommand: &str,
+) -> Result<&'t ExecutionTarget> {
+    match targets {
+        [target] => Ok(target),
+        [] => bail!("no profile resolved for `cx infra resources {subcommand}`"),
+        _ => bail!(
+            "`cx infra resources {subcommand}` accepts a single profile, but {} were given; \
+             a resource id is scoped to one team and cannot resolve in another profile. \
+             Re-run once per profile with a single -p.",
+            targets.len()
+        ),
+    }
+}
+
 /// Validates the `--start-row` / `--end-row` page window.
 ///
 /// The API coerces a bad window rather than rejecting it: a negative `startRow`
@@ -515,13 +516,15 @@ fn tag_profile(mut v: Value, include_profile: bool, profile: &str) -> Value {
     v
 }
 
-/// Builds one health-history row as JSON for `json` / `agents` output after fan-out.
-fn health_entry_to_json(item: &HealthHistoryEntry, include_profile: bool, profile: &str) -> Value {
-    let v = json!({
+/// Builds one health-history row as JSON for `json` / `agents` output.
+///
+/// No profile tagging: `health-history` runs against a single profile, so there
+/// is nothing to disambiguate.
+fn health_entry_to_json(item: &HealthHistoryEntry) -> Value {
+    json!({
         "timestamp": item.timestamp,
         "status": item.status,
-    });
-    tag_profile(v, include_profile, profile)
+    })
 }
 
 /// Builds one resource-type row as JSON for `json` / `agents` output after fan-out.

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -99,6 +99,7 @@ pub async fn run_list(
     let resource_type = require_non_empty(resource_type, "--type")?;
     let name_filter = name_filter.map(str::trim).filter(|s| !s.is_empty());
     let scope_filters = parse_scope_filters(scope)?;
+    validate_page_window(start_row, end_row)?;
 
     eprintln!("{}", "Fetching resources...".dimmed());
 
@@ -408,6 +409,40 @@ fn require_non_empty<'v>(value: &'v str, field_name: &str) -> Result<&'v str> {
     Ok(trimmed)
 }
 
+/// Validates the `--start-row` / `--end-row` page window.
+///
+/// The API coerces a bad window rather than rejecting it: a negative `startRow`
+/// is clamped to `0`, and a window whose end is at or before its start yields a
+/// row count of `0`.
+///
+/// Deliberately not checked here: the service's ceiling on `startRow + rows`.
+/// That is a server-side policy constant which the CLI should not mirror, and its
+/// 400 already names the limit and how to get under it.
+fn validate_page_window(start_row: Option<i64>, end_row: Option<i64>) -> Result<()> {
+    if let Some(start) = start_row {
+        if start < 0 {
+            bail!("--start-row must not be negative (got {start}); rows are 0-based");
+        }
+    }
+
+    if let Some(end) = end_row {
+        if end < 0 {
+            bail!("--end-row must not be negative (got {end})");
+        }
+    }
+
+    if let (Some(start), Some(end)) = (start_row, end_row) {
+        if end <= start {
+            bail!(
+                "--end-row ({end}) must be greater than --start-row ({start}); \
+                 --end-row is exclusive, so this window selects no rows"
+            );
+        }
+    }
+
+    Ok(())
+}
+
 /// Parses repeatable `--scope key=value` flags and validates keys against
 /// [`ALLOWED_SCOPE_KEYS`].
 ///
@@ -597,6 +632,55 @@ mod tests {
         let err = parse_scope_filters(&[" service = a ".to_string(), "service=b".to_string()])
             .unwrap_err();
         assert!(err.to_string().contains("given more than once"));
+    }
+
+    // ── validate_page_window ─────────────────────────────────────────────────
+
+    #[test]
+    fn page_window_accepts_an_ascending_window_and_open_ends() {
+        assert!(validate_page_window(None, None).is_ok());
+        assert!(validate_page_window(Some(0), Some(100)).is_ok());
+        assert!(validate_page_window(Some(100), Some(200)).is_ok());
+        assert!(validate_page_window(Some(100), None).is_ok());
+        assert!(validate_page_window(None, Some(50)).is_ok());
+        assert!(validate_page_window(Some(0), Some(1)).is_ok());
+    }
+
+    /// The API clamps a negative `startRow` to 0 and returns 200, so without this
+    /// check the caller silently gets the first window instead of an error.
+    #[test]
+    fn page_window_rejects_a_negative_start_row() {
+        let err = validate_page_window(Some(-5), None).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("--start-row must not be negative"),
+            "got: {msg}"
+        );
+        assert!(msg.contains("-5"), "got: {msg}");
+    }
+
+    #[test]
+    fn page_window_rejects_a_negative_end_row() {
+        let err = validate_page_window(None, Some(-1)).unwrap_err();
+        assert!(err.to_string().contains("--end-row must not be negative"));
+    }
+
+    /// An inverted window yields a row count of 0 server-side, so the caller sees
+    /// an empty result set and can easily read it as "no such resources".
+    #[test]
+    fn page_window_rejects_an_inverted_window() {
+        let err = validate_page_window(Some(200), Some(100)).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("must be greater than"), "got: {msg}");
+        assert!(msg.contains("100") && msg.contains("200"), "got: {msg}");
+    }
+
+    /// `--end-row` is exclusive, so an equal start and end can only ever return
+    /// nothing - always a mistake rather than a meaningful request.
+    #[test]
+    fn page_window_rejects_an_empty_window() {
+        let err = validate_page_window(Some(100), Some(100)).unwrap_err();
+        assert!(err.to_string().contains("selects no rows"));
     }
 
     /// The repeat check must not reject distinct keys that share a value.

--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -387,3 +387,79 @@ fn type_mapping_to_json(item: &ResourceTypeMapping, include_profile: bool, profi
 fn display_or_dash(value: Option<&str>) -> String {
     value.filter(|s| !s.is_empty()).unwrap_or("-").to_string()
 }
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_scope_filters_accepts_allowed_keys() {
+        let scope = vec![
+            "service=checkout".to_string(),
+            "environment=prod".to_string(),
+            "team=platform".to_string(),
+        ];
+        let filters = parse_scope_filters(&scope).unwrap();
+        assert_eq!(
+            filters,
+            vec![
+                ("service".to_string(), "checkout".to_string()),
+                ("environment".to_string(), "prod".to_string()),
+                ("team".to_string(), "platform".to_string()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_scope_filters_trims_whitespace() {
+        let scope = vec![" service = checkout ".to_string()];
+        let filters = parse_scope_filters(&scope).unwrap();
+        assert_eq!(
+            filters,
+            vec![("service".to_string(), "checkout".to_string())]
+        );
+    }
+
+    #[test]
+    fn parse_scope_filters_rejects_missing_equals() {
+        let err = parse_scope_filters(&["service".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("expected key=value"));
+    }
+
+    #[test]
+    fn parse_scope_filters_rejects_unknown_key() {
+        let err = parse_scope_filters(&["region=us-east-1".to_string()]).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown --scope key 'region'"));
+        assert!(msg.contains("service, environment, team"));
+    }
+
+    #[test]
+    fn parse_scope_filters_rejects_empty_value() {
+        let err = parse_scope_filters(&["service=".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("must be non-empty"));
+    }
+
+    #[test]
+    fn parse_scope_filters_empty_input_yields_no_filters() {
+        assert!(parse_scope_filters(&[]).unwrap().is_empty());
+    }
+
+    #[test]
+    fn tag_profile_inserts_key_only_when_multi_profile() {
+        let tagged = tag_profile(json!({"a": 1}), true, "prod");
+        assert_eq!(tagged["profile"], "prod");
+
+        let untagged = tag_profile(json!({"a": 1}), false, "prod");
+        assert!(untagged.get("profile").is_none());
+    }
+
+    #[test]
+    fn display_or_dash_falls_back_on_none_and_empty() {
+        assert_eq!(display_or_dash(Some("value")), "value");
+        assert_eq!(display_or_dash(Some("")), "-");
+        assert_eq!(display_or_dash(None), "-");
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -16,6 +16,7 @@ pub mod docs;
 pub mod e2m;
 pub mod enrichments;
 pub mod extensions;
+pub mod infra;
 pub mod integrations;
 pub mod ip_access;
 pub mod logs;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2607,7 +2607,8 @@ Examples:
         #[arg(long)]
         start_row: Option<i64>,
 
-        /// Row after the last one of the page window (default: start-row + 100).
+        /// Row after the last one of the page window, exclusive (default:
+        /// start-row + 100). The API rejects windows reaching past row 10,000.
         #[arg(long)]
         end_row: Option<i64>,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -2598,7 +2598,8 @@ Examples:
         #[arg(long)]
         name_filter: Option<String>,
 
-        /// Scope filter as key=value; repeatable. Keys: service, environment, team.
+        /// Scope filter as key=value; repeatable across different keys, at most
+        /// once per key. Keys: service, environment, team. Multiple keys AND together.
         #[arg(long)]
         scope: Vec<String>,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2565,7 +2565,9 @@ enum InfraCmd {
     #[command(after_help = "\
 Examples:
   cx infra resources types
-  cx infra resources list --category Hosts --type EC2_Instances --scope environment=prod")]
+  cx infra resources list --category Hosts --type EC2_Instances --scope environment=prod
+  cx infra resources health-history \"1001234:host_id=i-abc123\"
+  cx infra resources raw-data \"1001234:host_id=i-abc123\"")]
     Resources {
         #[command(subcommand)]
         cmd: InfraResourcesCmd,
@@ -2607,6 +2609,23 @@ Examples:
         /// Row after the last one of the page window (default: start-row + 100).
         #[arg(long)]
         end_row: Option<i64>,
+    },
+    /// Show the daily health status history for a resource.
+    #[command(after_help = "\
+Examples:
+  cx infra resources health-history \"1001234:host_id=i-abc123\"")]
+    HealthHistory {
+        /// Resource ID, exactly as returned by `cx infra resources list`.
+        resource_id: String,
+    },
+    /// Fetch the raw resource document as JSON.
+    #[command(after_help = "\
+Examples:
+  cx infra resources raw-data \"1001234:host_id=i-abc123\"
+  cx infra resources raw-data \"1001234:host_id=i-abc123\" -o json")]
+    RawData {
+        /// Resource ID, exactly as returned by `cx infra resources list`.
+        resource_id: String,
     },
 }
 
@@ -4195,6 +4214,13 @@ async fn main() -> Result<()> {
                             output,
                         )
                         .await?;
+                    }
+                    InfraResourcesCmd::HealthHistory { resource_id } => {
+                        commands::infra::run_health_history(&targets, &resource_id, output)
+                            .await?;
+                    }
+                    InfraResourcesCmd::RawData { resource_id } => {
+                        commands::infra::run_raw_data(&targets, &resource_id, output).await?;
                     }
                 },
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -528,7 +528,7 @@ Examples:
         cmd: SlosCmd,
     },
 
-    /// Query infrastructure resources and their health.
+    /// Query infrastructure resources and their data.
     #[command(after_help = "\
 Examples:
   cx infra resources types

--- a/src/main.rs
+++ b/src/main.rs
@@ -531,7 +531,8 @@ Examples:
     /// Query infrastructure resources and their health.
     #[command(after_help = "\
 Examples:
-  cx infra resources types")]
+  cx infra resources types
+  cx infra resources list --category Hosts --type EC2_Instances")]
     Infra {
         #[command(subcommand)]
         cmd: InfraCmd,
@@ -2563,7 +2564,8 @@ enum InfraCmd {
     /// Query infrastructure resources.
     #[command(after_help = "\
 Examples:
-  cx infra resources types")]
+  cx infra resources types
+  cx infra resources list --category Hosts --type EC2_Instances --scope environment=prod")]
     Resources {
         #[command(subcommand)]
         cmd: InfraResourcesCmd,
@@ -2574,6 +2576,38 @@ Examples:
 enum InfraResourcesCmd {
     /// List the available resource types (category/type pairs).
     Types,
+    /// List resources of a given category and type.
+    #[command(after_help = "\
+Examples:
+  cx infra resources list --category Hosts --type EC2_Instances
+  cx infra resources list --category Hosts --type EC2_Instances --name-filter web
+  cx infra resources list --category Hosts --type EC2_Instances --scope service=checkout --scope environment=prod
+  cx infra resources list --category Hosts --type EC2_Instances --start-row 100 --end-row 200")]
+    List {
+        /// Resource category (discover with `cx infra resources types`).
+        #[arg(long)]
+        category: String,
+
+        /// Resource type within the category (discover with `cx infra resources types`).
+        #[arg(long)]
+        r#type: String,
+
+        /// Filter resources by name.
+        #[arg(long)]
+        name_filter: Option<String>,
+
+        /// Scope filter as key=value; repeatable. Keys: service, environment, team.
+        #[arg(long)]
+        scope: Vec<String>,
+
+        /// First row of the page window (0-based; default 0).
+        #[arg(long)]
+        start_row: Option<i64>,
+
+        /// Row after the last one of the page window (default: start-row + 100).
+        #[arg(long)]
+        end_row: Option<i64>,
+    },
 }
 
 #[tokio::main]
@@ -4141,6 +4175,26 @@ async fn main() -> Result<()> {
                 InfraCmd::Resources { cmd } => match cmd {
                     InfraResourcesCmd::Types => {
                         commands::infra::run_types(&targets, output).await?;
+                    }
+                    InfraResourcesCmd::List {
+                        category,
+                        r#type,
+                        name_filter,
+                        scope,
+                        start_row,
+                        end_row,
+                    } => {
+                        commands::infra::run_list(
+                            &targets,
+                            &category,
+                            &r#type,
+                            name_filter.as_deref(),
+                            &scope,
+                            start_row,
+                            end_row,
+                            output,
+                        )
+                        .await?;
                     }
                 },
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ pub enum SearchByValueDataset {
   \x1b[1mdashboards\x1b[0m         Manage dashboards and dashboard folders
   \x1b[1mviews\x1b[0m              Manage saved views and view folders
   \x1b[1mslos\x1b[0m               Manage SLO definitions
+  \x1b[1minfra\x1b[0m              Query infrastructure resources and their data
 
 \x1b[1m\x1b[4mAI:\x1b[0m
   \x1b[1mai-center\x1b[0m (risky)  Manage AI Center applications, evaluations, policies, and pricing
@@ -525,6 +526,15 @@ Examples:
     Slos {
         #[command(subcommand)]
         cmd: SlosCmd,
+    },
+
+    /// Query infrastructure resources and their health.
+    #[command(after_help = "\
+Examples:
+  cx infra resources types")]
+    Infra {
+        #[command(subcommand)]
+        cmd: InfraCmd,
     },
 
     /// Search log/span fields by description or by value content.
@@ -2548,6 +2558,24 @@ Examples:
     },
 }
 
+#[derive(Subcommand)]
+enum InfraCmd {
+    /// Query infrastructure resources.
+    #[command(after_help = "\
+Examples:
+  cx infra resources types")]
+    Resources {
+        #[command(subcommand)]
+        cmd: InfraResourcesCmd,
+    },
+}
+
+#[derive(Subcommand)]
+enum InfraResourcesCmd {
+    /// List the available resource types (category/type pairs).
+    Types,
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Handle shell completions before any stdout output.
@@ -4107,6 +4135,14 @@ async fn main() -> Result<()> {
                     confirm_destructive(&format!("Delete SLO '{id}'?"), yes, agent_mode)?;
                     commands::slos::run_delete(&targets, &id).await?;
                 }
+            },
+
+            Commands::Infra { cmd } => match cmd {
+                InfraCmd::Resources { cmd } => match cmd {
+                    InfraResourcesCmd::Types => {
+                        commands::infra::run_types(&targets, output).await?;
+                    }
+                },
             },
 
             Commands::SearchFields {

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -44,6 +44,8 @@ mod e2m;
 mod enrichments;
 #[path = "e2e/extensions.rs"]
 mod extensions;
+#[path = "e2e/infra.rs"]
+mod infra;
 #[path = "e2e/integrations.rs"]
 mod integrations;
 #[path = "e2e/ip_access.rs"]

--- a/tests/e2e/infra.rs
+++ b/tests/e2e/infra.rs
@@ -33,7 +33,15 @@ fn infra_list() {
         "-o",
         "json",
     ]);
-    harness::assert_array_of_objects_with_keys(&v, &["resource_id", "name"]);
+    // `list` returns an envelope, not a bare array: callers page with
+    // `--start-row`/`--end-row` and `total_count` is their only stop condition.
+    harness::assert_object_with_keys(&v, &["total_count", "returned_count", "resources"]);
+    assert!(
+        v["total_count"].is_i64(),
+        "total_count should be a number, got {:?} - callers have no stop condition without it",
+        v["total_count"]
+    );
+    harness::assert_array_of_objects_with_keys(&v["resources"], &["resource_id", "name"]);
 }
 
 #[test]
@@ -102,7 +110,8 @@ fn discover_resource_id() -> Option<String> {
                 "json",
             ]);
             let v = harness::parse_json(&stdout)?;
-            v.as_array()?
+            v.get("resources")?
+                .as_array()?
                 .iter()
                 .find_map(|item| item.get("resource_id")?.as_str().map(String::from))
         })

--- a/tests/e2e/infra.rs
+++ b/tests/e2e/infra.rs
@@ -9,7 +9,14 @@ fn infra_types() {
         return;
     }
     let v = harness::run_ok_json(&["infra", "resources", "types", "-o", "json"]);
-    harness::assert_array_of_objects_with_keys(&v, &["category", "type", "resource_type"]);
+    harness::assert_array_of_objects_with_keys(&v, &["category", "type", "label"]);
+    // `resourceType` is returned by the API but deliberately not surfaced.
+    for item in v.as_array().unwrap_or(&vec![]) {
+        assert!(
+            item.get("resource_type").is_none(),
+            "resource_type must not be surfaced, got: {item}"
+        );
+    }
 }
 
 #[test]

--- a/tests/e2e/infra.rs
+++ b/tests/e2e/infra.rs
@@ -1,0 +1,113 @@
+use std::sync::OnceLock;
+
+use crate::harness;
+
+#[test]
+#[ignore]
+fn infra_types() {
+    if harness::require_creds("infra_types").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&["infra", "resources", "types", "-o", "json"]);
+    harness::assert_array_of_objects_with_keys(&v, &["category", "type", "resource_type"]);
+}
+
+#[test]
+#[ignore]
+fn infra_list() {
+    if harness::require_creds("infra_list").is_none() {
+        return;
+    }
+    let Some((category, resource_type)) = discover_category_type() else {
+        eprintln!("[e2e] skipping infra_list: no resource types on test team");
+        return;
+    };
+    let v = harness::run_ok_json(&[
+        "infra",
+        "resources",
+        "list",
+        "--category",
+        &category,
+        "--type",
+        &resource_type,
+        "-o",
+        "json",
+    ]);
+    harness::assert_array_of_objects_with_keys(&v, &["resource_id", "name"]);
+}
+
+#[test]
+#[ignore]
+fn infra_health_history() {
+    if harness::require_creds("infra_health_history").is_none() {
+        return;
+    }
+    let Some(id) = discover_resource_id() else {
+        eprintln!("[e2e] skipping infra_health_history: no resources on test team");
+        return;
+    };
+    let v = harness::run_ok_json(&["infra", "resources", "health-history", &id, "-o", "json"]);
+    harness::assert_array_of_objects_with_keys(&v, &["timestamp", "status"]);
+}
+
+#[test]
+#[ignore]
+fn infra_raw_data() {
+    if harness::require_creds("infra_raw_data").is_none() {
+        return;
+    }
+    let Some(id) = discover_resource_id() else {
+        eprintln!("[e2e] skipping infra_raw_data: no resources on test team");
+        return;
+    };
+    // The document shape is source-specific, so only verify exit 0 + valid JSON.
+    let stdout = harness::run_ok(&["infra", "resources", "raw-data", &id, "-o", "json"]);
+    harness::parse_json(&stdout).expect("raw-data should emit valid JSON");
+}
+
+/// Discover a (category, type) pair from `infra resources types`. Cached so
+/// multiple tests don't each pay for the call.
+fn discover_category_type() -> Option<(String, String)> {
+    static CACHE: OnceLock<Option<(String, String)>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            harness::require_creds("infra_discover_types")?;
+            let stdout = harness::run_ok(&["infra", "resources", "types", "-o", "json"]);
+            let v = harness::parse_json(&stdout)?;
+            v.as_array()?.iter().find_map(|item| {
+                let category = item.get("category")?.as_str()?.to_string();
+                let resource_type = item.get("type")?.as_str()?.to_string();
+                Some((category, resource_type))
+            })
+        })
+        .clone()
+}
+
+/// Discover a resource id via `infra resources list` for the first available
+/// resource type. Cached across the health-history and raw-data tests.
+fn discover_resource_id() -> Option<String> {
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            let (category, resource_type) = discover_category_type()?;
+            let stdout = harness::run_ok(&[
+                "infra",
+                "resources",
+                "list",
+                "--category",
+                &category,
+                "--type",
+                &resource_type,
+                "-o",
+                "json",
+            ]);
+            let v = harness::parse_json(&stdout)?;
+            v.as_array()?
+                .iter()
+                .find_map(|item| item.get("resource_id")?.as_str().map(String::from))
+        })
+        .clone()
+}
+
+// `infra` has no mutating subcommands, so there is nothing deliberately
+// uncovered here - all four read-only subcommands are exercised above.

--- a/tests/infra/main.rs
+++ b/tests/infra/main.rs
@@ -8,7 +8,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 use coralogix_cli::commands::infra::{run_health_history, run_list, run_raw_data, run_types};
 use coralogix_cli::config::OutputFormat;
 
-const BASE: &str = "/infrastructure/resources/v1";
+const BASE: &str = "/mgmt/api/infrastructure/resources/v1";
 
 fn types_body() -> serde_json::Value {
     json!({

--- a/tests/infra/main.rs
+++ b/tests/infra/main.rs
@@ -1,0 +1,347 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{method, path, query_param, query_param_is_missing};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use coralogix_cli::commands::infra::{run_health_history, run_list, run_raw_data, run_types};
+use coralogix_cli::config::OutputFormat;
+
+const BASE: &str = "/infrastructure/resources/v1";
+
+fn types_body() -> serde_json::Value {
+    json!({
+        "resourceTypes": [
+            {
+                "categoryType": { "category": "Hosts", "type": "EC2_Instances" },
+                "resourceType": "aws_ec2_instance",
+                "label": "EC2 Instances"
+            }
+        ]
+    })
+}
+
+#[tokio::test]
+async fn types_returns_mappings_from_mock() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/types")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(types_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_types(&targets, OutputFormat::Json)
+        .await
+        .expect("run_types should succeed");
+}
+
+#[tokio::test]
+async fn types_merges_multiple_profiles() {
+    let server_a = MockServer::start().await;
+    let server_b = MockServer::start().await;
+
+    for server in [&server_a, &server_b] {
+        Mock::given(method("GET"))
+            .and(path(format!("{BASE}/types")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(types_body()))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    let targets = vec![
+        common::test_target("profile-a", &server_a.uri()),
+        common::test_target("profile-b", &server_b.uri()),
+    ];
+
+    run_types(&targets, OutputFormat::Json)
+        .await
+        .expect("run_types should merge both profiles");
+}
+
+#[tokio::test]
+async fn types_tolerates_one_failing_profile() {
+    let server_ok = MockServer::start().await;
+    let server_err = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/types")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(types_body()))
+        .expect(1)
+        .mount(&server_ok)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/types")))
+        .respond_with(
+            ResponseTemplate::new(500).set_body_json(json!({ "error": "backend exploded" })),
+        )
+        .expect(1)
+        .mount(&server_err)
+        .await;
+
+    let targets = vec![
+        common::test_target("profile-ok", &server_ok.uri()),
+        common::test_target("profile-err", &server_err.uri()),
+    ];
+
+    run_types(&targets, OutputFormat::Json)
+        .await
+        .expect("one failing profile should be non-fatal");
+}
+
+#[tokio::test]
+async fn types_errors_when_all_profiles_fail() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/types")))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({ "error": "boom" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let result = run_types(&targets, OutputFormat::Json).await;
+    assert!(result.is_err(), "all profiles failing should be an error");
+}
+
+#[tokio::test]
+async fn list_sends_all_query_params() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .and(query_param("category", "Hosts"))
+        .and(query_param("type", "EC2_Instances"))
+        .and(query_param("nameFilter", "web"))
+        .and(query_param("scopeFilter.service", "checkout"))
+        .and(query_param("scopeFilter.environment", "prod"))
+        .and(query_param("startRow", "100"))
+        .and(query_param("endRow", "200"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resources": [
+                {
+                    "resourceId": "1001234:host_id=i-abc123",
+                    "name": "web-server-1",
+                    "columns": { "region": "us-east-1" }
+                }
+            ],
+            "totalCount": 1
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    let scope = vec![
+        "service=checkout".to_string(),
+        "environment=prod".to_string(),
+    ];
+
+    run_list(
+        &targets,
+        "Hosts",
+        "EC2_Instances",
+        Some("web"),
+        &scope,
+        Some(100),
+        Some(200),
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_list should send all query params");
+}
+
+#[tokio::test]
+async fn list_omits_optional_query_params() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .and(query_param("category", "Hosts"))
+        .and(query_param("type", "EC2_Instances"))
+        .and(query_param_is_missing("nameFilter"))
+        .and(query_param_is_missing("startRow"))
+        .and(query_param_is_missing("endRow"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resources": [],
+            "totalCount": 0
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_list(
+        &targets,
+        "Hosts",
+        "EC2_Instances",
+        None,
+        &[],
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_list should succeed with an empty response");
+}
+
+#[tokio::test]
+async fn list_rejects_invalid_scope_before_any_request() {
+    let server = MockServer::start().await;
+    // No mocks mounted: an invalid --scope must fail client-side without HTTP.
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+    let scope = vec!["region=us-east-1".to_string()];
+
+    let result = run_list(
+        &targets,
+        "Hosts",
+        "EC2_Instances",
+        None,
+        &scope,
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await;
+
+    let err = result.expect_err("unknown scope key should error");
+    assert!(err.to_string().contains("unknown --scope key 'region'"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn health_history_percent_encodes_resource_id() {
+    let server = MockServer::start().await;
+
+    // `:` and `=` in the resource id must reach the server percent-encoded.
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "{BASE}/1001234%3Ahost_id%3Di-abc123/health-history"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "healthHistory": [
+                { "timestamp": "2026-07-01T00:00:00Z", "status": "Healthy" },
+                { "timestamp": "2026-07-02T00:00:00Z", "status": "Critical" }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_health_history(&targets, "1001234:host_id=i-abc123", OutputFormat::Json)
+        .await
+        .expect("run_health_history should hit the encoded path");
+}
+
+#[tokio::test]
+async fn health_history_handles_empty_history() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/plain-id/health-history")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "healthHistory": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_health_history(&targets, "plain-id", OutputFormat::Json)
+        .await
+        .expect("empty health history should succeed");
+}
+
+#[tokio::test]
+async fn raw_data_returns_document() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!(
+            "{BASE}/1001234%3Ahost_id%3Di-abc123/raw-data"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "rawData": { "host_id": "i-abc123", "tags": { "env": "prod" } }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_raw_data(&targets, "1001234:host_id=i-abc123", OutputFormat::Json)
+        .await
+        .expect("run_raw_data should succeed");
+}
+
+#[tokio::test]
+async fn raw_data_handles_null_document() {
+    let server = MockServer::start().await;
+
+    // A 200 with null rawData means "cleanly missing" - not an error.
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/plain-id/raw-data")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "rawData": null })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_raw_data(&targets, "plain-id", OutputFormat::Json)
+        .await
+        .expect("null raw data should succeed");
+}
+
+#[tokio::test]
+async fn api_error_body_surfaces_in_message() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/types")))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "error": "category is required and must be non-empty"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let err = run_types(&targets, OutputFormat::Json)
+        .await
+        .expect_err("400 from the only profile should error");
+    // The service's {"error": ...} body must survive into the user-facing message.
+    assert!(err.to_string().contains("see above for details"));
+}
+
+#[tokio::test]
+async fn all_output_formats_render() {
+    for format in [OutputFormat::Text, OutputFormat::Json, OutputFormat::Agents] {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(format!("{BASE}/types")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(types_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let targets = vec![common::test_target("test-profile", &server.uri())];
+
+        run_types(&targets, format)
+            .await
+            .unwrap_or_else(|e| panic!("run_types should render {format:?}: {e:#}"));
+    }
+}

--- a/tests/infra/main.rs
+++ b/tests/infra/main.rs
@@ -322,8 +322,11 @@ async fn api_error_body_surfaces_in_message() {
     let err = run_types(&targets, OutputFormat::Json)
         .await
         .expect_err("400 from the only profile should error");
-    // The service's {"error": ...} body must survive into the user-facing message.
-    assert!(err.to_string().contains("see above for details"));
+    // With a single profile the actual error propagates (FORGE-482), so the
+    // service's {"error": ...} body must survive into the error chain.
+    let chain = format!("{err:#}");
+    assert!(chain.contains("category is required and must be non-empty"));
+    assert!(chain.contains("profile 'test-profile' failed"));
 }
 
 #[tokio::test]

--- a/tests/infra/main.rs
+++ b/tests/infra/main.rs
@@ -348,3 +348,102 @@ async fn all_output_formats_render() {
             .unwrap_or_else(|e| panic!("run_types should render {format:?}: {e:#}"));
     }
 }
+
+// ── Single-profile enforcement for the id-taking subcommands ──────────────────
+
+/// A resource id embeds the team id, so it can only resolve in the profile it
+/// came from. The command must refuse before issuing any request.
+#[tokio::test]
+async fn health_history_rejects_multiple_profiles() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "healthHistory": [] })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let targets = vec![
+        common::test_target("prod", &server.uri()),
+        common::test_target("staging", &server.uri()),
+    ];
+
+    let err = run_health_history(&targets, "1001234:host_id=i-abc123", OutputFormat::Json)
+        .await
+        .expect_err("health-history must reject multiple profiles");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("health-history"), "got: {msg}");
+    assert!(msg.contains("single profile"), "got: {msg}");
+    assert!(
+        msg.contains('2'),
+        "error should name the profile count, got: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn raw_data_rejects_multiple_profiles() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "rawData": null })))
+        .expect(0)
+        .mount(&server)
+        .await;
+
+    let targets = vec![
+        common::test_target("prod", &server.uri()),
+        common::test_target("staging", &server.uri()),
+    ];
+
+    let err = run_raw_data(&targets, "1001234:host_id=i-abc123", OutputFormat::Json)
+        .await
+        .expect_err("raw-data must reject multiple profiles");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("raw-data"), "got: {msg}");
+    assert!(msg.contains("single profile"), "got: {msg}");
+}
+
+/// `types` and `list` take no resource id, so comparing fleets across accounts
+/// is a supported use - the guard must not leak into them.
+#[tokio::test]
+async fn types_and_list_still_fan_out_across_profiles() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/types")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(types_body()))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "resources": [{ "resourceId": "1001234:host_id=i-abc123", "name": "web-1" }],
+            "totalCount": 1
+        })))
+        .expect(2)
+        .mount(&server)
+        .await;
+
+    let targets = vec![
+        common::test_target("prod", &server.uri()),
+        common::test_target("staging", &server.uri()),
+    ];
+
+    run_types(&targets, OutputFormat::Json)
+        .await
+        .expect("types should fan out");
+    run_list(
+        &targets,
+        "Hosts",
+        "EC2_Instances",
+        None,
+        &[],
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("list should fan out");
+}

--- a/tests/schema/main.rs
+++ b/tests/schema/main.rs
@@ -44,6 +44,7 @@ fn schema_outputs_valid_json_with_expected_commands() {
     assert!(names.contains(&"docs"), "missing docs");
     assert!(names.contains(&"olly"), "missing olly");
     assert!(names.contains(&"ai-center"), "missing ai-center");
+    assert!(names.contains(&"infra"), "missing infra");
 
     // Verify old commands are gone
     assert!(

--- a/tests/schema/main.rs
+++ b/tests/schema/main.rs
@@ -21,7 +21,7 @@ fn schema_outputs_valid_json_with_expected_commands() {
     let commands = schema["commands"]
         .as_array()
         .expect("commands should be an array");
-    assert_eq!(commands.len(), 29, "expected 29 top-level commands");
+    assert_eq!(commands.len(), 30, "expected 30 top-level commands");
 
     let names: Vec<&str> = commands
         .iter()


### PR DESCRIPTION
### Description
Add a new `cx infra` command for the infrastructure domain, following Archetype B (REST-based). The command is structured as a wrapper with a `resources` subgroup. This is because the infrastructure domain will grow beyond the resources functionality.

The initial scope (resources) lets users discover available infrastructure resources. For now they will be able to:

1. get available resource types
2. find resources
3. inspect their daily health history
4. fetch the raw resource data.

The command will appear in the hierarchy under the **Observe** group as a read-only command (the API is GET-only).

For more details check the issue here: https://github.com/coralogix/cx-cli/issues/170.

### Testing

There are e2e tests ready to be run manually (they are disabled by default). In order for them to run, setup a `.env` file. Use the provided `.env.example`. You will need to generate your API Key.