### PR TITLE
Add cx-onboarding and cx-system-health skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Install globally for all projects:
 npx skills add coralogix/cx-cli -g
 ```
 
-Available skills: `cx-query-logs`, `cx-query-spans`, `cx-metrics-query`, `cx-alerts`, `cx-dataprime`, `cx-rum`, `cx-telemetry-querying`, `cx-dashboards`, `cx-cost-optimization`, `cx-cases`, `cx-slos`, `cx-data-pipeline`, `cx-platform-admin`, `cx-observability-setup`. See [skills/README.md](https://github.com/coralogix/cx-cli/blob/master/skills/README.md) for per-skill usage.
+Available skills: `cx-query-logs`, `cx-query-spans`, `cx-metrics-query`, `cx-alerts`, `cx-dataprime`, `cx-rum`, `cx-telemetry-querying`, `cx-dashboards`, `cx-cost-optimization`, `cx-cases`, `cx-slos`, `cx-data-pipeline`, `cx-platform-admin`, `cx-observability-setup`, `cx-onboarding`, `cx-system-health`. See [skills/README.md](https://github.com/coralogix/cx-cli/blob/master/skills/README.md) for per-skill usage.
 
 ## Multi-profile fan-out
 

--- a/contributing/health-reference-md-template.md
+++ b/contributing/health-reference-md-template.md
@@ -1,0 +1,70 @@
+# Health reference MD — authoring template
+
+> **What this is.** The standard shape for a per-experience/extension health reference loaded by the
+> `cx-system-health` orchestrator (`skills/cx-system-health/references/health-<surface>.md`). Copy,
+> rename, fill every section. The orchestrator handles the verdict model + routing; your reference
+> defines *the conditions for one surface and how to verify them*.
+>
+> **Sibling template:** for *getting data in*, use `onboarding-reference-md-template.md` instead. This
+> one is for *checking data already there is healthy/complete*.
+>
+> **Golden rules:**
+> 1. **Every condition is checkable read-only** with a `cx` query — no mutation to assess health.
+> 2. **Every failing condition names the reason AND the route to fix it** (usually back to
+>    `cx-onboarding`). A verdict with no remediation is not actionable.
+> 3. **Distinguish a data verdict from a tier verdict** — "healthy data but the experience is hidden by
+>    tier" is a different answer than "no data".
+> 4. **Write conditions, not internal APIs.** The backing verdict source may change — keep the
+>    reference to "here's the condition and how to verify it" so it survives either design.
+
+Delete this callout in real reference files. Keep the structure below.
+
+---
+
+# Health: <Experience / extension name>
+
+One or two sentences: what this surface needs telemetry to look like to deliver value.
+
+## When to use this reference
+
+Intent phrases that route here. Note anything that should go elsewhere (e.g. "never set up →
+cx-onboarding"; "investigate a specific error → cx-telemetry-querying").
+
+## Conditions & checks
+
+A table — one row per condition. Kinds: Presence / Continuity / Completeness / Quality.
+
+| # | Condition | Kind | Check (read-only `cx` query) | Fail → |
+|---|---|---|---|---|
+| 1 | <the signal arrives now> | Presence | `cx <...>` | **missing** → route |
+| 2 | <required attribute present> | Completeness | `cx <...> -o json` / `cx search-fields` | **degraded** → fix |
+| 3 | <quality bar> | Quality | `<check>` | **degraded** → fix |
+
+## Verdict → remediation
+
+For each verdict, the concrete route: which `cx-onboarding` reference (or other skill) fixes it, and
+the smallest change that flips it back to healthy.
+
+## Surface-specific gotchas
+
+The traps unique to this surface (e.g. accidental 100% sampling; naming fragmentation; blank service
+names). These are where "looks healthy but isn't useful" hides.
+
+## Tier note
+
+How tier affects whether the *experience* is visible even with healthy data. Separate tier verdicts
+from data verdicts.
+
+## AI layers
+
+- **Layer 1 (no-AI):** the condition table.
+- **Layer 2 (minimal free):** optional — rank/phrase verdicts (cheap model; absorbed cost in COGS).
+- **Layer 3 (Olly, paid):** optional — diagnose + propose fix (credit-gated).
+
+## Docs deep-links
+
+- <canonical doc page(s)>
+
+## Sources / evidence
+
+Where the conditions came from (docs, support cases, first-hand knowledge). Cite sources.

--- a/contributing/onboarding-reference-md-template.md
+++ b/contributing/onboarding-reference-md-template.md
@@ -1,0 +1,108 @@
+# Onboarding reference MD — authoring template
+
+> **What this is.** The standard shape for a per-product onboarding reference file loaded by the
+> `cx-onboarding` orchestrator skill (`skills/cx-onboarding/references/onboarding-<product>.md`).
+> Copy this file, rename it, and fill every section. The orchestrator handles *routing and
+> verification*; your reference handles *the prerequisites and steps for one signal*.
+>
+> **Who owns it.** The PM for that product/signal. Author v1 from docs + Slack threads + support
+> cases; refine with the field. Don't block the orchestrator on a perfect reference — a good v1
+> that a PM iterates beats a blank slot.
+>
+> **Golden rules:**
+> 1. **Encode prerequisites in order, and be explicit about format.** The #1 cause of "no data" is a
+>    wrong format or a missing param (e.g. sending plain text where OTLP protobuf is required). State
+>    it before the happy path, not in a footnote.
+> 2. **Every reference ends by verifying data landed** with a read-only `cx` query. "Config applied"
+>    is not "done".
+> 3. **Layer-1 (no-AI) must work end to end.** AI assists are optional add-ons, never the only path.
+> 4. **Keep exact per-region endpoints out of the file.** Read the region from the `cx` profile and
+>    deep-link the endpoints doc — don't hardcode a table that goes stale.
+> 5. **Instructions live here; docs are the reference.** Link to the canonical doc page for depth
+>    instead of duplicating a wizard that will diverge (coordinate with the docs team on deep-links).
+
+Delete this callout block in real reference files. Keep the section structure below.
+
+---
+
+# Onboarding: <Product / signal name>
+
+One or two sentences: what this signal is and what "onboarded" means for it (what the user should
+see in the product when it works).
+
+## When to use this reference
+
+The orchestrator loads this file when the user wants to `<intent phrases>`. Note anything that
+should route elsewhere instead (e.g. "already flowing → cx-telemetry-querying").
+
+## Prerequisites (in order)
+
+Numbered, blocking, format-explicit. For each: what it is, how to check it, how to fix it.
+
+1. **<prereq>** — e.g. collector running / SDK installed / endpoint reachable.
+   ```bash
+   <check command>
+   ```
+2. **Required format & params.** State the wire format (e.g. **OTLP protobuf over gRPC**) and the
+   required parameters (endpoint, `Authorization: Bearer <send-your-data-api-key>`,
+   `cx.application.name`, `cx.subsystem.name`, any signal-specific params). Call out anything that
+   fails silently if wrong.
+
+## Minimal config (happy path)
+
+The smallest working setup. Prefer a copyable snippet with placeholders. Show the resource
+attributes / headers that tag the data (`cx.application.name`, `cx.subsystem.name`).
+
+```yaml
+# minimal example — placeholders in <angle brackets>
+```
+
+## Verify (close the loop)
+
+The exact read-only `cx` query that proves data arrived, plus what a healthy result looks like.
+
+```bash
+cx <logs|spans|metrics> "<query for this app/service>" --start now-15m --limit 5
+```
+
+Expected: `<what the user should see>`. If empty after ~5–10 min, see Common failures.
+
+## Common failures → fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| No data after 10 min | Wrong region/endpoint, or not OTLP protobuf | Match endpoint to profile region; confirm exporter format |
+| Data lands under the wrong name | app/subsystem attributes unset or misspelled | Set `cx.application.name` / `cx.subsystem.name` |
+| Rejected / dropped payloads | Payload > OTLP limit (hard 10 MB, ~2 MB recommended) | Batch / reduce payload size |
+| <signal-specific> | <cause> | <fix> |
+
+## Tier & cost
+
+- **Tier interaction (Medium First):** how this signal behaves across High / Medium / Low / Block
+  (e.g. features unavailable in Low). Don't guide a user toward a destination their tier blocks.
+- **Customer cost:** ingress/egress implications and mitigations (batching, compression, PrivateLink).
+- **Coralogix COGS:** note if any step absorbs AI tokens at Coralogix's cost (must be explicit).
+
+## AI layers for this signal
+
+- **Layer 1 (no-AI):** the deterministic steps above — always works.
+- **Layer 2 (minimal free AI):** optional low-token assist, if any (say what, and which cheap model).
+- **Layer 3 (full Olly, paid):** optional deep/autonomous assist, if any (credit-gated).
+
+## Docs deep-links
+
+- <canonical doc page 1>
+- <canonical doc page 2>
+
+## Sources / evidence
+
+Where the steps came from (docs, support cases, first-hand knowledge). Cite sources so the reference
+stays grounded and reviewable.
+
+---
+
+## Frontmatter for skill-local reference files
+
+Reference files do **not** need YAML frontmatter (only `SKILL.md` does). Keep the filename
+`lowercase-kebab-case.md`, prefixed `onboarding-` (e.g. `onboarding-apm-spans.md`), and make sure the
+orchestrator's **Loading references** table links to it.

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,6 +27,13 @@ Supports Claude Code, Cursor, Codex, OpenCode, and [other supported agents](http
 | `cx-platform-admin` | Manage access and security - API keys, roles, users, groups, IP access |
 | `cx-observability-setup` | Set up monitoring - saved views, webhooks, notifications, integrations |
 
+### Setup / Onboarding
+
+| Skill | Description |
+|---|---|
+| `cx-onboarding` | Get telemetry INTO Coralogix — deploy the collector, instrument logs/spans/metrics/RUM, and verify data lands. Loads per-signal reference files; the setup counterpart to `cx-telemetry-querying`. |
+| `cx-system-health` | Check whether telemetry already in Coralogix is healthy/complete enough for an experience or extension — coverage, continuity, quality. Emits verdicts and routes gaps back to `cx-onboarding`. Terminal companion to the UI health dashboards. |
+
 ## Requirements
 
 - [`cx` CLI](https://github.com/coralogix/cx-cli) installed and configured with a valid profile (`cx profiles add`)
@@ -73,3 +80,9 @@ Once installed, your agent uses the relevant skill automatically. Example querie
 - "Set up parsing rules for our new service"
 - "Who has access to production?"
 - "Configure Slack notifications for critical alerts"
+- "Onboard my Kubernetes cluster to Coralogix"
+- "Install the Coralogix OpenTelemetry collector"
+- "Send traces from my checkout service to Coralogix APM"
+- "Set up Fleet Management for my collectors"
+- "Is my APM data healthy and complete?"
+- "Why is Infra Explorer empty even though metrics are flowing?"

--- a/skills/cx-onboarding/SKILL.md
+++ b/skills/cx-onboarding/SKILL.md
@@ -61,18 +61,22 @@ prerequisites → minimal config → verify → common failures → tier & cost 
 
 Confirm these before instrumenting anything. Most "no data" cases fail here.
 
-1. **`cx` CLI installed and a profile configured.**
+1. **`cx` CLI installed and a query profile configured.** The profile powers the read-only
+   verification queries in this skill, so it authenticates to the **query** API — `cx profiles add`
+   requires a **Team Key or Personal Key**, *not* a Send-Your-Data key (ingress keys cannot query).
    ```bash
    cx profiles list            # is there a profile?
