### PR TITLE
Feat/profiles refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ Agent:
   schema             Output the full command tree as JSON for agent consumption
 
 Local:
-  profiles           Manage profiles (list, add, delete, set-default)
+  profiles           Manage profiles (list, add, refresh, delete, set-default)
   skills             Install or update the cx agent skills for coding agents
   cleanup            Remove stale temp files
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,6 +162,11 @@ silent refresh-token path has already run (and failed) by the time you need it.
 
 Tokens are written to whichever backend the profile already uses, so an
 `os_store` profile stays in the keyring and a `file` profile stays in its TOML.
+For `os_store` the previous token set is replaced wholesale in a single keyring
+write, so no stale refresh or id token can outlive the re-login, and a failed
+write leaves the old session intact rather than deleting it. Other secrets in
+the same keyring entry are preserved.
+
 The command fails without touching the profile if it names an API key profile
 (those don't expire - use `cx profiles add <name>` to change the key) or an OAuth
 profile whose custom environment has no `oauth_client_id`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -167,6 +167,9 @@ write, so no stale refresh or id token can outlive the re-login, and a failed
 write leaves the old session intact rather than deleting it. Other secrets in
 the same keyring entry are preserved.
 
+Unlike the other `profiles` subcommands, `refresh` is blocked in
+[read-only mode](#read-only-mode) - it writes credentials.
+
 The command fails without touching the profile if it names an API key profile
 (those don't expire - use `cx profiles add <name>` to change the key) or an OAuth
 profile whose custom environment has no `oauth_client_id`.
@@ -479,6 +482,8 @@ Error: Write operation 'create' is blocked in read-only mode
 ```
 
 Local commands (`profiles`, `cleanup`, `completions`) are exempt from read-only enforcement - they manage local configuration and never touch the Coralogix API.
+
+The one exception is `cx profiles refresh`, which is blocked: unlike the other local commands it performs a browser login and persists a new credential set.
 
 The env var accepts `1`, `true`, `yes`, or `on` (case-insensitive).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -143,8 +143,28 @@ OAuth uses the standard browser-based Authorization Code + PKCE flow.
 - If the refresh token is also expired, `cx` exits with an actionable message:
 
   ```
-  Run cx profiles add <name> to re-authenticate.
+  Run cx profiles refresh <name> to re-authenticate.
   ```
+
+#### Re-authenticating an expired session
+
+`cx profiles refresh <name>` re-runs the browser login for an existing profile
+and replaces only its stored OAuth tokens:
+
+```sh
+cx profiles refresh prod
+```
+
+Region, label, credential storage, output format, and default tier are read from
+the profile and written back unchanged, and nothing is prompted for - the command
+takes only the profile name. It always performs a full browser login, because the
+silent refresh-token path has already run (and failed) by the time you need it.
+
+Tokens are written to whichever backend the profile already uses, so an
+`os_store` profile stays in the keyring and a `file` profile stays in its TOML.
+The command fails without touching the profile if it names an API key profile
+(those don't expire - use `cx profiles add <name>` to change the key) or an OAuth
+profile whose custom environment has no `oauth_client_id`.
 
 #### Custom or non-standard environments (BYOC / private-link)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -99,6 +99,11 @@ about - additional profiles, profile labels, API-key auth, OS-keyring credential
 storage, and a non-default output format. See
 [Advanced configuration](configuration.md).
 
+OAuth access tokens are refreshed silently on every invocation. When the session
+has expired entirely, `cx profiles refresh <name>` re-runs the browser login for
+that profile and replaces only its tokens - every other setting is left
+untouched, and there are no prompts.
+
 ### 3. Ask it something
 
 The answer is the confirmation. If your agent comes back with your data, it is
@@ -263,7 +268,7 @@ These need no API credentials and are exempt from the risky-command confirmation
 | Command | Purpose |
 |---|---|
 | `cx init` | One-step onboarding: configure a profile and install the agent skills |
-| `cx profiles` | Manage profiles: `list`, `add`, `delete`, `set-default` |
+| `cx profiles` | Manage profiles: `list`, `add`, `refresh`, `delete`, `set-default` |
 | `cx skills` | Install or update the cx agent skills for coding agents: `install` |
 | `cx completions` | Shell tab-completion: `install`, `refresh`, `generate` |
 | `cx cleanup` | Remove `cx_results*` temp files older than 30 minutes |

--- a/src/commands/profiles/mod.rs
+++ b/src/commands/profiles/mod.rs
@@ -591,6 +591,71 @@ pub async fn run_add(args: AddArgs) -> Result<()> {
     Ok(())
 }
 
+// ── Refresh ───────────────────────────────────────────────────────────────────
+
+/// OAuth secrets written by `oauth::store_tokens_keyring`. Listed here so a
+/// refresh can clear the previous set without touching the API keys that share
+/// the same keyring entry.
+const OAUTH_KEYRING_KEYS: &[&str] = &[
+    "oauth_access_token",
+    "oauth_refresh_token",
+    "oauth_id_token",
+    "oauth_token_expiry",
+];
+
+/// Re-run the OAuth browser login for an existing profile.
+///
+/// Only the stored token set is replaced - region, label, credential storage,
+/// output format, and default tier are read from the existing profile and
+/// written back untouched. Nothing is prompted for.
+pub async fn run_refresh(profile_name: String) -> Result<()> {
+    if !profile_file(&profile_name)?.exists() {
+        anyhow::bail!("Profile '{profile_name}' not found.");
+    }
+
+    let mut profile = load_profile(&profile_name)?;
+
+    if profile.auth != AuthKind::OAuth {
+        anyhow::bail!(
+            "Profile '{profile_name}' uses API key authentication, which does not expire.\n\
+             Run `cx profiles add {profile_name}` to change its credentials."
+        );
+    }
+
+    let (base_url, client_id) = profile.oauth_endpoint(&profile_name)?;
+
+    println!(
+        "Re-authenticating profile '{profile_name}' (region: {})\n",
+        profile.region
+    );
+    let tokens = oauth::browser_login(&base_url, &client_id).await?;
+    println!("Login successful!");
+
+    let storage_desc = match profile.credential_storage {
+        CredentialStorage::OsStore => {
+            // `store_tokens_keyring` only writes the fields the IdP returned, so
+            // clear the old set first to avoid leaving a stale refresh or id
+            // token behind. Per-key deletion: the entry also holds API keys.
+            for key in OAUTH_KEYRING_KEYS {
+                keyring_store::delete_secret(&profile_name, key);
+            }
+            oauth::store_tokens_keyring(&profile_name, &tokens)?;
+            // Drop any inline tokens left over from a previous `file` setup.
+            profile.oauth_tokens = None;
+            "OS credential store"
+        }
+        CredentialStorage::File => {
+            profile.oauth_tokens = Some(oauth::tokens_to_stored(&tokens));
+            "profile file"
+        }
+    };
+
+    save_profile(&profile_name, &profile)?;
+
+    println!("OAuth tokens for '{profile_name}' refreshed in {storage_desc}.");
+    Ok(())
+}
+
 // ── Delete ────────────────────────────────────────────────────────────────────
 
 pub fn run_delete(profile_name: String, force: bool) -> Result<()> {

--- a/src/commands/profiles/mod.rs
+++ b/src/commands/profiles/mod.rs
@@ -593,16 +593,6 @@ pub async fn run_add(args: AddArgs) -> Result<()> {
 
 // ── Refresh ───────────────────────────────────────────────────────────────────
 
-/// OAuth secrets written by `oauth::store_tokens_keyring`. Listed here so a
-/// refresh can clear the previous set without touching the API keys that share
-/// the same keyring entry.
-const OAUTH_KEYRING_KEYS: &[&str] = &[
-    "oauth_access_token",
-    "oauth_refresh_token",
-    "oauth_id_token",
-    "oauth_token_expiry",
-];
-
 /// Re-run the OAuth browser login for an existing profile.
 ///
 /// Only the stored token set is replaced - region, label, credential storage,
@@ -633,13 +623,14 @@ pub async fn run_refresh(profile_name: String) -> Result<()> {
 
     let storage_desc = match profile.credential_storage {
         CredentialStorage::OsStore => {
-            // `store_tokens_keyring` only writes the fields the IdP returned, so
-            // clear the old set first to avoid leaving a stale refresh or id
-            // token behind. Per-key deletion: the entry also holds API keys.
-            for key in OAUTH_KEYRING_KEYS {
-                keyring_store::delete_secret(&profile_name, key);
-            }
-            oauth::store_tokens_keyring(&profile_name, &tokens)?;
+            // Full replacement, not a merge: `store_tokens_keyring` writes only
+            // the fields the IdP returned, so a stale refresh or id token from
+            // the previous session could otherwise survive a re-login. The
+            // clear and the write are a single checked keyring operation, so a
+            // failure here leaves the old token set in place rather than
+            // wiping a working session it cannot replace. API keys in the same
+            // entry are preserved.
+            oauth::replace_tokens_keyring(&profile_name, &tokens)?;
             // Drop any inline tokens left over from a previous `file` setup.
             profile.oauth_tokens = None;
             "OS credential store"

--- a/src/config.rs
+++ b/src/config.rs
@@ -410,6 +410,22 @@ impl Profile {
     }
 }
 
+/// Whether the generic "Run `cx profiles add` to set up credentials." hint
+/// should be printed after `error`.
+///
+/// Most configuration failures are a missing or unconfigured profile, where
+/// that hint is the right next step. Some, though, already carry a more
+/// specific instruction of their own: an expired OAuth session says to run
+/// `cx profiles refresh <name>`. Appending the generic hint to one of those
+/// contradicts it on the same stderr and points the user back at the
+/// reconfiguration flow `profiles refresh` exists to spare them, so suppress
+/// it whenever the error chain has already said what to run.
+pub fn wants_generic_credentials_hint(error: &anyhow::Error) -> bool {
+    !error
+        .chain()
+        .any(|cause| cause.to_string().contains("cx profiles"))
+}
+
 /// Resolved configuration ready for use at runtime.
 #[derive(Debug, Clone)]
 pub struct ResolvedConfig {
@@ -804,6 +820,40 @@ mod tests {
             OutputFormat::from_str("agents", true).unwrap(),
             OutputFormat::Toon
         );
+    }
+
+    // ── wants_generic_credentials_hint ────────────────────────────────────────
+
+    #[test]
+    fn generic_hint_shown_for_errors_with_no_instruction_of_their_own() {
+        let err = anyhow::anyhow!("Profile 'prod' not found.");
+        assert!(wants_generic_credentials_hint(&err));
+    }
+
+    #[test]
+    fn generic_hint_suppressed_when_the_error_already_names_a_command() {
+        // The message `oauth::resolve_token` produces for an expired session.
+        let err = anyhow::anyhow!(
+            "OAuth session expired for profile 'prod'.\n\
+             Run `cx profiles refresh prod` to re-authenticate."
+        );
+        assert!(
+            !wants_generic_credentials_hint(&err),
+            "an error that already says `cx profiles refresh` must not be followed \
+             by `cx profiles add`"
+        );
+    }
+
+    #[test]
+    fn generic_hint_suppressed_when_a_wrapped_cause_names_a_command() {
+        // `resolve_token` attaches its instruction with `.with_context(...)`,
+        // and the transport failure is wrapped underneath it - so the check has
+        // to walk the whole chain, not just the outermost message.
+        let err = anyhow::anyhow!("Token refresh failed (400 Bad Request)").context(
+            "OAuth token refresh failed for profile 'prod'.\n\
+             Run `cx profiles refresh prod` to re-authenticate.",
+        );
+        assert!(!wants_generic_credentials_hint(&err));
     }
 
     // ── Profile::oauth_endpoint ───────────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -380,6 +380,36 @@ pub struct Profile {
     pub cached_console_url_at: Option<DateTime<Utc>>,
 }
 
+impl Profile {
+    /// Resolve the OAuth base URL and client ID for this profile.
+    ///
+    /// The base URL comes from `oauth_base_url` when set (custom environments),
+    /// otherwise from the region's API endpoint. The client ID comes from
+    /// `oauth_client_id` when set, otherwise from the hard-coded per-region
+    /// table in `oauth::KNOWN_ENVIRONMENTS`.
+    ///
+    /// `profile_name` is used only to build the error message.
+    pub fn oauth_endpoint(&self, profile_name: &str) -> Result<(String, String)> {
+        let region_name = self.region.to_string();
+        let base_url = self
+            .oauth_base_url
+            .clone()
+            .unwrap_or_else(|| self.region.api_endpoint().to_string());
+        let client_id = self
+            .oauth_client_id
+            .clone()
+            .or_else(|| oauth::client_id_for_region(&region_name).map(str::to_string))
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No OAuth client ID configured for profile '{profile_name}' \
+                     (region: {region_name}).\n\
+                     Run `cx profiles add {profile_name}` to reconfigure."
+                )
+            })?;
+        Ok((base_url, client_id))
+    }
+}
+
 /// Resolved configuration ready for use at runtime.
 #[derive(Debug, Clone)]
 pub struct ResolvedConfig {
@@ -569,22 +599,7 @@ async fn resolve_single(
         }
         AuthKind::OAuth => {
             debug_assert!(api_key_override.is_none());
-            let region_name = profile.region.to_string();
-            let base_url = profile
-                .oauth_base_url
-                .clone()
-                .unwrap_or_else(|| profile.region.api_endpoint().to_string());
-            let client_id = profile
-                .oauth_client_id
-                .clone()
-                .or_else(|| oauth::client_id_for_region(&region_name).map(str::to_string))
-                .ok_or_else(|| {
-                    anyhow::anyhow!(
-                        "No OAuth client ID configured for profile '{profile_name}' \
-                         (region: {region_name}).\n\
-                         Run `cx profiles add {profile_name}` to reconfigure."
-                    )
-                })?;
+            let (base_url, client_id) = profile.oauth_endpoint(profile_name)?;
             let storage = profile.credential_storage;
             let (bearer, refreshed) = oauth::resolve_token(
                 profile_name,
@@ -789,6 +804,67 @@ mod tests {
             OutputFormat::from_str("agents", true).unwrap(),
             OutputFormat::Toon
         );
+    }
+
+    // ── Profile::oauth_endpoint ───────────────────────────────────────────────
+
+    fn oauth_profile(region: Region) -> Profile {
+        Profile {
+            auth: AuthKind::OAuth,
+            credential_storage: CredentialStorage::File,
+            api_key: None,
+            region,
+            label: None,
+            oauth_client_id: None,
+            oauth_base_url: None,
+            oauth_tokens: None,
+            default_output_format: None,
+            default_tier: None,
+            console_url: None,
+            cached_console_url: None,
+            cached_console_url_at: None,
+        }
+    }
+
+    #[test]
+    fn oauth_endpoint_known_region_uses_builtin_client_id() {
+        let profile = oauth_profile(Region::Eu2);
+        let (base_url, client_id) = profile.oauth_endpoint("prod").unwrap();
+        assert_eq!(base_url, "https://api.eu2.coralogix.com");
+        assert_eq!(client_id, oauth::client_id_for_region("eu2").unwrap());
+    }
+
+    #[test]
+    fn oauth_endpoint_profile_overrides_win() {
+        let mut profile = oauth_profile(Region::Eu2);
+        profile.oauth_base_url = Some("https://api.myenv.coralogix.com".to_string());
+        profile.oauth_client_id = Some("custom-client".to_string());
+        let (base_url, client_id) = profile.oauth_endpoint("custom").unwrap();
+        assert_eq!(base_url, "https://api.myenv.coralogix.com");
+        assert_eq!(client_id, "custom-client");
+    }
+
+    #[test]
+    fn oauth_endpoint_custom_region_without_client_id_errors() {
+        let profile = oauth_profile(Region::Custom(
+            "https://api.myenv.coralogix.com".to_string(),
+        ));
+        let err = profile
+            .oauth_endpoint("custom")
+            .expect_err("a custom region with no client ID cannot be resolved");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("No OAuth client ID configured") && msg.contains("custom"),
+            "error should name the profile and the missing client ID, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn oauth_endpoint_stg1_has_no_builtin_client_id() {
+        // stg1 is a known Region variant but is absent from KNOWN_ENVIRONMENTS,
+        // so it behaves like a custom environment and needs an explicit ID.
+        let profile = oauth_profile(Region::Stg1);
+        assert!(profile.oauth_endpoint("staging").is_err());
     }
 
     // ── list_profile_names_from ────────────────────────────────────────────────

--- a/src/keyring_store.rs
+++ b/src/keyring_store.rs
@@ -51,6 +51,36 @@ pub fn get_secret(profile: &str, key_name: &str) -> Result<Option<String>> {
     Ok(load_map(profile)?.and_then(|m| m.get(key_name).cloned()))
 }
 
+/// Apply a removal/insertion set to an in-memory secret map.
+///
+/// Split out from [`replace_secrets`] so the merge semantics — drop `remove`,
+/// write `set`, leave everything else alone — are testable without a keyring.
+fn apply_replacement(map: &mut SecretMap, remove: &[&str], set: &[(&str, String)]) {
+    for key in remove {
+        map.remove(*key);
+    }
+    for (key, value) in set {
+        map.insert((*key).to_string(), value.clone());
+    }
+}
+
+/// Replace a group of secrets for `profile` in a single checked write.
+///
+/// Keys named in `remove` are dropped and every pair in `set` is written, in
+/// one load-modify-save cycle. Secrets named in neither list are preserved, so
+/// this can replace the OAuth token set without disturbing the API keys that
+/// share the same keyring entry.
+///
+/// Unlike [`delete_secret`], failures are surfaced rather than swallowed, and
+/// because the whole group goes out in one `save_map` there is no window in
+/// which the old secrets are gone and the new ones are not yet stored: either
+/// the entry is fully updated or it is left exactly as it was.
+pub fn replace_secrets(profile: &str, remove: &[&str], set: &[(&str, String)]) -> Result<()> {
+    let mut map = load_map(profile)?.unwrap_or_default();
+    apply_replacement(&mut map, remove, set);
+    save_map(profile, &map)
+}
+
 /// Delete a secret from the system keyring. Best-effort - does not fail if missing.
 pub fn delete_secret(profile: &str, key_name: &str) {
     let Ok(Some(mut map)) = load_map(profile) else {
@@ -99,6 +129,67 @@ mod tests {
         delete_secret(profile, "delete_test");
         let result = get_secret(profile, "delete_test").unwrap();
         assert_eq!(result, None);
+        delete_profile(profile);
+    }
+
+    // ── replace_secrets ───────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_replacement_swaps_the_named_group_and_keeps_the_rest() {
+        let mut map = SecretMap::new();
+        map.insert("api_key".to_string(), "team-key".to_string());
+        map.insert("oauth_access_token".to_string(), "old-access".to_string());
+        map.insert("oauth_refresh_token".to_string(), "old-refresh".to_string());
+        map.insert("oauth_id_token".to_string(), "old-id".to_string());
+
+        apply_replacement(
+            &mut map,
+            &[
+                "oauth_access_token",
+                "oauth_refresh_token",
+                "oauth_id_token",
+            ],
+            &[("oauth_access_token", "new-access".to_string())],
+        );
+
+        // The new set is written...
+        assert_eq!(
+            map.get("oauth_access_token").map(String::as_str),
+            Some("new-access")
+        );
+        // ...the stale members of the group are gone, not carried over. This is
+        // the whole point: the IdP need not return a refresh or id token, and a
+        // leftover one from the previous session must not survive a re-login.
+        assert!(!map.contains_key("oauth_refresh_token"));
+        assert!(!map.contains_key("oauth_id_token"));
+        // ...and secrets outside the group are untouched.
+        assert_eq!(map.get("api_key").map(String::as_str), Some("team-key"));
+    }
+
+    #[test]
+    #[ignore = "requires system keyring access"]
+    fn replace_secrets_preserves_unrelated_secrets() {
+        let profile = "cx_keyring_test_replace";
+        store_secret(profile, "api_key", "team-key").unwrap();
+        store_secret(profile, "oauth_access_token", "old-access").unwrap();
+        store_secret(profile, "oauth_refresh_token", "old-refresh").unwrap();
+
+        replace_secrets(
+            profile,
+            &["oauth_access_token", "oauth_refresh_token"],
+            &[("oauth_access_token", "new-access".to_string())],
+        )
+        .unwrap();
+
+        assert_eq!(
+            get_secret(profile, "api_key").unwrap(),
+            Some("team-key".to_string())
+        );
+        assert_eq!(
+            get_secret(profile, "oauth_access_token").unwrap(),
+            Some("new-access".to_string())
+        );
+        assert_eq!(get_secret(profile, "oauth_refresh_token").unwrap(), None);
         delete_profile(profile);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3286,7 +3286,9 @@ async fn main() -> Result<()> {
                 std::process::exit(1);
             }
             eprintln!("Configuration error: {error}");
-            eprintln!("Run `cx profiles add` to set up credentials.");
+            if config::wants_generic_credentials_hint(&error) {
+                eprintln!("Run `cx profiles add` to set up credentials.");
+            }
             return Err(error);
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -2941,6 +2941,31 @@ Examples:
     },
 }
 
+/// Block `cx profiles refresh` in read-only mode.
+///
+/// The `profiles` command tree is otherwise exempt from read-only gating: its
+/// subcommands touch local config, not tenant data. `refresh` is the exception
+/// worth singling out — it runs a browser login and persists a new credential
+/// set — so it is checked here instead.
+///
+/// `flag` carries `--read-only` when the caller has parsed the global flags.
+/// The early `profiles` parser runs before `Cli` exists and passes `false`;
+/// there the env var and `~/.cx/config.toml` still apply, and `--read-only`
+/// reaches the other call site by being written before the subcommand
+/// (`cx --read-only profiles refresh …`).
+fn enforce_profiles_read_only(cmd: &ProfilesCmd, flag: bool) -> Result<()> {
+    if !matches!(cmd, ProfilesCmd::Refresh { .. }) {
+        return Ok(());
+    }
+    let read_only = flag
+        || safety::env_is_truthy("CX_READ_ONLY")
+        || config::load_config().unwrap_or_default().read_only;
+    if read_only {
+        safety::enforce_read_only("refresh")?;
+    }
+    Ok(())
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Handle shell completions before any stdout output.
@@ -2965,6 +2990,7 @@ async fn main() -> Result<()> {
         let profile_matches = ProfilesCli::command().get_matches();
         let profiles_cli = ProfilesCli::from_arg_matches(&profile_matches)?;
         let ProfilesTopLevel::Profiles { cmd } = profiles_cli.command;
+        enforce_profiles_read_only(&cmd, false)?;
         let result = match cmd {
             ProfilesCmd::List => commands::profiles::run_list(),
             ProfilesCmd::Add {
@@ -3061,6 +3087,7 @@ async fn main() -> Result<()> {
     // but when global flags precede `profiles` (e.g. `cx --read-only profiles list`),
     // it falls through to here.
     if let Commands::Profiles { cmd } = cli.command {
+        enforce_profiles_read_only(&cmd, read_only)?;
         let result = match cmd {
             ProfilesCmd::List => commands::profiles::run_list(),
             ProfilesCmd::Add {

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,7 +124,7 @@ pub enum SearchByValueDataset {
 
 \x1b[1m\x1b[4mLocal:\x1b[0m
   \x1b[1minit\x1b[0m               One-step onboarding: configure a profile and install the agent skills
-  \x1b[1mprofiles\x1b[0m           Manage profiles (list, add, delete, set-default)
+  \x1b[1mprofiles\x1b[0m           Manage profiles (list, add, refresh, delete, set-default)
   \x1b[1mskills\x1b[0m             Install or update the cx agent skills for coding agents
   \x1b[1mcleanup\x1b[0m            Remove stale temp files"
 )]
@@ -193,7 +193,7 @@ struct ProfilesCli {
 
 #[derive(Subcommand)]
 enum ProfilesTopLevel {
-    /// Manage profiles (list, add, delete, set-default).
+    /// Manage profiles (list, add, refresh, delete, set-default).
     Profiles {
         #[command(subcommand)]
         cmd: ProfilesCmd,
@@ -331,7 +331,7 @@ Examples:
         install_completions: Option<Shell>,
     },
 
-    /// Manage profiles (list, add, delete, set-default).
+    /// Manage profiles (list, add, refresh, delete, set-default).
     Profiles {
         #[command(subcommand)]
         cmd: ProfilesCmd,
@@ -801,6 +801,16 @@ Examples:
         /// written. No prompt either way.
         #[arg(long)]
         disable_olly: bool,
+    },
+    /// Re-run the OAuth browser login for an existing profile.
+    ///
+    /// Replaces only the stored OAuth tokens. Region, label, credential
+    /// storage, and output format are left exactly as they are, and nothing
+    /// is prompted for. Use this when a session has expired.
+    Refresh {
+        /// Profile name to re-authenticate.
+        #[arg(add = ArgValueCompleter::new(complete_profile_names))]
+        name: String,
     },
     /// Delete a profile and its stored credentials.
     Delete {
@@ -2981,6 +2991,7 @@ async fn main() -> Result<()> {
                 })
                 .await
             }
+            ProfilesCmd::Refresh { name } => commands::profiles::run_refresh(name).await,
             ProfilesCmd::Delete { name, force } => commands::profiles::run_delete(name, force),
             ProfilesCmd::SetDefault { name } => commands::profiles::run_set_default(name),
         };
@@ -3076,6 +3087,7 @@ async fn main() -> Result<()> {
                 })
                 .await
             }
+            ProfilesCmd::Refresh { name } => commands::profiles::run_refresh(name).await,
             ProfilesCmd::Delete { name, force } => commands::profiles::run_delete(name, force),
             ProfilesCmd::SetDefault { name } => commands::profiles::run_set_default(name),
         };

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -619,7 +619,7 @@ pub async fn resolve_token(
             let t = file_tokens.ok_or_else(|| {
                 anyhow::anyhow!(
                     "OAuth tokens missing for profile '{profile_name}'.\n\
-                     Run `cx profiles add {profile_name}` to re-authenticate."
+                     Run `cx profiles refresh {profile_name}` to re-authenticate."
                 )
             })?;
             (
@@ -639,7 +639,7 @@ pub async fn resolve_token(
     let refresh_token = cached_refresh.ok_or_else(|| {
         anyhow::anyhow!(
             "OAuth session expired for profile '{profile_name}'.\n\
-             Run `cx profiles add {profile_name}` to re-authenticate."
+             Run `cx profiles refresh {profile_name}` to re-authenticate."
         )
     })?;
 
@@ -654,7 +654,7 @@ pub async fn resolve_token(
         .with_context(|| {
             format!(
                 "OAuth token refresh failed for profile '{profile_name}'.\n\
-                 Run `cx profiles add {profile_name}` to re-authenticate."
+                 Run `cx profiles refresh {profile_name}` to re-authenticate."
             )
         })?;
 

--- a/src/oauth.rs
+++ b/src/oauth.rs
@@ -557,26 +557,62 @@ pub fn tokens_to_stored(tokens: &TokenResponse) -> StoredOAuthTokens {
     }
 }
 
+/// Every keyring key [`store_tokens_keyring`] may write.
+///
+/// Named here so [`replace_tokens_keyring`] can clear the previous token set
+/// without touching the API keys that share the same keyring entry.
+const OAUTH_KEYRING_KEYS: &[&str] = &[
+    "oauth_access_token",
+    "oauth_refresh_token",
+    "oauth_id_token",
+    "oauth_token_expiry",
+];
+
+/// The keyring key/value pairs representing `tokens`.
+///
+/// Only the fields the IdP actually returned are included. In particular the
+/// expiry is omitted when the server sends no `expires_in`: `resolve_token`
+/// then falls back to parsing the JWT `exp` claim, whereas a sentinel `0`
+/// would make every cached token look permanently expired.
+fn keyring_entries(tokens: &TokenResponse) -> Vec<(&'static str, String)> {
+    let mut entries = vec![("oauth_access_token", tokens.access_token.clone())];
+    if let Some(ref rt) = tokens.refresh_token {
+        entries.push(("oauth_refresh_token", rt.clone()));
+    }
+    if let Some(ref it) = tokens.id_token {
+        entries.push(("oauth_id_token", it.clone()));
+    }
+    if let Some(exp_in) = tokens.expires_in {
+        entries.push(("oauth_token_expiry", (unix_now_secs() + exp_in).to_string()));
+    }
+    entries
+}
+
+/// Replace the whole OAuth token set for `profile` in the OS keyring.
+///
+/// Where [`store_tokens_keyring`] merges in only the fields the IdP returned -
+/// correct for a silent refresh, which often returns no new refresh token -
+/// this drops the previous `oauth_*` set first, so a stale refresh or id token
+/// cannot outlive a fresh browser login. Use it only after a full re-login.
+///
+/// The clear and the write are one checked keyring operation: a failure leaves
+/// the previous token set intact rather than deleting a working session and
+/// erroring out with nothing to replace it.
+pub fn replace_tokens_keyring(profile: &str, tokens: &TokenResponse) -> Result<()> {
+    keyring_store::replace_secrets(profile, OAUTH_KEYRING_KEYS, &keyring_entries(tokens))
+}
+
 /// Persist an OAuth token set to the OS keyring for `profile`.
 ///
 /// Stores: `oauth_access_token`, `oauth_refresh_token`, `oauth_id_token`,
 /// `oauth_token_expiry` (Unix timestamp, computed from `expires_in`).
+///
+/// Merges rather than replaces: `resolve_token`'s silent refresh calls this and
+/// the IdP commonly returns no new refresh token, so any key the response omits
+/// must keep its existing value. [`replace_tokens_keyring`] is the counterpart
+/// for a full browser re-login, where the old set should not survive.
 pub fn store_tokens_keyring(profile: &str, tokens: &TokenResponse) -> Result<()> {
-    keyring_store::store_secret(profile, "oauth_access_token", &tokens.access_token)?;
-    if let Some(ref rt) = tokens.refresh_token {
-        keyring_store::store_secret(profile, "oauth_refresh_token", rt)?;
-    }
-    if let Some(ref it) = tokens.id_token {
-        keyring_store::store_secret(profile, "oauth_id_token", it)?;
-    }
-    // Only store the expiry timestamp when the server provides `expires_in`.
-    // When absent, `resolve_token` falls back to parsing the JWT `exp` claim directly.
-    // Storing a sentinel `0` would make every cached token appear permanently expired.
-    if let Some(exp_in) = tokens.expires_in {
-        let expiry = unix_now_secs() + exp_in;
-        keyring_store::store_secret(profile, "oauth_token_expiry", &expiry.to_string())?;
-    }
-    Ok(())
+    keyring_store::replace_secrets(profile, &[], &keyring_entries(tokens))
 }
 
 fn cached_token_is_valid(token: &str, expiry: Option<u64>) -> bool {

--- a/src/safety.rs
+++ b/src/safety.rs
@@ -19,6 +19,7 @@ const WRITE_VERBS: &[&str] = &[
     "disable",
     "enable",
     "overwrite",
+    "refresh",
     "remove",
     "reorder",
     "replace",

--- a/tests/profiles/main.rs
+++ b/tests/profiles/main.rs
@@ -247,6 +247,34 @@ fn refresh_leaves_profile_untouched_on_failure() {
     );
 }
 
+// ── re-authentication hint on stderr ─────────────────────────────────────────
+
+#[test]
+fn expired_oauth_profile_is_not_also_told_to_run_profiles_add() {
+    // An OAuth profile with no stored tokens fails in `oauth::resolve_token`
+    // with its own `cx profiles refresh` instruction. The generic
+    // "Run `cx profiles add` to set up credentials." fallback must not be
+    // printed underneath it - two contradictory instructions on one stderr is
+    // what `profiles refresh` exists to fix.
+    let tmp = temp_home();
+    seed_oauth_profile(&tmp, "expired", "region = \"eu2\"\n");
+
+    let output = cx(&tmp)
+        .args(["-p", "expired", "alerts", "list"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cx profiles refresh expired"),
+        "should point at `profiles refresh`, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("cx profiles add"),
+        "should not also suggest `profiles add`, stderr: {stderr}"
+    );
+}
+
 #[test]
 fn refresh_appears_in_profiles_help() {
     let tmp = temp_home();

--- a/tests/profiles/main.rs
+++ b/tests/profiles/main.rs
@@ -148,6 +148,120 @@ fn set_default_already_default_is_noop() {
     );
 }
 
+// ── profiles refresh ─────────────────────────────────────────────────────────
+// The browser handshake itself can't be driven from a test, but every
+// pre-flight branch fails before `browser_login` is reached, so all of them
+// are checked here without opening a browser.
+
+fn seed_oauth_profile(home: &std::path::Path, name: &str, extra: &str) {
+    let profiles_dir = home.join(".cx").join("profiles");
+    fs::create_dir_all(&profiles_dir).unwrap();
+    let profile_toml = format!(
+        "auth = \"o_auth\"\n\
+         credential_storage = \"file\"\n\
+         {extra}"
+    );
+    fs::write(profiles_dir.join(format!("{name}.toml")), profile_toml).unwrap();
+}
+
+#[test]
+fn refresh_nonexistent_profile_fails() {
+    let tmp = temp_home();
+    let output = cx(&tmp)
+        .args(["profiles", "refresh", "ghost"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "should report profile not found, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn refresh_api_key_profile_is_rejected() {
+    let tmp = temp_home();
+    seed_profile(&tmp, "static");
+
+    let output = cx(&tmp)
+        .args(["profiles", "refresh", "static"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("API key authentication"),
+        "should explain that API keys don't expire, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("cx profiles add static"),
+        "should point at `profiles add` to change credentials, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn refresh_custom_region_without_client_id_fails() {
+    let tmp = temp_home();
+    seed_oauth_profile(
+        &tmp,
+        "custom",
+        "region = \"https://api.myenv.coralogix.com\"\n",
+    );
+
+    let output = cx(&tmp)
+        .args(["profiles", "refresh", "custom"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("No OAuth client ID configured"),
+        "should report the missing client ID, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn refresh_leaves_profile_untouched_on_failure() {
+    let tmp = temp_home();
+    let original = "auth = \"o_auth\"\n\
+                    credential_storage = \"file\"\n\
+                    region = \"stg1\"\n\
+                    label = \"staging\"\n\
+                    default_tier = \"frequent\"\n";
+    let profiles_dir = tmp.join(".cx").join("profiles");
+    fs::create_dir_all(&profiles_dir).unwrap();
+    fs::write(profiles_dir.join("staging.toml"), original).unwrap();
+
+    // stg1 has no built-in OAuth client ID, so this fails pre-flight.
+    let output = cx(&tmp)
+        .args(["profiles", "refresh", "staging"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+
+    let after = fs::read_to_string(profiles_dir.join("staging.toml")).unwrap();
+    assert_eq!(
+        after, original,
+        "a failed refresh must not rewrite the profile"
+    );
+}
+
+#[test]
+fn refresh_appears_in_profiles_help() {
+    let tmp = temp_home();
+    let output = cx(&tmp)
+        .args(["profiles", "--help"])
+        .output()
+        .expect("failed to run cx");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("refresh"),
+        "refresh should be listed as a profiles subcommand, got: {stdout}"
+    );
+}
+
 // ── profiles list ────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/profiles/main.rs
+++ b/tests/profiles/main.rs
@@ -247,6 +247,86 @@ fn refresh_leaves_profile_untouched_on_failure() {
     );
 }
 
+// ── profiles refresh under --read-only ───────────────────────────────────────
+// `profiles` is exempt from read-only gating because its subcommands touch
+// local config rather than tenant data. `refresh` is the exception: it runs a
+// browser login and persists a new credential set, so it must be blocked
+// before it opens anything.
+
+#[test]
+fn refresh_is_blocked_by_read_only_env_var() {
+    let tmp = temp_home();
+    seed_oauth_profile(&tmp, "prod", "region = \"eu2\"\n");
+
+    let output = cx(&tmp)
+        .env("CX_READ_ONLY", "1")
+        .args(["profiles", "refresh", "prod"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("read-only mode"),
+        "refresh should be blocked in read-only mode, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn refresh_is_blocked_by_read_only_flag_before_the_subcommand() {
+    // `cx --read-only profiles ...` misses the early `profiles` parser and
+    // falls through to the main `Cli`, so it is a separate code path.
+    let tmp = temp_home();
+    seed_oauth_profile(&tmp, "prod", "region = \"eu2\"\n");
+
+    let output = cx(&tmp)
+        .args(["--read-only", "profiles", "refresh", "prod"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("read-only mode"),
+        "refresh should be blocked by --read-only, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn refresh_is_blocked_by_read_only_in_config() {
+    let tmp = temp_home();
+    seed_config(&tmp, "read_only = true\n");
+    seed_oauth_profile(&tmp, "prod", "region = \"eu2\"\n");
+
+    let output = cx(&tmp)
+        .args(["profiles", "refresh", "prod"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("read-only mode"),
+        "refresh should be blocked by read_only in config.toml, stderr: {stderr}"
+    );
+}
+
+#[test]
+fn read_only_does_not_block_the_rest_of_profiles() {
+    // Guard against the gate widening into the other profiles subcommands,
+    // which stay exempt.
+    let tmp = temp_home();
+    seed_profile(&tmp, "prod");
+
+    let output = cx(&tmp)
+        .env("CX_READ_ONLY", "1")
+        .args(["profiles", "list"])
+        .output()
+        .expect("failed to run cx");
+    assert!(
+        output.status.success(),
+        "profiles list must still work in read-only mode, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
 // ── re-authentication hint on stderr ─────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
This is an entirely claude-authored PR to illustrate a problem and its solution.

Currently, when you try to use a profile whose oauth has expired you get an error:

```
$ cx -p test alerts list | wc -l                                                                                                                                                                                                                                                                                           
Configuration error: OAuth token refresh failed for profile 'test'.                                                                                                                                                                                                                                                        
Run `cx profiles add test` to re-authenticate.                                                                                                                                                                                                                                                                             
Run `cx profiles add` to set up credentials.
Error: OAuth token refresh failed for profile 'test'.
Run `cx profiles add test` to re-authenticate.

Caused by:                                                                    
    Token refresh failed (400 Bad Request): {"error":"invalid_grant","error_description":"The provided authorization grant is invalid."}
       0                  
```

the suggestion is to use `cx profiles add <name>` to refresh, but this actually prompts you to re-enter everything again, hopefully correctly:

```
$ cx profiles add test                                                        
Configuring profile 'test'                                                    

? Authentication method:                                                      
> OAuth (browser login)                                                       
  API key (paste manually)                                                    
[OAuth opens your browser for secure login. API key lets you paste credentials directly (must be a Team Key or Personal Key - not a Send-Your-Data key).
[...]
```

So this PR adds a `cx profiles refresh <name>` which, in the case of an oauth-authing profile, takes the user straight to the browser to reauth:

```
$ ./target/release/cx profiles refresh test                                                                                                                                                                                                                                                                                
Re-authenticating profile 'test' (region: eu2)                                                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                                                                                           
Opening browser for authentication...                                                                                                                                                                                                                                                                                      
Waiting for browser callback...                                                                                                                                                                                                                                                                                            
Authorization code received, exchanging for tokens...                                                                                                                                                                                                                                                                      
Login successful!                                                                                                                                                                                                                                                                                                          
OAuth tokens for 'test' refreshed in profile file.                             
```

Ideally the browser would be coerced into choosing the same team name as last time, too :) 