-   cx profiles add <name>      # if not: prompts for region + Send-Your-Data API key
+   cx profiles add <name>      # if not: prompts for region + a Team/Personal (query) API key
    ```
-   The profile's **region** determines the ingress endpoint. Never hardcode a region — read it
-   from the profile. Region → endpoint mapping is in the
+   The profile's **region** also resolves the ingress endpoint used when sending data. Never hardcode
+   a region — read it from the profile. Region → endpoint mapping is in the
    [Coralogix endpoints doc](https://coralogix.com/docs/integrations/coralogix-endpoints/).
 
-2. **A Send-Your-Data API key.** Ingestion authenticates with
-   `Authorization: Bearer <send-your-data-api-key>` — this is a *different* key from the query API
-   key. See [Send-Your-Data API key](https://coralogix.com/docs/user-guides/account-management/api-keys/send-your-data-api-key/).
+2. **A Send-Your-Data API key — a *separate* credential from the profile key above.** *Ingestion*
+   authenticates with `Authorization: Bearer <send-your-data-api-key>`; this is a **different** key
+   from the Team/Personal key the `cx` profile uses to *query*. Keep the two distinct — the profile key
+   never ingests, and the Send-Your-Data key never appears in a `cx` profile. See
+   [Send-Your-Data API key](https://coralogix.com/docs/user-guides/account-management/api-keys/send-your-data-api-key/).
 
 3. **The OTLP endpoint pattern.** All native ingestion is OpenTelemetry over gRPC:
    `ingress.<coralogix-domain>:443`. Resolve `<coralogix-domain>` from the profile region.
@@ -122,8 +126,10 @@ cx logs "filter \$l.applicationname == '<app>'" --start now-15m --limit 5
 # Spans landed?
 cx spans "filter \$l.serviceName == '<service>'" --start now-15m --limit 5
 
-# Metric present?
-cx metrics search --name '*<metric>*'
+# Metric arriving *now*? `metrics search` reads the untimed name catalog, so on its own it can't tell
+# "arriving now" from "seen once, long ago" — use it to find the name, then prove liveness with a query.
+cx metrics search --name '*<metric>*'    # discover the exact metric name from the catalog
+cx metrics query '<metric>'              # instant query at now → non-empty result means it's live
 ```
 
 If nothing appears after ~5–10 minutes: extend the time range, re-check the app/subsystem name used,

--- a/skills/cx-onboarding/SKILL.md
+++ b/skills/cx-onboarding/SKILL.md
@@ -1,0 +1,210 @@
+---
+name: cx-onboarding
+description: |
+  Use this skill to get telemetry INTO Coralogix from a new or partially-instrumented
+  environment — the setup/instrumentation side of onboarding, not querying existing data.
+  Trigger when the user asks to "onboard to Coralogix", "set up Coralogix", "send data to Coralogix",
+  "instrument my app", "install the Coralogix collector", "deploy the OpenTelemetry collector",
+  "ship logs to Coralogix", "send traces / APM to Coralogix", "send metrics to Coralogix",
+  "set up RUM", "connect Kubernetes to Coralogix", "get started with Coralogix",
+  "add a new service to Coralogix", "set up Fleet Management", "configure the OTel agent",
+  "no data yet after I just set this up", "verify my new integration is sending data",
+  or wants to stand up observability on an environment and see first data land.
+  For "data used to flow and stopped", "what telemetry am I missing", or "is my data healthy
+  enough for this experience", route to `cx-system-health` instead.
+metadata:
+  version: "0.1.0"
+---
+
+# Coralogix Onboarding Skill
+
+Use this skill as the **entry point for getting telemetry into Coralogix** — deploying the
+collector, instrumenting a service, and confirming data lands. It is the *instrumentation /
+data-in* counterpart to `cx-telemetry-querying` (which investigates data that is **already**
+flowing). If the user wants to *analyze* existing telemetry, route to `cx-telemetry-querying`
+instead.
+
+> **Why CLI-first for onboarding:** the user is already in the terminal with their own tools
+> (`kubectl`, `helm`, `aws`, their code). This skill guides instrumentation from where they
+> already are, then verifies the result with read-only `cx` queries. Troubleshooting a *degraded*
+> experience is UI-first; standing up instrumentation is CLI-first.
+
+---
+
+## How this skill works
+
+1. **Identify the signal(s)** the user wants to onboard (collector, logs, spans/APM, metrics, RUM, AI Center).
+2. **Load the matching reference file** from the table below — do this *before* giving instructions.
+3. **Walk the prerequisites in order.** Each reference encodes the format and required params for
+   that signal. Do not skip ahead — a missing prerequisite is the #1 cause of "no data".
+4. **Verify data landed** with a read-only `cx` query (see [Verification](#verification-always-close-the-loop)).
+5. **Only mark a step done when data is confirmed in Coralogix**, not when the config was applied.
+
+## Loading references
+
+| The user wants to… | Load this reference | Status |
+|---|---|---|
+| Deploy / manage the collector, connect Kubernetes, set up Fleet Management | `references/onboarding-fleet.md` | **Full** |
+| Send infrastructure & custom **metrics**, light up Infra Explorer | `references/onboarding-metrics-infra.md` | **Full** |
+| Send **traces / spans / APM** for a service | `references/onboarding-apm-spans.md` | **Full** |
+| Ship **logs** | `references/onboarding-logs.md` | Stub — PM to complete |
+| Set up **RUM** (browser / mobile) | `references/onboarding-rum.md` | Stub — PM to complete |
+| Send **AI Center** / LLM telemetry | `references/onboarding-ai-center.md` | Stub — PM to complete |
+
+Each reference follows the shared **onboarding reference template**
+(`contributing/onboarding-reference-md-template.md`) so every signal has the same shape:
+prerequisites → minimal config → verify → common failures → tier & cost → docs deep-links.
+
+---
+
+## Global prerequisites (check once, before any signal)
+
+Confirm these before instrumenting anything. Most "no data" cases fail here.
+
+1. **`cx` CLI installed and a profile configured.**
+   ```bash
+   cx profiles list            # is there a profile?
+   cx profiles add <name>      # if not: prompts for region + Send-Your-Data API key
+   ```
+   The profile's **region** determines the ingress endpoint. Never hardcode a region — read it
+   from the profile. Region → endpoint mapping is in the
+   [Coralogix endpoints doc](https://coralogix.com/docs/integrations/coralogix-endpoints/).
+
+2. **A Send-Your-Data API key.** Ingestion authenticates with
+   `Authorization: Bearer <send-your-data-api-key>` — this is a *different* key from the query API
+   key. See [Send-Your-Data API key](https://coralogix.com/docs/user-guides/account-management/api-keys/send-your-data-api-key/).
+
+3. **The OTLP endpoint pattern.** All native ingestion is OpenTelemetry over gRPC:
+   `ingress.<coralogix-domain>:443`. Resolve `<coralogix-domain>` from the profile region.
+
+4. **Application & subsystem naming.** Every data point is tagged with an **application name** and a
+   **subsystem name** (set via resource attributes `cx.application.name` / `cx.subsystem.name`, or the
+   OTLP metadata headers). Decide these before instrumenting — they are how the data is found later.
+   See [Application and subsystem names](https://coralogix.com/docs/user-guides/account-management/account-settings/application-and-subsystem-names/).
+
+> ### ⚠️ The single most common mistake: format, not credentials
+> Coralogix's OTLP endpoints expect **OpenTelemetry protobuf over gRPC**, *not* arbitrary plain text.
+> Sending a raw text payload to the OTLP endpoint fails silently or is rejected — this is exactly the
+> trap that cost a full onboarding cycle before switching to protobuf. **Always confirm the exporter
+> is emitting OTLP protobuf** (the OTel SDKs and the Coralogix collector do this by default; hand-rolled
+> shippers often do not). Each per-signal reference states its required format and params explicitly —
+> read them first.
+
+---
+
+## Recommended onboarding order
+
+Signals are independent, but this order builds confidence fastest and matches how real onboardings
+converge (each step verifies before the next):
+
+1. **Collector / Fleet** — get the OTel collector running and reporting (`onboarding-fleet.md`). This is
+   the transport for everything else in Kubernetes/host environments.
+2. **Logs** — usually the first signal customers care about (`onboarding-logs.md`).
+3. **Spans / APM** — service traces (`onboarding-apm-spans.md`).
+4. **Metrics / Infra** — infra + custom metrics, Infra Explorer (`onboarding-metrics-infra.md`).
+5. **RUM** — front-end / real-user monitoring (`onboarding-rum.md`).
+6. **AI Center** — LLM/agent telemetry (`onboarding-ai-center.md`).
+
+For SDK-based (non-Kubernetes) apps, steps 2–5 can be done directly from the app's OTel exporter and
+step 1 is optional. Let the user's environment decide — ask before assuming Kubernetes.
+
+---
+
+## Verification — always close the loop
+
+Instrumentation is not "done" until data is queryable. After each signal, verify with read-only
+`cx` queries (these consume **no** ingestion quota and no AI Units):
+
+```bash
+# Logs landed?
+cx logs "filter \$l.applicationname == '<app>'" --start now-15m --limit 5
+
+# Spans landed?
+cx spans "filter \$l.serviceName == '<service>'" --start now-15m --limit 5
+
+# Metric present?
+cx metrics search --name '*<metric>*'
+```
+
+If nothing appears after ~5–10 minutes: extend the time range, re-check the app/subsystem name used,
+confirm the endpoint region matches the profile, and confirm the exporter is OTLP protobuf. For deeper
+query help, hand off to `cx-telemetry-querying`.
+
+---
+
+## AI usage & no-AI path (required posture)
+
+This skill runs **inside the customer's own coding agent**, so its guidance and `cx` commands
+**consume no Coralogix AI Units** — the cost is borne by whatever agent the user runs it in. AI Units
+are only consumed if a step explicitly calls the **Olly API** (e.g. "ask Olly to explain this failure").
+
+Design every assist across three layers:
+
+- **Layer 1 — no-AI path (always works):** the deterministic steps + verification queries in the
+  reference files. Fully usable in air-gapped / BYOC / high-security environments and when a user is
+  out of AI Units. This is the default and must never depend on AI.
+- **Layer 2 — minimal free AI (optional):** a low-token assist (e.g. summarize a collector error,
+  pick the right fix for a verdict) using a cheap model. If a step absorbs tokens at Coralogix's cost,
+  that cost must be explicit in the feature's COGS.
+- **Layer 3 — full Olly (paid, credit-gated):** deep, autonomous help (analyze the whole environment,
+  propose and deploy a collector config). Available only if the customer has AI credits; surface a
+  consumption tooltip, and fall back to Layer 1 when units are exhausted.
+
+---
+
+## Safety
+
+Onboarding is **not** read-only. It deploys collectors, edits Helm/values files, sets env vars, and
+changes the user's code or cluster. Treat these as mutating:
+
+- **State what will change before running it** (which files, which cluster/namespace).
+- Prefer `helm upgrade --install ... --dry-run` / showing a diff before applying.
+- Instrumentation edits happen in the **user's own repo/cluster** — never invent credentials or push
+  changes without confirmation.
+- The **verification** `cx logs`/`cx spans`/`cx metrics` queries are read-only and safe to run freely.
+
+---
+
+## Key principles
+
+- **Load the reference before instructing** — never improvise a signal's prerequisites.
+- **Format first, credentials second** — most failures are OTLP-protobuf / param issues, not auth.
+- **Decide app + subsystem names up front** — they are how the data is found later.
+- **Verify with a query before declaring success** — config applied ≠ data landing.
+- **Read region from the profile** — never hardcode an ingress endpoint.
+- **Content is contributable** — each signal's steps live in a per-product MD a PM can own and refine.
+
+---
+
+## Additional resources
+
+### Reference files
+
+- **`references/onboarding-fleet.md`** — deploy the OTel collector on Kubernetes/hosts; Fleet Management remote config (OpAMP).
+- **`references/onboarding-metrics-infra.md`** — infra + custom metrics via OTLP/Prometheus; Infra Explorer.
+- **`references/onboarding-apm-spans.md`** — service traces / APM via OpenTelemetry.
+- **`references/onboarding-logs.md`** — log shipping (stub for a PM to complete).
+- **`references/onboarding-rum.md`** — Real User Monitoring (stub for a PM to complete).
+- **`references/onboarding-ai-center.md`** — AI Center / LLM telemetry (stub for a PM to complete).
+
+### Authoring standard
+
+- **`contributing/onboarding-reference-md-template.md`** — the benchmark template every per-product reference follows.
+
+---
+
+## Related skills
+
+> **The onboarding ↔ health loop.** `cx-system-health` verifies whether a customer's telemetry meets the
+> conditions an experience/extension needs. When it finds a **gap**, it routes back *here* to
+> instrument the missing piece (the discovery-gated activation path). So the two skills form a loop:
+> onboard → verify health/coverage → gap → onboard the gap.
+
+| User intent | Route to |
+|---|---|
+| Data used to flow and stopped; is my data healthy/complete enough for an experience | `cx-system-health` |
+| Analyze / investigate data that already flows | `cx-telemetry-querying` |
+| Look up exact product docs | `coralogix-docs` |
+| Configure saved views, webhooks, notifications, integrations/extensions | `cx-observability-setup` |
+| Build dashboards for the newly onboarded data | `cx-dashboards` |
+| Set up alerts on the new data | `cx-alerts` |

--- a/skills/cx-onboarding/references/onboarding-ai-center.md
+++ b/skills/cx-onboarding/references/onboarding-ai-center.md
@@ -1,0 +1,44 @@
+# Onboarding: AI Center / LLM telemetry  *(STUB — not yet authored)*
+
+> **Status:** not yet authored. AI Center onboards over OpenTelemetry like the other signals; this is a
+> thin routable stub so the orchestrator can hand off cleanly. Complete it from
+> `contributing/onboarding-reference-md-template.md`.
+
+Send LLM / AI-agent telemetry (prompts, completions, token usage, evals, guardrails) into Coralogix
+AI Center. "Onboarded" means: AI spans/metrics appear in AI Center with model and token data.
+
+## When to use this reference
+
+"Monitor my LLM app", "send AI/agent telemetry", "set up AI Center", "track token usage / model
+calls / guardrails".
+
+## Prerequisites (in order)
+
+1. **A collector or OTLP destination** (as for spans/metrics) — AI Center consumes OpenTelemetry.
+2. **Required format & params — OTLP protobuf over gRPC**, `ingress.<coralogix-domain>:443`,
+   `Authorization: Bearer <send-your-data-api-key>`, with `cx.application.name` / `cx.subsystem.name`.
+3. **GenAI semantic conventions** on spans (model, tokens, prompt/response) so AI Center can parse them.
+   *TODO (AI Center PM):* confirm the exact attributes and any Coralogix-specific ones.
+
+## Minimal config (happy path)
+
+*TODO (AI Center PM):* the OTel GenAI instrumentation snippet (e.g. an OpenAI/LLM auto-instrumentation
+library) exporting to the endpoint/collector, per the
+[AI Center OTel integration doc](https://coralogix.com/docs/user-guides/ai/otel-integration/).
+
+## Verify (close the loop)
+
+```bash
+cx spans "filter \$l.serviceName == '<ai-service>'" --start now-15m --limit 5
+```
+*TODO:* the specific attribute/metric that confirms AI Center parsed it (model / token count).
+
+## Common failures → fixes / Tier & cost / AI layers / Docs deep-links
+
+*TODO (AI Center PM)* — follow the template. **Note the meta-point:** AI Center is *per-team* billed
+(evals/guardrails), distinct from *per-user* Olly. Docs:
+[AI Center OpenTelemetry integration](https://coralogix.com/docs/user-guides/ai/otel-integration/).
+
+## Sources / evidence
+
+Scaffold (2026-07). AI Center OpenTelemetry integration doc (verified). Onboarding order = last (after RUM).

--- a/skills/cx-onboarding/references/onboarding-apm-spans.md
+++ b/skills/cx-onboarding/references/onboarding-apm-spans.md
@@ -1,0 +1,101 @@
+# Onboarding: APM / Traces (spans)
+
+Get distributed traces from a service into Coralogix APM via OpenTelemetry. "Onboarded" means:
+spans for the service are queryable and the service shows up in APM / Explore Spans with latency and
+error data.
+
+## When to use this reference
+
+The orchestrator loads this file when the user wants to "send traces to Coralogix", "set up APM",
+"instrument my service for tracing", "see spans / a service map", or "debug request latency by trace".
+
+If spans already flow and the user wants to *analyze* them, route to `cx-telemetry-querying`.
+
+## Prerequisites (in order)
+
+1. **A destination for spans.** Either the **collector** (`onboarding-fleet.md`, recommended in
+   Kubernetes — the gateway does tail sampling) or direct OTLP export from the app to
+   `ingress.<coralogix-domain>:443`.
+2. **Required format & params — OTLP protobuf over gRPC.** APM ingests **OpenTelemetry traces**;
+   the exporter must emit OTLP protobuf, not a custom format. Required:
+   - Endpoint: `ingress.<coralogix-domain>:443` (region from the `cx` profile), or the in-cluster
+     collector endpoint.
+   - Auth (direct export): `Authorization: Bearer <send-your-data-api-key>`.
+   - Resource attributes: **`cx.application.name`** and **`cx.subsystem.name`** — these decide where
+     the service appears. Also set `service.name` (OTel standard) for the service map.
+3. **An instrumentation method** for the language/runtime: OTel **auto-instrumentation** (agent/init
+   container, zero-code for supported frameworks) or the **OTel SDK** in code.
+
+> ### ⚠️ Non-native / legacy APM agents don't export OTLP by default
+> A vendor's proprietary APM agent (e.g. a .NET CLR profiler using bytecode injection) generally
+> **cannot emit OTLP natively**. Bridging it (vendor agent → vendor OTel collector → OTel collector →
+> Coralogix) is a real, supported-but-heavy path — and bridging can silently change behaviour (e.g.
+> switching adaptive sampling to 100% raw capture). If the user is on a legacy agent, flag the bridge
+> path and its sampling implications up front rather than discovering them months later.
+
+## Minimal config (happy path)
+
+**A. Kubernetes auto-instrumentation (zero-code)** — with the collector already running, annotate the
+workload so the OpenTelemetry Operator injects auto-instrumentation, or use the language auto-agent.
+See the APM-on-Kubernetes doc linked below for the per-language annotation.
+
+**B. SDK / env-var export (any environment)** — point the app's OTel exporter at the endpoint:
+
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://ingress.<coralogix-domain>:443"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <send-your-data-api-key>"
+export OTEL_RESOURCE_ATTRIBUTES="cx.application.name=<app>,cx.subsystem.name=<service>,service.name=<service>"
+# then run the app under the language's OTel auto-instrumentation, e.g. Python:
+opentelemetry-instrument python app.py
+```
+
+(When exporting to the in-cluster collector instead of directly, set the endpoint to the collector
+service and drop the auth header — the collector holds the key.)
+
+## Verify (close the loop)
+
+```bash
+cx spans "filter \$l.serviceName == '<service>'" --start now-15m --limit 5
+```
+
+Expected: recent spans for the service, with duration and status. Then confirm it appears in APM /
+Explore Spans in the UI. If empty after ~5–10 min, see Common failures.
+
+## Common failures → fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| No spans after 10 min | Exporter not OTLP protobuf, or wrong endpoint region | Confirm OTLP exporter; match endpoint to profile region |
+| Spans land under wrong/blank service | `cx.subsystem.name` / `service.name` unset | Set resource attributes explicitly |
+| Traces incomplete / broken | Context not propagated across services, or tail-sampling drops | Ensure propagation; review gateway sampling |
+| Legacy .NET/Java agent won't export | Proprietary agent can't emit OTLP | Use OTel auto-instrumentation, or the documented bridge (mind sampling change) |
+| 100% of spans captured, cost spikes | Bridge/agent switched off adaptive sampling | Configure sampling explicitly on the collector/exporter |
+
+## Tier & cost
+
+- **Tier interaction:** spans/APM require a tier that includes tracing; **Low/Block tiers may not
+  surface APM features** — don't guide a user to a tier that hides the result. Confirm before routing.
+- **Customer cost:** span volume × sampling rate drives egress + ingestion. Tail sampling on the
+  gateway is the main lever.
+- **Coralogix COGS:** span ingestion; no AI tokens in the Layer-1 path.
+
+## AI layers for this signal
+
+- **Layer 1 (no-AI):** the steps + `cx spans` verify above.
+- **Layer 2 (minimal free AI):** optional — given a detected framework, suggest the right
+  auto-instrumentation snippet (low token, cheap model).
+- **Layer 3 (full Olly, paid):** optional — "ask Olly why traces are missing / why latency is high"
+  (credit-gated; uses the Olly API → consumes AI Units).
+
+## Docs deep-links
+
+- [APM using OpenTelemetry as a unified shipper with Kubernetes](https://coralogix.com/docs/opentelemetry/integrations/apm-kubernetes-open-telemetry-opentelemetry/)
+- [OpenTelemetry custom traces](https://coralogix.com/docs/integrations/data-ingestion/opentelemetry-custom-traces/)
+- [Explore spans (querying, once flowing)](https://coralogix.com/docs/user-guides/data_exploration/spans/)
+- [Coralogix endpoints (region → domain)](https://coralogix.com/docs/integrations/coralogix-endpoints/)
+
+## Sources / evidence
+
+Coralogix OTLP custom-traces + APM-on-Kubernetes docs; endpoints + Send-Your-Data key docs (verified
+2026-07). The legacy-agent bridge + accidental sampling-change is a known real-world onboarding
+failure mode.

--- a/skills/cx-onboarding/references/onboarding-fleet.md
+++ b/skills/cx-onboarding/references/onboarding-fleet.md
@@ -1,0 +1,123 @@
+# Onboarding: Collector & Fleet Management
+
+Stand up the **OpenTelemetry collector** that transports telemetry to Coralogix, and (in
+Kubernetes) put it under **Fleet Management** so its config can be updated remotely via OpAMP.
+"Onboarded" means: the collector is running, healthy, and its own telemetry is visible in
+Coralogix — everything else (logs, spans, metrics) rides on this transport.
+
+## When to use this reference
+
+The orchestrator loads this file when the user wants to "install the Coralogix collector",
+"deploy the OpenTelemetry collector", "connect Kubernetes to Coralogix", "set up Fleet Management",
+"configure the OTel agent", or "manage collector config remotely".
+
+For **SDK-only apps** that export OTLP straight from the process, a standalone collector is optional
+— route to `onboarding-apm-spans.md` / `onboarding-metrics-infra.md` and treat this file as the
+Kubernetes/host path.
+
+## Prerequisites (in order)
+
+1. **A `cx` profile** with the right region + Send-Your-Data API key.
+   ```bash
+   cx profiles list        # confirm a profile exists and note its region
+   cx profiles add <name>  # if not — prompts for region + API key
+   ```
+2. **Deploy tooling for the target environment.** Kubernetes: `kubectl` + `helm` with cluster access.
+   Hosts/VMs: shell access to install the collector binary.
+3. **The ingress endpoint + auth.** Collector sends **OTLP protobuf over gRPC** to
+   `ingress.<coralogix-domain>:443` with `Authorization: Bearer <send-your-data-api-key>`. Resolve
+   `<coralogix-domain>` from the profile region — see the
+   [Coralogix endpoints doc](https://coralogix.com/docs/integrations/coralogix-endpoints/).
+4. **A cluster / host name** to tag the collector's data with, and the **application / subsystem**
+   naming convention you'll use downstream.
+
+## Minimal config (happy path) — Kubernetes via Helm
+
+Coralogix ships the **`otel-integration`** Helm chart (`otel-coralogix-integration`), which deploys an
+OTLP **receiver** (agent DaemonSet: metrics + logs, load-balances spans) and a **gateway** (tail
+sampling for spans).
+
+1. Store the Send-Your-Data key as a secret (don't inline it):
+   ```bash
+   kubectl create secret generic coralogix-keys \
+     --from-literal=PRIVATE_KEY=<send-your-data-api-key> -n <namespace>
+   ```
+2. Minimal `values.yaml` override — the two required values are the **endpoint domain** and the
+   **cluster name**:
+   ```yaml
+   global:
+     domain: "<coralogix-domain>"        # e.g. resolved from your profile region
+     clusterName: "<my-cluster>"
+   ```
+3. Install / upgrade (dry-run first to review what changes):
+   ```bash
+   helm repo add coralogix-charts-virtual https://cgx.jfrog.io/artifactory/coralogix-charts-virtual
+   helm upgrade --install otel-coralogix-integration \
+     coralogix-charts-virtual/otel-integration \
+     -n <namespace> --create-namespace \
+     -f values.yaml --dry-run     # remove --dry-run to apply
+   ```
+
+Advanced topologies (central tail-sampling cluster, the OpenTelemetry Operator via a
+`OpenTelemetryCollector` CRD) are in the docs — link them rather than expanding here.
+
+## Verify (close the loop)
+
+The collector emits its **own** telemetry. Confirm the pods are up, then confirm data in Coralogix:
+
+```bash
+kubectl get pods -n <namespace> | grep -i coralogix   # receiver + gateway Running
+# Collector / cluster metrics arriving?
+cx metrics search --name '*otelcol*'
+# Any signal tagged with the cluster arriving?
+cx logs "filter \$l.applicationname == '<my-cluster>'" --start now-15m --limit 5
+```
+
+Expected: collector pods `Running`, and `otelcol_*` process metrics (or your cluster's logs)
+appearing within a few minutes. If empty, see Common failures.
+
+## Common failures → fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Pods `CrashLoopBackOff` | Bad/missing API key secret, or wrong `domain` | Check the secret; confirm `global.domain` matches the profile region |
+| Pods `Running`, no data in Coralogix | Endpoint region ≠ where you're querying, or key lacks send permission | Match ingress region to the profile; verify the Send-Your-Data key |
+| Spans arrive but sampling looks off | Tail-sampling on the gateway | Review gateway sampling policy in `values.yaml` |
+| Config change needs a redeploy every time | Not yet under Fleet remote config | Enable Fleet Management (below) to push config via OpAMP |
+
+## Fleet Management (remote config via OpAMP)
+
+Once the collector is running, **Fleet Management** lets you update its configuration centrally
+without a redeploy — the collector connects out via **OpAMP** and pulls config. This is how config
+targeting, health, and version rollouts work across a fleet of collectors. Enable it on the Kubernetes
+integration per the [Fleet Management for Kubernetes doc](https://coralogix.com/docs/user-guides/fleet-management/fleet-remote-config-kubernetes/).
+
+## Tier & cost
+
+- **Tier interaction:** the collector is tier-agnostic; the *signals* it sends inherit their pillar's
+  tier behaviour (see each signal's reference). Don't route data to a destination the tier blocks.
+- **Customer cost:** the collector adds cluster CPU/memory; egress is the telemetry volume it ships.
+  Batching and compression are on by default in the chart. Consider a private link where offered.
+- **Coralogix COGS:** ingestion volume from the collector; the collector deployment itself is customer-side.
+
+## AI layers for this signal
+
+- **Layer 1 (no-AI):** the Helm/verify steps above — always works, incl. air-gapped/BYOC.
+- **Layer 2 (minimal free AI):** optional — summarize a `CrashLoopBackOff` reason or a collector log
+  error into a likely fix (cheap model, low token).
+- **Layer 3 (full Olly, paid):** optional — analyze the cluster and propose/deploy a collector config
+  autonomously (credit-gated).
+
+## Docs deep-links
+
+- [Kubernetes complete observability — basic configuration](https://coralogix.com/docs/external/telemetry-shippers/otel-integration/k8s-helm/kubernetes-observability/kubernetes-complete-observability-basic-configuration/)
+- [Advanced configuration (central tail-sampling, Operator/CRD)](https://coralogix.com/docs/opentelemetry/kubernetes-observability/advanced-configuration/)
+- [Fleet Management for Kubernetes](https://coralogix.com/docs/user-guides/fleet-management/fleet-remote-config-kubernetes/)
+- [Integration troubleshooting](https://coralogix.com/docs/opentelemetry/kubernetes-observability/troubleshooting/)
+- [Coralogix endpoints (region → domain)](https://coralogix.com/docs/integrations/coralogix-endpoints/)
+
+## Sources / evidence
+
+Coralogix `otel-integration` Helm docs (basic + advanced config); Fleet Management for Kubernetes doc;
+endpoints doc (verified 2026-07). This reference is the "get a collector into the fleet" entry step;
+ongoing fleet health lives in the `cx-system-health` skill (`health-fleet.md`).

--- a/skills/cx-onboarding/references/onboarding-fleet.md
+++ b/skills/cx-onboarding/references/onboarding-fleet.md
@@ -67,8 +67,9 @@ The collector emits its **own** telemetry. Confirm the pods are up, then confirm
 
 ```bash
 kubectl get pods -n <namespace> | grep -i coralogix   # receiver + gateway Running
-# Collector / cluster metrics arriving?
-cx metrics search --name '*otelcol*'
+# Collector metrics arriving now? (instant query — result >0 means collectors are reporting;
+# `metrics search --name '*otelcol*'` only lists the untimed catalog, so use it just to find names)
+cx metrics query 'count({__name__=~"otelcol_.*"})'
 # Any signal tagged with the cluster arriving?
 cx logs "filter \$l.applicationname == '<my-cluster>'" --start now-15m --limit 5
 ```

--- a/skills/cx-onboarding/references/onboarding-logs.md
+++ b/skills/cx-onboarding/references/onboarding-logs.md
@@ -1,0 +1,54 @@
+# Onboarding: Logs  *(STUB — for the Logs PM to complete)*
+
+> **Status:** scaffold. The orchestrator routes here, but a Logs PM should complete it from the
+> template (`contributing/onboarding-reference-md-template.md`). The prerequisite below is the
+> load-bearing lesson and should survive into v1.
+
+Ship logs into Coralogix. "Onboarded" means: logs are queryable in Explore with the expected
+application/subsystem names and severity.
+
+## When to use this reference
+
+"Ship logs to Coralogix", "my logs aren't arriving", "set up log collection", "send application logs".
+
+## Prerequisites (in order)
+
+1. **A destination.** The collector (`onboarding-fleet.md`) in Kubernetes, or direct OTLP export.
+2. **Required format & params — this is the classic trap.** The OTLP logs endpoint expects
+   **OpenTelemetry protobuf over gRPC**, not raw text. **Sending logs as plain text fails** —
+   in a real onboarding this blocked ingestion until the sender was switched to OTLP **protobuf**.
+   Confirm the log exporter emits OTLP protobuf, and set `cx.application.name` / `cx.subsystem.name`.
+   *(Known failure mode: logs sent as plain text are rejected/silently dropped until the exporter is
+   switched to OTLP protobuf.)*
+3. **App / subsystem naming** decided up front.
+
+## Minimal config (happy path)
+
+*TODO (Logs PM):* smallest working config for (a) collector-collected container logs and (b) direct
+OTLP-logs export, with the protobuf note and resource attributes. Endpoint pattern
+`ingress.<coralogix-domain>:443`, `Authorization: Bearer <send-your-data-api-key>`.
+
+## Verify (close the loop)
+
+```bash
+cx logs "filter \$l.applicationname == '<app>'" --start now-15m --limit 5
+```
+
+## Common failures → fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| No logs after 10 min | Sent as plain text, not OTLP protobuf | Switch exporter to OTLP protobuf |
+| Wrong app/subsystem | Attributes unset | Set `cx.application.name` / `cx.subsystem.name` |
+| *TODO* | | |
+
+## Tier & cost / AI layers / Docs deep-links
+
+*TODO (Logs PM)* — follow the template. Docs: [OpenTelemetry custom logs](https://coralogix.com/docs/developer-portal/apis/data-ingestion/opentelemetry-custom-logs/),
+[Explore logs](https://coralogix.com/docs/user-guides/data_exploration/logs/quickstart/),
+[endpoints](https://coralogix.com/docs/integrations/coralogix-endpoints/).
+
+## Sources / evidence
+
+The protobuf prerequisite is a well-known real-world onboarding failure. Fill remaining sections from
+the Coralogix logs docs + real cases.

--- a/skills/cx-onboarding/references/onboarding-metrics-infra.md
+++ b/skills/cx-onboarding/references/onboarding-metrics-infra.md
@@ -49,12 +49,12 @@ the docs (reuse existing scrape config; no re-instrumentation).
 ## Verify (close the loop)
 
 ```bash
-# Is the metric present?
+# Find the exact metric name (catalog lookup — untimed, so it can't prove the metric is live)
 cx metrics search --name '*<metric>*'
-# Query it (PromQL)
+# Prove it's arriving now (instant PromQL query — a non-empty series means it's live)
 cx metrics query 'rate(<metric>[5m])'
 # Infra metrics arriving?
-cx metrics search --name '*container_cpu*'
+cx metrics query 'container_cpu_usage_seconds_total'
 ```
 
 Expected: the metric appears in search and returns a series; infra metrics like `container_cpu_*` /

--- a/skills/cx-onboarding/references/onboarding-metrics-infra.md
+++ b/skills/cx-onboarding/references/onboarding-metrics-infra.md
@@ -1,0 +1,100 @@
+# Onboarding: Metrics & Infra Explorer
+
+Get infrastructure and custom metrics into Coralogix and light up **Infra Explorer**. "Onboarded"
+means: metrics are queryable with PromQL and infrastructure entities (nodes, pods, hosts) appear in
+Infra Explorer with live values.
+
+## When to use this reference
+
+The orchestrator loads this file when the user wants to "send metrics to Coralogix", "monitor
+infrastructure", "see CPU / memory / pods", "set up Infra Explorer", "scrape Prometheus into
+Coralogix", or "send custom application metrics".
+
+If metrics already flow and the user wants to *query* them, route to `cx-telemetry-querying`.
+
+## Prerequisites (in order)
+
+1. **A metrics source + destination.** In Kubernetes the **collector** (`onboarding-fleet.md`)
+   scrapes infra + Prometheus endpoints and ships them. For app metrics, the OTel SDK or a Prometheus
+   remote-write source can send directly.
+2. **Required format & params.** Two supported paths:
+   - **OTLP metrics (protobuf/gRPC)** to `ingress.<coralogix-domain>:443` with
+     `Authorization: Bearer <send-your-data-api-key>` — same endpoint pattern as other signals.
+   - **Prometheus remote-write** for existing Prometheus/scrape setups.
+   In both cases set **`cx.application.name`** / **`cx.subsystem.name`** so metrics are attributed.
+3. **Know the metric names / labels** you expect — metrics are found by name + labels, so a naming
+   convention matters (fragmented names are the hard part of metrics activation; agree them early).
+
+## Minimal config (happy path)
+
+**A. Kubernetes infra metrics** — the `otel-integration` chart's agent collects node/pod/container
+metrics out of the box once the collector is running (`onboarding-fleet.md`). No per-app work needed
+for infra coverage.
+
+**B. Custom app metrics via OTLP** — export from the app's OTel metrics SDK:
+```bash
+export OTEL_EXPORTER_OTLP_ENDPOINT="https://ingress.<coralogix-domain>:443"
+export OTEL_EXPORTER_OTLP_HEADERS="Authorization=Bearer <send-your-data-api-key>"
+export OTEL_RESOURCE_ATTRIBUTES="cx.application.name=<app>,cx.subsystem.name=<service>"
+```
+(Export to the in-cluster collector instead of directly when a collector is present — drop the auth
+header, the collector holds the key.)
+
+**C. Existing Prometheus** — point Prometheus remote-write at the Coralogix Prometheus endpoint per
+the docs (reuse existing scrape config; no re-instrumentation).
+
+> **Scrape interval is a cost lever.** Default 1s/10s scrapes multiply metric volume. Set the interval
+> deliberately per metric group — it directly drives customer cost and Coralogix COGS.
+
+## Verify (close the loop)
+
+```bash
+# Is the metric present?
+cx metrics search --name '*<metric>*'
+# Query it (PromQL)
+cx metrics query 'rate(<metric>[5m])'
+# Infra metrics arriving?
+cx metrics search --name '*container_cpu*'
+```
+
+Expected: the metric appears in search and returns a series; infra metrics like `container_cpu_*` /
+`kube_pod_*` show up, and nodes/pods populate Infra Explorer in the UI. If empty, see Common failures.
+
+## Common failures → fixes
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| Metric not found in search | Not sent yet, wrong endpoint region, or name differs | Confirm exporter/scrape target; match endpoint region; check exact name |
+| Metric exists but Infra Explorer empty | Missing resource/semantic labels for entity mapping | Ensure infra semantic conventions (node/pod labels) are set |
+| Huge metric volume / cost spike | Scrape interval too tight or high-cardinality labels | Raise scrape interval; drop/aggregate high-cardinality labels |
+| Default dashboards don't populate | Metric names don't match expected conventions | Align names to the dashboard's expected metrics (naming fragmentation) |
+
+## Tier & cost
+
+- **Tier interaction:** metrics behaviour varies by tier (alerts/dashboards limited on lower tiers) —
+  don't guide a user to a tier that hides Infra Explorer or alerting.
+- **Customer cost:** metric volume = series × scrape frequency; scrape interval + cardinality are the
+  levers. See [optimizing metrics cost by scrape interval](https://coralogix.com/docs/user-guides/account-management/payment-and-billing/optimize-metrics-costs-in-coralogix-by-adjusting-your-scrape-interval/).
+- **Coralogix COGS:** metric ingestion; no AI tokens in the Layer-1 path.
+
+## AI layers for this signal
+
+- **Layer 1 (no-AI):** the steps + `cx metrics` verify above.
+- **Layer 2 (minimal free AI):** optional — suggest a PromQL query for an intent, or map a raw metric
+  name to a default dashboard (low token, cheap model).
+- **Layer 3 (full Olly, paid):** optional — "ask Olly what's driving this metric / why infra looks
+  unhealthy" (credit-gated; Olly API → consumes AI Units).
+
+## Docs deep-links
+
+- [Kubernetes complete observability — basic configuration (infra metrics)](https://coralogix.com/docs/external/telemetry-shippers/otel-integration/k8s-helm/kubernetes-observability/kubernetes-complete-observability-basic-configuration/)
+- [OpenTelemetry custom metrics](https://coralogix.com/docs/developer-portal/apis/data-ingestion/opentelemetry-custom-metrics/)
+- [Metrics API](https://coralogix.com/docs/user-guides/data-query/metrics-api/)
+- [Explore metrics (querying, once flowing)](https://coralogix.com/docs/user-guides/data_exploration/metrics-explorer/)
+- [Coralogix endpoints (region → domain)](https://coralogix.com/docs/integrations/coralogix-endpoints/)
+
+## Sources / evidence
+
+Coralogix OTLP custom-metrics + K8s observability docs; scrape-interval cost doc; endpoints doc
+(verified 2026-07). Metric-name fragmentation is a well-known reason default dashboards / Infra
+Explorer stay empty even when metrics are flowing.

--- a/skills/cx-onboarding/references/onboarding-rum.md
+++ b/skills/cx-onboarding/references/onboarding-rum.md
@@ -1,0 +1,62 @@
+# Onboarding: RUM (Real User Monitoring)  *(STUB — for the RUM PM to complete)*
+
+> **Status:** scaffold. The orchestrator routes here; the RUM PM completes it from the template
+> (`contributing/onboarding-reference-md-template.md`).
+
+Instrument a browser or mobile app so real-user sessions, page loads, web vitals and front-end errors
+reach Coralogix RUM. "Onboarded" means: sessions and web-vitals appear in the RUM UI.
+
+## When to use this reference
+
+"Set up RUM", "monitor front-end performance", "track real users / page loads / web vitals",
+"capture browser JS errors".
+
+## Prerequisites (in order)
+
+1. **Deploy the RUM integration package** in Coralogix — this creates the **RUM public key** the SDK
+   needs. This key is *publicly visible* and is **distinct from the Send-Your-Data API key**.
+2. **The RUM SDK** for the platform (NPM browser SDK / CDN snippet, or the mobile / React Native /
+   Flutter SDK).
+3. **Application name, version, and `coralogixDomain`** (a **region enum** like `EU2`/`US1`, *not* an
+   ingress hostname) to configure the SDK.
+
+> **Not the OTLP protobuf/gRPC path.** RUM is a **front-end** signal shipped by the RUM SDK over its own
+> transport with the RUM public key — the protobuf/Bearer/`ingress:443` prerequisites from the other
+> references do **not** apply here. Don't conflate them.
+
+## Minimal config (happy path) — browser (NPM)
+
+```js
+import { CoralogixRum } from '@coralogix/browser';
+
+CoralogixRum.init({
+  public_key: '<rum-public-key>',
+  application: '<app>',
+  version: '1.0.0',
+  coralogixDomain: 'EU2',      // region enum for your account (EU1/EU2/US1/US2/AP1/AP2…)
+});
+```
+
+*TODO (RUM PM):* confirm the current package name/version, recommended optional params
+(`user_context`, `labels`, `ignoreUrls`, session sampling), the CDN-snippet variant, and the
+mobile/React Native/Flutter equivalents.
+
+## Verify (close the loop)
+
+*TODO (RUM PM):* how to confirm sessions arrived (UI check; RUM data is `$d.cx_rum.*` when queried via
+`cx-telemetry-querying`). Example:
+```bash
+cx logs "filter \$d.cx_rum.application_name == '<app>'" --start now-15m --limit 5
+```
+
+## Common failures → fixes / Tier & cost / AI layers / Docs deep-links
+
+*TODO (RUM PM)* — follow the template. Docs deep-links (verified 2026-07-07):
+- [RUM SDK installation — overview](https://coralogix.com/docs/user-guides/rum/sdk-installation/overview/)
+- [NPM browser SDK installation guide](https://coralogix.com/docs/user-guides/rum/sdk-installation/javascript/npm-browser/)
+
+Prefer these canonical pages over guessing a URL; or use `cx docs search "RUM setup"`.
+
+## Sources / evidence
+
+Scaffold (2026-07). Fill from the RUM docs linked above + real cases.

--- a/skills/cx-system-health/SKILL.md
+++ b/skills/cx-system-health/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: cx-system-health
+description: |
+  Use this skill to check whether telemetry ALREADY in Coralogix is healthy and complete enough for a
+  given experience or extension to deliver value — coverage, continuity, and quality of the data, not
+  querying it. Trigger when the user asks "is my data healthy", "what telemetry am I missing",
+  "why is APM/Infra/RUM empty or incomplete", "my data used to flow and stopped", "did my logs stop",
+  "is my instrumentation good enough", "check my observability coverage", "why isn't this dashboard
+  populating", "does this extension have the data it needs", "is my service fully instrumented",
+  "monitor the monitor", "check the health of my collectors' data", "are my collectors healthy",
+  "which agents stopped reporting", "collector config drift", "fleet health", or wants to know whether
+  an experience/extension has the signals and attributes it requires. When a gap is found, this skill
+  routes to `cx-onboarding` to instrument the missing piece.
+metadata:
+  version: "0.1.0"
+---
+
+# Coralogix System Health Skill
+
+Use this skill to answer **"is my telemetry healthy and complete enough to get value?"** — the
+coverage/quality/continuity side of observability, distinct from *getting data in* (`cx-onboarding`)
+and *investigating* data (`cx-telemetry-querying`). It checks whether each **experience** (APM, Infra
+Explorer, RUM, Fleet Health…) and **extension** (quick-start integration packages) has the signals and
+attributes it needs, reports a **verdict**, and when something is missing, hands back to
+`cx-onboarding` to instrument it.
+
+> **UI-first, CLI-companion.** Troubleshooting and system health are *primarily a UI experience* in
+> Coralogix (the health dashboards). This skill is the **programmatic companion** for users already in
+> the terminal: it verifies conditions, tells them exactly what's missing, and routes them to the fix.
+> It does **not** replace the UI dashboard — for visual triage, point the user there.
+
+---
+
+## The core idea: health conditions → verdict → remediation
+
+Every experience/extension has **conditions** its telemetry must meet to be useful (e.g. APM needs
+spans flowing *with* `service.name` set *and* error/latency populated). This skill:
+
+1. **Picks the experience/extension** the user cares about (or scans several).
+2. **Loads the matching reference** from the table below — each defines that surface's conditions.
+3. **Checks each condition** with read-only `cx` queries.
+4. **Emits a verdict per condition:** `healthy` · `degraded` · `missing`.
+5. **On `missing`/`degraded`, routes back to `cx-onboarding`** for the specific signal to instrument
+   the gap (the onboarding ↔ health loop; the discovery-gated activation path is the automatic version).
+
+> **How verdicts are computed.** Today this skill derives verdicts from **read-only `cx` queries**
+> (see `references/health-conditions-model.md`). It's written to a stable *conditions → verdict →
+> remediation* contract, so if a product health API becomes available later, the skill can call it
+> without changing the model.
+
+## Loading references
+
+| The user wants to check… | Load this reference | Status |
+|---|---|---|
+| The health-condition model itself (verdicts, the loop, how to check) | `references/health-conditions-model.md` | **Full** |
+| Fleet / collector health — agents reporting, roles present, config drift | `references/health-fleet.md` | **Full** |
+| APM / a service's tracing health & completeness | `references/health-apm.md` | **Full** |
+| Infra Explorer / metrics coverage health | `references/health-infra.md` | **Full** |
+| An **extension**'s data requirements (does the extension have what it needs) | `references/health-extensions.md` | Stub — PM to complete |
+| Logs / RUM / other surfaces | *(add per the template)* | Not yet authored |
+
+Author new references from `contributing/health-reference-md-template.md`.
+
+---
+
+## Verdict model
+
+| Verdict | Meaning | Action |
+|---|---|---|
+| **healthy** | All conditions met; the experience/extension can deliver value | Nothing to do |
+| **degraded** | Data flows but a quality/completeness condition fails (e.g. spans without `service.name`, missing attributes, gaps in continuity) | Fix the specific attribute/config → often a small `cx-onboarding` change |
+| **missing** | A required signal is absent entirely | Route to `cx-onboarding` for that signal |
+
+Always report *which condition* failed and *why it matters* for that experience — a verdict without a
+reason isn't actionable.
+
+---
+
+## How to check (read-only)
+
+Health checks use read-only `cx` queries (no ingestion quota, no AI Units):
+
+```bash
+# Continuity: is the signal still arriving? (compare recent vs a baseline window)
+cx logs "filter \$l.applicationname == '<app>'" --start now-15m --limit 1
+cx spans "filter \$l.serviceName == '<service>'" --start now-15m --limit 1
+cx metrics search --name '*<key-metric>*'
+
+# Completeness: are the required attributes present?
+cx spans "filter \$l.serviceName == '<service>'" --limit 5 -o json   # inspect for service.name, error, duration
+cx search-fields "<attribute the experience needs>" --dataset spans
+
+# Extensions/integrations present?
+cx integrations list        # what's configured; cross-check against expected extensions
+```
+
+Each reference spells out the exact conditions and queries for its surface.
+
+---
+
+## AI usage & no-AI path (required posture)
+
+Runs in the customer's own agent → **no Coralogix AI Units consumed** unless a step calls the Olly API.
+
+- **Layer 1 — no-AI:** the deterministic condition checks + verdicts in the references. Always works
+  (air-gapped/BYOC/out-of-units).
+- **Layer 2 — minimal free AI:** optional — phrase a verdict in context, or rank which missing
+  condition to fix first (low token, cheap model; absorbed cost must be explicit in COGS).
+- **Layer 3 — full Olly (paid, credit-gated):** optional — "ask Olly to diagnose why this experience
+  is degraded and propose a fix" (Olly API → consumes AI Units; fall back to Layer 1 when exhausted).
+
+---
+
+## Safety
+
+Health **checks** are read-only and safe to run freely. **Remediation** (instrumenting a gap) is
+mutating and is handled by `cx-onboarding` — apply its safety rules there (state what changes, dry-run,
+user's own repo/cluster).
+
+---
+
+## Key principles
+
+- **Organize by intent, not by our roadmap** — this skill is "is my data good enough"; onboarding is
+  "get data in". Different intents, cross-linked in a loop.
+- **A verdict needs a reason and a route** — say which condition failed, why it matters, and where to fix it.
+- **Checks are read-only; fixes go through `cx-onboarding`.**
+- **UI is the primary health surface** — this is the terminal companion, not a replacement.
+- **Conditions are contributable** — each experience/extension owns its reference MD.
+
+---
+
+## Additional resources
+
+### Reference files
+
+- **`references/health-conditions-model.md`** — the verdict model, the onboarding↔health loop, how to check conditions.
+- **`references/health-fleet.md`** — fleet / collector health (agents reporting, roles, config drift).
+- **`references/health-apm.md`** — APM / tracing health conditions for a service.
+- **`references/health-infra.md`** — Infra Explorer / metrics coverage conditions.
+- **`references/health-extensions.md`** — extension data-requirement checks (stub).
+
+### Authoring standard
+
+- **`contributing/health-reference-md-template.md`** — template for a per-experience/extension health reference.
+
+---
+
+## Related skills
+
+| User intent | Route to |
+|---|---|
+| Fix / instrument a missing or degraded signal (the remediation half of the loop) | `cx-onboarding` |
+| Investigate a specific incident/error in data that flows | `cx-telemetry-querying` |
+| Build a dashboard or alert on the health signals | `cx-dashboards` |
+| Look up product docs | `coralogix-docs` |

--- a/skills/cx-system-health/SKILL.md
+++ b/skills/cx-system-health/SKILL.md
@@ -84,14 +84,19 @@ Health checks use read-only `cx` queries (no ingestion quota, no AI Units):
 # Continuity: is the signal still arriving? (compare recent vs a baseline window)
 cx logs "filter \$l.applicationname == '<app>'" --start now-15m --limit 1
 cx spans "filter \$l.serviceName == '<service>'" --start now-15m --limit 1
-cx metrics search --name '*<key-metric>*'
+# For metrics, a time-bounded PromQL query — NOT `metrics search`, which reads the untimed name
+# catalog and would report a metric that stopped flowing as still present (a false "healthy"):
+cx metrics query '<key-metric>'                                        # live now? (instant, at now)
+cx metrics query-range '<key-metric>' --start now-24h --end now --step 1h   # recent vs baseline
 
 # Completeness: are the required attributes present?
 cx spans "filter \$l.serviceName == '<service>'" --limit 5 -o json   # inspect for service.name, error, duration
 cx search-fields "<attribute the experience needs>" --dataset spans
 
-# Extensions/integrations present?
-cx integrations list        # what's configured; cross-check against expected extensions
+# Extensions present? Extension install-state lives under the extensions subcommand,
+# not `cx integrations list` (which lists ordinary integrations):
+cx integrations extensions deployed        # installed extensions; cross-check against expected ones
+cx integrations extensions list            # what extensions are available to install
 ```
 
 Each reference spells out the exact conditions and queries for its surface.

--- a/skills/cx-system-health/references/health-apm.md
+++ b/skills/cx-system-health/references/health-apm.md
@@ -1,0 +1,61 @@
+# Health: APM / tracing (a service)
+
+*Validated end-to-end (2026-07).*
+
+Is a service's tracing data healthy and complete enough for APM (service map, latency, errors) to be
+useful? Checks presence, completeness, and quality of spans for one service.
+
+## When to use this reference
+
+"Is my APM healthy", "why is the service map incomplete", "my traces look wrong", "did tracing stop
+for `<service>`", "is `<service>` fully instrumented for APM".
+
+## Conditions & checks
+
+| # | Condition | Kind | Check | Fail → |
+|---|---|---|---|---|
+| 1 | Spans arriving now for the service | Presence | `cx spans "filter \$l.serviceName == '<svc>'" --start now-15m --limit 1` | **missing** → `cx-onboarding` `onboarding-apm-spans.md` |
+| 2 | Was flowing, still flowing (no stop) | Continuity | compare now vs baseline `--start now-24h --end now-1h` | **degraded** (stopped) → check collector/exporter |
+| 3 | `service.name` / `cx.subsystem.name` set (not blank/defaulted) | Completeness | `cx spans "filter \$l.serviceName == '<svc>'" --limit 5 -o json` → inspect | **degraded** → set resource attributes (onboarding APM) |
+| 4 | Errors are flagged (status/`error` present) | Completeness | inspect sample for status code / error attribute | **degraded** → instrument error semantics |
+| 5 | Duration present (latency computable) | Completeness | inspect sample for span duration | **degraded** → SDK/auto-instrumentation gap |
+| 6 | Sampling is intentional (not accidental 100% or ~0%) | Quality | check span volume vs request volume / sampling config | **degraded** → set sampling on collector/exporter |
+| 7 | Trace continuity (context propagated across services) | Quality | look for orphan/broken traces in Explore Spans | **degraded** → fix propagation |
+
+## Verdict → remediation
+
+- **missing** (cond. 1): the service isn't sending spans → route to `cx-onboarding` →
+  `onboarding-apm-spans.md`. If the customer runs a legacy/proprietary APM agent, flag the bridge path
+  and its sampling implications (see that reference).
+- **degraded** (cond. 3–7): data flows but isn't fully useful → the specific fix, usually a small
+  attribute/sampling/propagation change routed through onboarding.
+
+## Quality gotchas specific to APM
+
+- **Accidental 100% sampling** (e.g. a legacy agent bridged through OTel switched off adaptive
+  sampling) inflates cost and can still look "healthy" on presence — check condition 6 explicitly.
+- **Blank/`unknown_service`** means resource attributes weren't set — data lands but the service map is
+  wrong. Common and high-impact.
+
+## Tier note
+
+APM/tracing requires a tier that includes it — on Low/Block the *experience* may be unavailable even
+when spans arrive. A "healthy data / no visible experience" case is a **tier** verdict, not a data
+verdict; say so and don't send the user chasing instrumentation.
+
+## AI layers
+
+- **Layer 1 (no-AI):** the condition table above.
+- **Layer 2:** rank which degraded condition to fix first for this service.
+- **Layer 3 (Olly, paid):** "diagnose why APM for `<service>` is degraded and propose the fix."
+
+## Docs deep-links
+
+- [Explore spans](https://coralogix.com/docs/user-guides/data_exploration/spans/)
+- [APM via OpenTelemetry on Kubernetes](https://coralogix.com/docs/opentelemetry/integrations/apm-kubernetes-open-telemetry-opentelemetry/)
+
+## Sources / evidence
+
+Coralogix APM/tracing health conditions (`service.name`, error/latency completeness, sampling). The
+bridged-agent accidental-sampling-change is a known real-world failure mode. Read-only `cx spans`
+checks. Created 2026-07.

--- a/skills/cx-system-health/references/health-conditions-model.md
+++ b/skills/cx-system-health/references/health-conditions-model.md
@@ -1,0 +1,75 @@
+# Health conditions model
+
+The shared contract every health reference follows, and how this skill turns "is my data healthy?"
+into an actionable verdict.
+
+## What a "health condition" is
+
+A condition is a checkable statement about telemetry that an experience or extension needs in order to
+deliver value. Three kinds:
+
+1. **Presence / continuity** — the signal is arriving *now* (not just historically). "Spans for
+   `checkout` in the last 15 min."
+2. **Completeness** — the required fields/attributes are present. "Spans carry `service.name` and a
+   duration; errors are flagged."
+3. **Quality** — the data meets a usefulness bar. "Not 100%-sampled by accident; app/subsystem names
+   aren't blank or defaulted; no high-cardinality explosion."
+
+## The verdict
+
+Each condition resolves to one of:
+
+| Verdict | Definition |
+|---|---|
+| **healthy** | condition met |
+| **degraded** | data present but a completeness/quality condition fails |
+| **missing** | required signal absent |
+
+An experience's overall verdict is the worst of its conditions. **Always report the failing condition
++ why it matters + the route to fix it** — a bare "degraded" is not actionable.
+
+## The onboarding ↔ health loop
+
+```
+cx-onboarding  ──instrument──▶  data flows  ──▶  cx-system-health checks conditions
+      ▲                                                     │
+      └──────────── gap: missing/degraded ◀─────────────────┘
+```
+
+When a condition is `missing` or `degraded`, hand back to `cx-onboarding` for the specific signal
+(e.g. degraded APM completeness → `onboarding-apm-spans.md` to set `service.name`). The **automatic**
+version of "detect the gap, then instrument it" is discovery-gated activation; this
+skill is the manual/assistive path.
+
+## How to check a condition (read-only)
+
+- **Presence/continuity:** query the signal for a recent window; optionally compare to a baseline
+  window to detect a *stop* (was flowing, now isn't).
+  ```bash
+  cx spans "filter \$l.serviceName == '<svc>'" --start now-15m --limit 1     # now
+  cx spans "filter \$l.serviceName == '<svc>'" --start now-24h --end now-1h --limit 1  # baseline
+  ```
+- **Completeness:** inspect a sample and check for required fields, or use field discovery.
+  ```bash
+  cx spans "filter \$l.serviceName == '<svc>'" --limit 5 -o json
+  cx search-fields "<required attribute>" --dataset spans
+  ```
+- **Quality:** surface-specific (sampling rate, blank names, cardinality) — defined per reference.
+
+## What backs the condition data
+
+Today this skill derives verdicts from **read-only `cx` queries**. It's written to a stable
+**conditions → verdict → remediation** contract, so if a product health API becomes available it can
+back the same verdicts without changing the model — only the *source* of a condition's status changes,
+not the model or the loop. Write references as "here is the condition and how to verify it."
+
+## Cost & AI
+
+Checks are read-only `cx` queries → no ingestion quota, no AI Units. AI layers (optional): Layer-2 can
+rank/phrase verdicts with a cheap model; Layer-3 Olly can diagnose+propose fixes (credit-gated). Any
+absorbed AI cost must be explicit in COGS.
+
+## Sources / evidence
+
+Coralogix system-health — verdict/condition framing ("monitor the monitor"). Read-only `cx` checks;
+the loop to instrumentation is the discovery-gated activation path. Created 2026-07.

--- a/skills/cx-system-health/references/health-extensions.md
+++ b/skills/cx-system-health/references/health-extensions.md
@@ -16,7 +16,7 @@ the integration for `<tech>` actually working".
 
 | # | Condition | Kind | Check | Fail → |
 |---|---|---|---|---|
-| 1 | The extension is installed/configured | Presence | `cx integrations list` | **missing** → install (route to setup) |
+| 1 | The extension is installed/configured | Presence | `cx integrations extensions deployed` (install-state lives here, *not* `cx integrations list`, which lists ordinary integrations) | **missing** → install (route to setup) |
 | 2 | The signal the extension parses is arriving | Presence | `cx logs/metrics/spans` for the extension's expected source | **missing** → `cx-onboarding` |
 | 3 | Data matches the extension's expected fields/format | Completeness | inspect sample vs the extension's schema | **degraded** → fix parsing/attributes |
 | 4 | *TODO (PM):* extension-specific quality conditions | Quality | | |
@@ -29,7 +29,7 @@ the integration for `<tech>` actually working".
 
 ## TODO (owning PM)
 
-Fill the extension-specific conditions, the exact `cx integrations` output to expect, and the mapping
+Fill the extension-specific conditions, the exact `cx integrations extensions deployed` output to expect, and the mapping
 from "extension X" → "signals + fields it requires". Consider generating this per-extension from the
 extension catalog rather than hand-authoring each.
 

--- a/skills/cx-system-health/references/health-extensions.md
+++ b/skills/cx-system-health/references/health-extensions.md
@@ -1,0 +1,38 @@
+# Health: Extensions data requirements  *(STUB — for the owning PM to complete)*
+
+> **Status:** scaffold. Complete from `contributing/health-reference-md-template.md`. Extensions =
+> Coralogix quick-start integration packages (dashboards + alerts + parsing for a specific tech, e.g.
+> nginx, MySQL, a cloud service). An extension only delivers value if the telemetry it expects is
+> actually arriving with the right shape.
+
+Check whether an installed extension has the data it needs to populate its dashboards/alerts.
+
+## When to use this reference
+
+"Does my `<tech>` extension have the data it needs", "why is the `<extension>` dashboard empty", "is
+the integration for `<tech>` actually working".
+
+## Conditions & checks (to complete)
+
+| # | Condition | Kind | Check | Fail → |
+|---|---|---|---|---|
+| 1 | The extension is installed/configured | Presence | `cx integrations list` | **missing** → install (route to setup) |
+| 2 | The signal the extension parses is arriving | Presence | `cx logs/metrics/spans` for the extension's expected source | **missing** → `cx-onboarding` |
+| 3 | Data matches the extension's expected fields/format | Completeness | inspect sample vs the extension's schema | **degraded** → fix parsing/attributes |
+| 4 | *TODO (PM):* extension-specific quality conditions | Quality | | |
+
+## Verdict → remediation
+
+- **missing** → route to onboarding for the source signal, or install the extension.
+- **degraded** → the data doesn't match what the extension parses → fix at the instrumentation/parsing
+  layer (route to `cx-onboarding`; parsing rules are `cx-data-pipeline`).
+
+## TODO (owning PM)
+
+Fill the extension-specific conditions, the exact `cx integrations` output to expect, and the mapping
+from "extension X" → "signals + fields it requires". Consider generating this per-extension from the
+extension catalog rather than hand-authoring each.
+
+## Sources / evidence
+
+Scaffold (2026-07). `cx integrations` manages integrations/extensions/contextual data.

--- a/skills/cx-system-health/references/health-fleet.md
+++ b/skills/cx-system-health/references/health-fleet.md
@@ -1,0 +1,85 @@
+# Health: Fleet / collector health
+
+*Validated end-to-end (2026-07).*
+
+Is the collector fleet healthy — are all expected collectors reporting, on the intended config/version,
+and not restart-looping? This is the ongoing-health counterpart to `onboarding-fleet.md` (which *deploys*
+a collector). Covers ongoing **Fleet Health**.
+
+## When to use this reference
+
+"Are my collectors healthy", "which agents stopped reporting", "is my fleet reporting", "collector
+config drift", "did an agent go down", "fleet health", "are all my OTel collectors up", "is the gateway
+running".
+
+> **UI-first.** Fleet Health has a dedicated UI. This reference is the terminal companion —
+> quick programmatic checks + "what's wrong, where to fix it". For visual triage point the user to the
+> Fleet Health dashboard.
+
+> **Fleet Health model.** Fleet Health classifies via out-of-the-box **policies** into
+> **Critical / Warning / Healthy** across the canonical failure modes: **agent down** (Availability),
+> **throughput drop / no data** (Freshness), **config rejected** and **version drift** (Other). This
+> reference uses those same modes; its verdicts map: `missing`≈no fleet at all, `degraded`≈Critical/Warning
+> policy. Predefined policies are **enable/disable-only** (not editable); customers **add their own** rules
+> (Fleet-only). A broken policy can raise a **Case**.
+>
+> **Health API (future).** If Fleet Health exposes a health API, the skill can call it for the verdict.
+> Today the checks below hand-run read-only `cx` queries — same conditions → verdict contract, no rework later.
+
+## Conditions & checks
+
+| # | Condition (failure mode) | Category | Check | Fail → |
+|---|---|---|---|---|
+| 1 | Collectors emitting their own telemetry at all | Availability | `cx metrics search --name '*otelcol*'` | no fleet → `cx-onboarding` `onboarding-fleet.md` |
+| 2 | **Agent down** — each expected collector still reporting (none silently gone) | Availability | per-collector `otelcol_*` now vs baseline (`--start now-24h --end now-1h`) | Critical → check pod/host, redeploy |
+| 3 | All expected **roles** present (DaemonSet agent · cluster collector · gateway) | Availability | confirm each role reports (a DaemonSet fleet can be healthy while the gateway is not) | Warning/Critical → fix the Helm release for the missing role |
+| 4 | **Throughput drop** — data still flowing at expected volume (not nop-config) | Freshness | compare recent throughput vs baseline; "no data in 5 min" style | Warning/Critical → nop/rejected config or upstream stop |
+| 5 | **Config rejected / restart loop** — collector accepted its config and is stable | Other | `otelcol_exporter_send_failed_*` / restart counts / collector logs | Critical → endpoint/key/resources; re-push valid config |
+| 6 | **Version drift** — collectors on the intended config/agent version | Other | compare version each collector reports via OpAMP vs intended Fleet config | Warning → push intended config via Fleet Management (OpAMP) |
+
+*(These are exactly the modes the Fleet Health experience surfaces per agent → cluster → fleet. When the
+1.2 health API ships, call it instead of the queries above — same contract.)*
+
+## Verdict → remediation
+
+- **No fleet** (cond. 1): no collector telemetry → route to `cx-onboarding` → `onboarding-fleet.md` (deploy).
+- **Critical / Warning:**
+  - agent down (2) → redeploy / check the node/pod.
+  - missing role (3) → fix the Helm values (receiver vs cluster collector vs gateway) — evaluate roles separately.
+  - throughput drop (4) → nop/rejected config or an upstream stop; check the source + collector config.
+  - config rejected / restart loop (5) → collector logs: wrong endpoint/region, bad key, or resources; re-push valid config.
+  - version drift (6) → push the intended config via **Fleet Management (OpAMP)** — no redeploy needed.
+- **Raise a Case** for a Critical verdict where the customer has Fleet Health policies, instead of
+  ad-hoc alerting.
+
+## Fleet-specific gotchas
+
+- **Split health by role.** "The fleet is healthy" is per-role: the DaemonSet agent can be fine while the
+  gateway is failing tail-sampling (or vice-versa). Always evaluate roles separately.
+- **Config drift ≠ agent down.** A collector can be up and reporting yet running a stale config — that's a
+  quality verdict (cond. 4), not a presence verdict. OpAMP is how it's corrected without redeploy.
+- **All Helm customers stream config via OpAMP** — so Fleet Health generalizes across the fleet, not just
+  a special cohort.
+
+## Tier note
+
+Fleet/collector health is tier-agnostic (it's about the transport). The *signals* the fleet carries
+inherit their pillar's tier behaviour — see the relevant per-signal health reference.
+
+## AI layers
+
+- **Layer 1 (no-AI):** the condition table above.
+- **Layer 2 (minimal free):** rank which unhealthy collector/role to fix first; summarize a collector
+  error log into a likely cause (cheap model, low token).
+- **Layer 3 (Olly, paid):** "diagnose why the fleet is degraded and propose/deploy the fix" (credit-gated;
+  Olly API → consumes AI Units).
+
+## Docs deep-links
+
+- [Fleet Management for Kubernetes (OpAMP remote config)](https://coralogix.com/docs/user-guides/fleet-management/fleet-remote-config-kubernetes/)
+- [Integration troubleshooting (collector)](https://coralogix.com/docs/opentelemetry/kubernetes-observability/troubleshooting/)
+
+## Sources / evidence
+
+Coralogix Fleet Health — out-of-the-box policies, per-role split (DaemonSet / cluster collector /
+gateway), OpAMP config across all Helm collectors. Read-only `cx metrics` checks. Created 2026-07.

--- a/skills/cx-system-health/references/health-fleet.md
+++ b/skills/cx-system-health/references/health-fleet.md
@@ -30,15 +30,15 @@ running".
 
 | # | Condition (failure mode) | Category | Check | Fail → |
 |---|---|---|---|---|
-| 1 | Collectors emitting their own telemetry at all | Availability | `cx metrics search --name '*otelcol*'` | no fleet → `cx-onboarding` `onboarding-fleet.md` |
+| 1 | Collectors emitting their own telemetry at all | Availability | `cx metrics query 'count({__name__=~"otelcol_.*"})'` (instant — result >0 = collectors reporting *now*; `metrics search` only lists the untimed catalog) | no fleet → `cx-onboarding` `onboarding-fleet.md` |
 | 2 | **Agent down** — each expected collector still reporting (none silently gone) | Availability | per-collector `otelcol_*` now vs baseline (`--start now-24h --end now-1h`) | Critical → check pod/host, redeploy |
 | 3 | All expected **roles** present (DaemonSet agent · cluster collector · gateway) | Availability | confirm each role reports (a DaemonSet fleet can be healthy while the gateway is not) | Warning/Critical → fix the Helm release for the missing role |
 | 4 | **Throughput drop** — data still flowing at expected volume (not nop-config) | Freshness | compare recent throughput vs baseline; "no data in 5 min" style | Warning/Critical → nop/rejected config or upstream stop |
 | 5 | **Config rejected / restart loop** — collector accepted its config and is stable | Other | `otelcol_exporter_send_failed_*` / restart counts / collector logs | Critical → endpoint/key/resources; re-push valid config |
 | 6 | **Version drift** — collectors on the intended config/agent version | Other | compare version each collector reports via OpAMP vs intended Fleet config | Warning → push intended config via Fleet Management (OpAMP) |
 
-*(These are exactly the modes the Fleet Health experience surfaces per agent → cluster → fleet. When the
-1.2 health API ships, call it instead of the queries above — same contract.)*
+*(These are exactly the modes the Fleet Health experience surfaces per agent → cluster → fleet. If a
+Fleet Health API ships later, call it instead of the queries above — same contract.)*
 
 ## Verdict → remediation
 

--- a/skills/cx-system-health/references/health-infra.md
+++ b/skills/cx-system-health/references/health-infra.md
@@ -1,0 +1,57 @@
+# Health: Infra Explorer / metrics coverage
+
+*Validated end-to-end (2026-07).*
+
+Is infrastructure metric coverage healthy and complete enough for Infra Explorer to populate entities
+(nodes, pods, hosts) with live values?
+
+## When to use this reference
+
+"Is my infra monitoring healthy", "why is Infra Explorer empty/partial", "did metrics stop", "are my
+nodes/pods showing up", "is my metrics coverage complete".
+
+## Conditions & checks
+
+| # | Condition | Kind | Check | Fail → |
+|---|---|---|---|---|
+| 1 | Core infra metrics arriving now | Presence | `cx metrics search --name '*container_cpu*'` / `'*kube_pod*'` | **missing** → `cx-onboarding` `onboarding-metrics-infra.md` |
+| 2 | Still flowing (no stop vs baseline) | Continuity | `cx metrics query 'rate(<key_metric>[5m])'` recent vs earlier | **degraded** (stopped) → check collector scrape |
+| 3 | Entity-mapping labels present (node/pod/host identifiers) | Completeness | inspect labels on infra metrics | **degraded** → ensure infra semantic conventions |
+| 4 | Expected metric names match dashboard/experience needs | Completeness | `cx metrics search --name '*<expected>*'` | **degraded** → naming mismatch (see below) |
+| 5 | Cardinality sane (no label explosion) | Quality | check series count for high-cardinality labels | **degraded** → drop/aggregate labels |
+| 6 | Scrape interval intentional (cost vs resolution) | Quality | review scrape config | **degraded** → tune interval |
+
+## Verdict → remediation
+
+- **missing** (cond. 1): infra metrics not collected → route to `cx-onboarding` →
+  `onboarding-metrics-infra.md` (deploy/enable the collector's infra metrics).
+- **degraded** (cond. 3–6): data flows but Infra Explorer is partial or costly → the specific fix
+  (labels, naming, cardinality, interval).
+
+## The naming-fragmentation trap (why "healthy metrics" ≠ "populated experience")
+
+Metrics can be present and continuous yet the **default dashboards / Infra Explorer stay empty** because
+the metric names don't match what the experience expects (8–10 naming variations are common — the hard
+part of metrics activation). Condition 4 catches this: healthy *ingestion* but degraded *experience
+coverage*. Report it as a naming/mapping gap, not a "no data" gap.
+
+## Tier note
+
+Metrics experiences (alerts/dashboards) vary by tier; on lower tiers some are unavailable even with
+healthy data. Distinguish a **tier** verdict from a **data** verdict.
+
+## AI layers
+
+- **Layer 1 (no-AI):** the condition table.
+- **Layer 2:** map raw metric names to the expected convention; suggest the label/interval fix.
+- **Layer 3 (Olly, paid):** "diagnose why Infra Explorer is empty and propose the fix."
+
+## Docs deep-links
+
+- [Explore metrics](https://coralogix.com/docs/user-guides/data_exploration/metrics-explorer/)
+- [Optimize metrics cost by scrape interval](https://coralogix.com/docs/user-guides/account-management/payment-and-billing/optimize-metrics-costs-in-coralogix-by-adjusting-your-scrape-interval/)
+
+## Sources / evidence
+
+Coralogix Infra Explorer / metrics health. Metric-name fragmentation is a well-known reason default
+dashboards / Infra Explorer stay empty even when metrics flow. Read-only `cx metrics` checks. Created 2026-07.

--- a/skills/cx-system-health/references/health-infra.md
+++ b/skills/cx-system-health/references/health-infra.md
@@ -14,7 +14,7 @@ nodes/pods showing up", "is my metrics coverage complete".
 
 | # | Condition | Kind | Check | Fail → |
 |---|---|---|---|---|
-| 1 | Core infra metrics arriving now | Presence | `cx metrics search --name '*container_cpu*'` / `'*kube_pod*'` | **missing** → `cx-onboarding` `onboarding-metrics-infra.md` |
+| 1 | Core infra metrics arriving now | Presence | `cx metrics query 'container_cpu_usage_seconds_total'` / `'kube_pod_info'` (instant — non-empty = live *now*; `metrics search` reads the untimed catalog and can't prove liveness) | **missing** → `cx-onboarding` `onboarding-metrics-infra.md` |
 | 2 | Still flowing (no stop vs baseline) | Continuity | `cx metrics query 'rate(<key_metric>[5m])'` recent vs earlier | **degraded** (stopped) → check collector scrape |
 | 3 | Entity-mapping labels present (node/pod/host identifiers) | Completeness | inspect labels on infra metrics | **degraded** → ensure infra semantic conventions |
 | 4 | Expected metric names match dashboard/experience needs | Completeness | `cx metrics search --name '*<expected>*'` | **degraded** → naming mismatch (see below) |


### PR DESCRIPTION
Adds two agent skills for the setup/health side of observability, complementing the existing query/investigation skills:

* `cx-onboarding` — get telemetry into Coralogix (collector/Fleet, APM, metrics/infra; logs/RUM/AI-Center stubs). Orchestrator + per-signal reference files, mirroring `cx-telemetry-querying`.
* `cx-system-health` — check whether telemetry is healthy/complete for an experience/extension; emits verdicts (healthy/degraded/missing) and loops back to `cx-onboarding` on a gap.

Both follow `contributing/adding-a-skill.md`; pass `agentskills validate` + `scripts/verify-skills.sh`. Health checks are read-only `cx` queries. Two `contributing/` reference-MD templates included so product owners can author their own per-signal references. First rollout is internal use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)