### PR TITLE
Add cx service-catalog command (CX-52318)

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -16,6 +16,7 @@ Supports Claude Code, Cursor, Codex, OpenCode, and [other supported agents](http
 | `cx-alerts` | Manage Coralogix alert definitions - list, inspect, create, enable/disable via `cx alerts`                                                        |
 | `cx-dashboards` | Build and deploy Coralogix dashboards - telemetry discovery, PromQL/DataPrime verification, JSON generation                                       |
 | `cx-infra` | Explore infrastructure resources - discover monitored resource types, list resources, check per-resource data                                     |
+| `cx-service-catalog` | Query Service Catalog APM entities - services, databases, operations, JVMs, K8s pods; schema, entities, and aggregated/timeseries data          |
 
 ### Workflow
 
@@ -70,6 +71,7 @@ Once installed, your agent uses the relevant skill automatically. Example querie
 - "Why is the checkout page slow for users?"
 - "Debug the 500 errors on the payment endpoint"
 - "Which of our EC2 instances were unhealthy this week?"
+- "Show me the top 5 services by p99 latency in the last hour"
 - "How can we reduce our Coralogix costs?"
 - "Help me triage this case"
 - "Set up parsing rules for our new service"

--- a/skills/cx-service-catalog/SKILL.md
+++ b/skills/cx-service-catalog/SKILL.md
@@ -77,39 +77,50 @@ Four steps, and only because each one supplies an input the next one requires:
    cx service-catalog entities service -o json
    ```
 
-4. **Query data** — aggregated across all entities, or scoped to one:
+4. **Query data** — aggregated across all entities, or scoped to one. Column
+   ids, filter/group-by labels, and entity ids below are placeholders — always
+   substitute values returned by `schema`/`entities` for the entity type in
+   question, they vary by account and entity type:
 
    ```bash
-   cx service-catalog data service --start now-1h --end now \
-     --column latency_p99 --column error_rate -o json
+   cx service-catalog data <entity-type> --start now-1h --end now \
+     --column <column-id> --column <column-id> -o json
 
-   cx service-catalog entity-data service checkout --start now-1h --end now \
-     --column latency_p99 -o json
+   cx service-catalog entity-data <entity-type> <entity-id> --start now-1h --end now \
+     --column <column-id> -o json
    ```
 
 ## Examples
 
-### Top 5 services by p99 latency in the last hour
+The commands below use `service` and `k8s-pod` for concreteness, but every
+`<column-id>`, `<filterable-label>`, `<groupable-label>`, and `<entity-id>`
+must come from that entity type's own `schema`/`entities` output — never
+assume a column or label from one entity type exists on another.
+
+### Top 5 entities by a metric in the last hour
 
 ```bash
+cx service-catalog schema service -o json  # discover column ids first
 cx service-catalog data service --start now-1h --end now \
-  --column latency_p99 --aggregation table \
-  --sort-column latency_p99 --sort-order desc --limit 5 -o json
+  --column <column-id> --aggregation table \
+  --sort-column <column-id> --sort-order desc --limit 5 -o json
 ```
 
-### Filter to one environment
+### Filter to one label value
 
 ```bash
+cx service-catalog schema service -o json  # discover filterable_labels first
 cx service-catalog data service --start now-1h --end now \
-  --column latency_p99 --column error_rate \
-  --filter environment=prod -o json
+  --column <column-id> --column <column-id> \
+  --filter <filterable-label>=<value> -o json
 ```
 
-### Group by environment
+### Group by a label
 
 ```bash
+cx service-catalog schema service -o json  # discover groupable_labels first
 cx service-catalog data service --start now-1h --end now \
-  --column latency_p99 --group-by environment -o json
+  --column <column-id> --group-by <groupable-label> -o json
 ```
 
 ### Kubernetes pod resource saturation
@@ -117,14 +128,15 @@ cx service-catalog data service --start now-1h --end now \
 ```bash
 cx service-catalog schema k8s-pod -o json  # discover column ids first
 cx service-catalog data k8s-pod --start now-1h --end now \
-  --column cpu_usage --column memory_usage --column oom_killed -o json
+  --column <column-id> --column <column-id> --column <column-id> -o json
 ```
 
-### Latency over time for one service
+### Latency over time for one entity
 
 ```bash
-cx service-catalog entity-data service checkout --start now-24h --end now \
-  --column latency_p99 --aggregation timeseries -o json
+cx service-catalog entities service -o json  # discover entity ids first
+cx service-catalog entity-data service <entity-id> --start now-24h --end now \
+  --column <column-id> --aggregation timeseries -o json
 ```
 
 ### Just the rows
@@ -132,7 +144,7 @@ cx service-catalog entity-data service checkout --start now-24h --end now \
 ```bash
 # Table responses live under .rows; timeseries under .series
 cx service-catalog data service --start now-1h --end now \
-  --column error_rate -o json | jq '.rows'
+  --column <column-id> -o json | jq '.rows'
 ```
 
 ## Key Principles

--- a/skills/cx-service-catalog/SKILL.md
+++ b/skills/cx-service-catalog/SKILL.md
@@ -1,0 +1,175 @@
+---
+name: cx-service-catalog
+description: >
+  Query Coralogix's Service Catalog (APM v2 entities) with the `cx service-catalog`
+  CLI — discover entity types, list known entities, check their schema, and pull
+  aggregated or timeseries data for services, databases, operations, JVMs, and
+  Kubernetes pods. Use when the user asks to "list services", "what entity types
+  exist", "show me service latency", "check error rate for a service",
+  "which pods are using the most memory", "database operation performance",
+  "JVM GC pauses", "service health over time", "compare services by latency",
+  "what columns are available for this entity type", "service catalog schema",
+  or wants to explore APM entities and their metrics.
+metadata:
+  version: "0.1.0"
+---
+
+# Service Catalog Skill
+
+Use this skill to discover and query **Service Catalog entities** — services,
+databases, operations, database operations, JVMs, JVM GC, Kubernetes pods, and
+transactions — and their columnar metrics (latency, error rate, health, resource
+usage, etc.) via the v2 Service Catalog API.
+
+## CLI Commands
+
+| Command | Purpose | Key flags |
+|---|---|---|
+| `cx service-catalog entity-types` | List entity types this account has data for | - |
+| `cx service-catalog schema <entity-type>` | Columns/labels schema for one entity type | - |
+| `cx service-catalog entities <entity-type>` | Known entities of one type (e.g. service names) | - |
+| `cx service-catalog data <entity-type>` | Aggregated column data across every entity of a type | `--start`, `--end`, `--column` (required, repeatable); `--group-by`, `--filter`, `--aggregation`, `--limit`, `--sort-column`, `--sort-order` |
+| `cx service-catalog entity-data <entity-type> <entity-id>` | Column data for one named entity (drilldown) | `--start`, `--end`, `--column` (required, repeatable); `--group-by`, `--filter`, `--aggregation` |
+
+- All commands are **read-only** and support `-o json` / `-o agents` for
+  structured output.
+- **Entity type accepts short forms**: `service`, `database`, `operation`,
+  `database-operation`, `jvm`, `jvm-gc`, `k8s-pod`, `transaction` (case-insensitive,
+  hyphens or underscores). The full proto name (`ENTITY_TYPE_K8S_POD`) also works.
+  Unknown values are rejected client-side before any request is made.
+- `--start`/`--end` accept `now`, `now-1h`-style relative expressions, or
+  RFC3339 timestamps.
+- `--column` is **required** and repeatable — discover valid column ids with
+  `cx service-catalog schema <entity-type>` first; the API rejects unknown ones.
+- `--filter label=value1,value2` is repeatable **across distinct labels only**
+  (filters AND together); combine multiple values for the same label with commas
+  rather than repeating the flag — repeating a label is rejected client-side.
+- `--aggregation` is `table` (default behavior when combined with `--limit`/
+  `--sort-column`/`--sort-order`) or `timeseries`. **`--limit`, `--sort-column`,
+  and `--sort-order` only apply to `table`** — the backend silently ignores them
+  for `timeseries`, so the CLI rejects that combination up front rather than
+  sending a request whose flags are quietly dropped.
+- `entity-data` percent-encodes the entity id for you — pass it as returned by
+  `entities` (e.g. `checkout/api`), quoted if it contains `/`.
+
+## Inspection Workflow
+
+Four steps, and only because each one supplies an input the next one requires:
+`entity-types` gives valid `<entity-type>` values, `schema` gives valid
+`--column` ids, `entities` gives the `entity-id` for a drilldown.
+
+1. **Discover what entity types exist** — never guess, they vary by account:
+
+   ```bash
+   cx service-catalog entity-types -o json
+   ```
+
+2. **Check the schema** for one entity type to find valid column ids and
+   filterable/groupable labels:
+
+   ```bash
+   cx service-catalog schema service -o json
+   ```
+
+3. **List known entities** of that type (e.g. service names):
+
+   ```bash
+   cx service-catalog entities service -o json
+   ```
+
+4. **Query data** — aggregated across all entities, or scoped to one:
+
+   ```bash
+   cx service-catalog data service --start now-1h --end now \
+     --column latency_p99 --column error_rate -o json
+
+   cx service-catalog entity-data service checkout --start now-1h --end now \
+     --column latency_p99 -o json
+   ```
+
+## Examples
+
+### Top 5 services by p99 latency in the last hour
+
+```bash
+cx service-catalog data service --start now-1h --end now \
+  --column latency_p99 --aggregation table \
+  --sort-column latency_p99 --sort-order desc --limit 5 -o json
+```
+
+### Filter to one environment
+
+```bash
+cx service-catalog data service --start now-1h --end now \
+  --column latency_p99 --column error_rate \
+  --filter environment=prod -o json
+```
+
+### Group by environment
+
+```bash
+cx service-catalog data service --start now-1h --end now \
+  --column latency_p99 --group-by environment -o json
+```
+
+### Kubernetes pod resource saturation
+
+```bash
+cx service-catalog schema k8s-pod -o json  # discover column ids first
+cx service-catalog data k8s-pod --start now-1h --end now \
+  --column cpu_usage --column memory_usage --column oom_killed -o json
+```
+
+### Latency over time for one service
+
+```bash
+cx service-catalog entity-data service checkout --start now-24h --end now \
+  --column latency_p99 --aggregation timeseries -o json
+```
+
+### Just the rows
+
+```bash
+# Table responses live under .rows; timeseries under .series
+cx service-catalog data service --start now-1h --end now \
+  --column error_rate -o json | jq '.rows'
+```
+
+## Key Principles
+
+- **Discover before querying** — `entity-types` and `schema` are cheap and
+  answer "what's valid here" before spending a `data`/`entity-data` call on a
+  guess.
+- **`--column` values are per-entity-type** — a column valid for `service` may
+  not exist for `k8s-pod`; always re-check `schema` when switching entity types.
+- **Malformed responses are errors, not silent empty results** — a column that
+  is neither a value nor an error (or both) fails loudly rather than producing
+  a partial or empty row, so a non-zero exit means investigate, not "no data".
+- **A column-level error is not a command failure** — an individual column can
+  come back as `{"error": "..."}` inside an otherwise successful row (e.g. a
+  query timeout for just that column); check per-column before assuming the
+  whole request failed.
+- **`table` vs `timeseries` are mutually exclusive result shapes** — `table`
+  responses are flat rows suitable for `-o json | jq '.rows'`; `timeseries`
+  responses nest datapoints per series and are best consumed as raw JSON rather
+  than forced into a table.
+- **Use `-o json` with `jq`** for filtering; use `-o agents` for token-efficient
+  output in agent contexts.
+- **Multi-profile fan-out** works on every subcommand — repeat `-p <profile>` to
+  compare the same entity type/data across accounts; rows and series are tagged
+  with `profile` when more than one is given.
+
+## Related Skills
+
+- **`cx-infra`** — infrastructure resource health (hosts, containers) is a
+  distinct concept from Service Catalog entity health; use `cx-infra` for
+  host/instance-level monitoring and this skill for application/service-level
+  APM entities.
+- **`cx-telemetry-querying`** — once a service or pod name surfaces from this
+  skill's commands, pivot to raw telemetry: `cx logs "filter $l.subsystemname ==
+  '<service>'"` or `cx search-fields "<name>" -s value` to find related log/span
+  fields. Correlate a latency or error spike with the underlying logs/spans.
+- **`cx-alerts`** — `cx alerts list --name "<service-name>"` finds alert
+  definitions matching a service surfaced by this skill.
+- **`cx-dashboards`** — `cx dashboards search "<service-name> ..."` finds
+  dashboards built around a service found here.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -35,6 +35,7 @@ pub mod schema;
 pub mod scopes;
 pub mod search_by_value;
 pub mod search_fields;
+pub mod service_catalog;
 pub mod slos;
 pub mod spans;
 pub mod suppression_rules;

--- a/src/commands/service_catalog/api.rs
+++ b/src/commands/service_catalog/api.rs
@@ -1,0 +1,565 @@
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Result as AnyResult};
+use percent_encoding::{utf8_percent_encode, AsciiSet, NON_ALPHANUMERIC};
+use serde::Deserialize;
+use serde_json::{json, Value};
+
+use crate::api_client::CxClient;
+use crate::error::Result;
+
+const BASE_PATH: &str = "/v2/entities";
+
+/// Full proto enum names accepted by the service-catalog v2 HTTP API, in the
+/// same order as `com.coralogix.catalog.v2.EntityType`. `ENTITY_TYPE_UNSPECIFIED`
+/// is deliberately excluded - it is a protobuf zero-value, never a meaningful
+/// entity type to query.
+const VALID_ENTITY_TYPES: &[&str] = &[
+    "ENTITY_TYPE_TRANSACTION",
+    "ENTITY_TYPE_SERVICE",
+    "ENTITY_TYPE_DATABASE",
+    "ENTITY_TYPE_OPERATION",
+    "ENTITY_TYPE_DATABASE_OPERATION",
+    "ENTITY_TYPE_JVM",
+    "ENTITY_TYPE_JVM_GC",
+    "ENTITY_TYPE_K8S_POD",
+];
+
+/// Normalizes a user-supplied entity type into the full proto enum name the v2
+/// HTTP API's path segment accepts - e.g. `service`, `K8S_POD`, or
+/// `ENTITY_TYPE_K8S_POD` all become `ENTITY_TYPE_K8S_POD`. The backend rejects
+/// anything else (including the short forms), so this must run before the id
+/// ever reaches a URL.
+pub fn normalize_entity_type(input: &str) -> AnyResult<String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        bail!("entity type must not be empty");
+    }
+    let upper = trimmed.to_uppercase().replace('-', "_");
+    let name = if upper.starts_with("ENTITY_TYPE_") {
+        upper
+    } else {
+        format!("ENTITY_TYPE_{upper}")
+    };
+    if !VALID_ENTITY_TYPES.contains(&name.as_str()) {
+        bail!(
+            "unknown entity type '{input}'; supported: service, database, operation, \
+             database-operation, jvm, jvm-gc, k8s-pod, transaction"
+        );
+    }
+    Ok(name)
+}
+
+/// Entity ids travel as a URL path segment and are otherwise free-form
+/// (service/pod names), so percent-encode everything except RFC 3986
+/// unreserved characters - mirrors `infra::api::encode_resource_id`.
+const PATH_SEGMENT_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'~');
+
+pub fn encode_entity_id(entity_id: &str) -> String {
+    utf8_percent_encode(entity_id, PATH_SEGMENT_ENCODE_SET).to_string()
+}
+
+// ── Response types ─────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityTypeInfo {
+    #[serde(rename = "type")]
+    pub entity_type: Option<String>,
+    pub id: Option<String>,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ListEntityTypesResponse {
+    #[serde(default)]
+    pub entity_types: Vec<EntityTypeInfo>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ColumnMetadata {
+    pub id: Option<String>,
+    pub display_name: Option<String>,
+    pub unit: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityTypeMetadata {
+    pub entity_id: Option<String>,
+    pub display_name: Option<String>,
+    pub description: Option<String>,
+    #[serde(default)]
+    pub columns: Vec<ColumnMetadata>,
+    #[serde(default)]
+    pub default_columns: Vec<String>,
+    #[serde(default)]
+    pub groupable_labels: Vec<String>,
+    pub group_by_limit: Option<i32>,
+    #[serde(default)]
+    pub default_group_by: Vec<String>,
+    #[serde(default)]
+    pub filterable_labels: Vec<String>,
+    #[serde(default)]
+    pub required_filters: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnvironmentActivity {
+    pub name: Option<String>,
+    pub last_seen: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityItem {
+    pub name: Option<String>,
+    pub system: Option<String>,
+    pub last_seen: Option<String>,
+    #[serde(default)]
+    pub deployments: Vec<String>,
+    #[serde(default)]
+    pub environments: Vec<EnvironmentActivity>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ListEntitiesResponse {
+    #[serde(default)]
+    pub entities: Vec<EntityItem>,
+}
+
+/// Raw `EntitiesDataResult` - a protobuf `oneof` of `table` or `timeseries`.
+/// `values`/`series` are kept as raw JSON: `ColumnValue` is itself a `oneof`
+/// with a dozen possible shapes, so flattening happens in `mod.rs` rather than
+/// through a fully-typed struct here (mirrors the shared Python implementation
+/// in `cx-olly`'s `libs/common/src/common/tools/service_catalog_tools.py`).
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct EntitiesDataResult {
+    pub table: Option<TableData>,
+    pub timeseries: Option<TimeseriesData>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TableData {
+    #[serde(default)]
+    pub rows: Vec<TableRow>,
+    #[serde(default)]
+    pub columns: Vec<ColumnMetadata>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+pub struct TableRow {
+    #[serde(default)]
+    pub identity: BTreeMap<String, String>,
+    /// Column id -> raw `ColumnResult` JSON (`{"value": ColumnValue}` or
+    /// `{"error": ColumnError}`).
+    #[serde(default)]
+    pub values: BTreeMap<String, Value>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TimeseriesData {
+    #[serde(default)]
+    pub series: Vec<Value>,
+    #[serde(default)]
+    pub columns: Vec<ColumnMetadata>,
+    #[serde(default)]
+    pub total_series_count: i32,
+}
+
+// ── Request body ────────────────────────────────────────────────────────────────
+
+/// One `ApmFilter`: a label name plus the values it must match. `metric_label_name`
+/// (for labels that live under a different name in the metric series) is not
+/// exposed by the CLI - it is a niche field with no natural flag, and every
+/// other product surface treats it as optional.
+#[derive(Debug)]
+pub struct ApmFilterInput {
+    pub label_name: String,
+    pub label_values: Vec<String>,
+}
+
+/// Parameters for [`ServiceCatalogApi::entities_data`] / [`ServiceCatalogApi::entity_data`].
+///
+/// `limit` / `sort_column` / `sort_order` only apply to `entities_data` (TABLE
+/// aggregation) - callers building an entity-data request simply leave them `None`.
+pub struct DataParams<'p> {
+    pub start: i64,
+    pub end: i64,
+    pub columns: &'p [String],
+    pub group_by: &'p [String],
+    pub filters: &'p [ApmFilterInput],
+    /// Full proto enum name, e.g. `DATA_AGGREGATION_TYPE_TABLE`.
+    pub data_aggregation_type: &'p str,
+    pub limit: Option<i32>,
+    pub sort_column: Option<&'p str>,
+    /// Full proto enum name, e.g. `SORT_ORDER_ASCENDING`.
+    pub sort_order: Option<&'p str>,
+}
+
+/// Builds the JSON body shared by `GetEntitiesDataRequest` / `GetEntityDataRequest`.
+///
+/// `entityType` (and `entityId` for the single-entity endpoint) are deliberately
+/// omitted: the HTTP route overrides both from the URL path regardless of what
+/// the body carries, so sending them would be dead weight.
+fn build_data_body(params: &DataParams<'_>) -> Value {
+    let mut body = json!({
+        "timeRange": { "start": params.start, "end": params.end },
+        "dataAggregationType": params.data_aggregation_type,
+        "columns": params.columns.iter().map(|c| json!({ "columnId": c })).collect::<Vec<_>>(),
+        "groupBy": params.group_by,
+        "filters": params.filters.iter().map(|f| json!({
+            "labelName": f.label_name,
+            "labelValues": f.label_values,
+        })).collect::<Vec<_>>(),
+    });
+    let obj = body.as_object_mut().expect("body is always an object");
+    if let Some(limit) = params.limit {
+        obj.insert("limit".to_string(), json!(limit));
+    }
+    if let Some(sort_column) = params.sort_column {
+        obj.insert("sortColumn".to_string(), json!(sort_column));
+    }
+    if let Some(sort_order) = params.sort_order {
+        obj.insert("sortOrder".to_string(), json!(sort_order));
+    }
+    body
+}
+
+// ── API client ───────────────────────────────────────────────────────────────────
+
+pub struct ServiceCatalogApi<'a> {
+    client: &'a CxClient,
+}
+
+impl<'a> ServiceCatalogApi<'a> {
+    pub fn new(client: &'a CxClient) -> Self {
+        Self { client }
+    }
+
+    /// `ListEntityTypes` - the entity types this account has service-catalog data for.
+    pub async fn list_entity_types(&self) -> Result<ListEntityTypesResponse> {
+        self.client.get(BASE_PATH, &[]).await
+    }
+
+    /// `GetEntityTypeMetadata` - the columns/labels schema for one entity type.
+    /// `entity_type` must already be normalized (see [`normalize_entity_type`]).
+    pub async fn entity_type_schema(&self, entity_type: &str) -> Result<EntityTypeMetadata> {
+        let path = format!("{BASE_PATH}/{entity_type}/metadata");
+        self.client.get(&path, &[]).await
+    }
+
+    /// `ListEntities` - the known entities (e.g. service names) of one entity type.
+    /// `entity_type` must already be normalized.
+    pub async fn list_entities(&self, entity_type: &str) -> Result<ListEntitiesResponse> {
+        let path = format!("{BASE_PATH}/{entity_type}");
+        self.client.get(&path, &[]).await
+    }
+
+    /// `GetEntitiesData` - column data across every entity of one type.
+    /// `entity_type` must already be normalized.
+    pub async fn entities_data(
+        &self,
+        entity_type: &str,
+        params: &DataParams<'_>,
+    ) -> Result<EntitiesDataResult> {
+        let path = format!("{BASE_PATH}/{entity_type}/data");
+        self.client.post(&path, &build_data_body(params)).await
+    }
+
+    /// `GetEntityData` - column data for exactly one named entity (drilldown).
+    /// `entity_type` must already be normalized; `entity_id` is percent-encoded here.
+    pub async fn entity_data(
+        &self,
+        entity_type: &str,
+        entity_id: &str,
+        params: &DataParams<'_>,
+    ) -> Result<EntitiesDataResult> {
+        let path = format!(
+            "{BASE_PATH}/{entity_type}/data/entity/{}",
+            encode_entity_id(entity_id)
+        );
+        self.client.post(&path, &build_data_body(params)).await
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ── normalize_entity_type ────────────────────────────────────────────────
+
+    #[test]
+    fn normalize_entity_type_accepts_short_lowercase_form() {
+        assert_eq!(
+            normalize_entity_type("service").unwrap(),
+            "ENTITY_TYPE_SERVICE"
+        );
+    }
+
+    #[test]
+    fn normalize_entity_type_accepts_hyphenated_short_form() {
+        assert_eq!(
+            normalize_entity_type("k8s-pod").unwrap(),
+            "ENTITY_TYPE_K8S_POD"
+        );
+        assert_eq!(
+            normalize_entity_type("database-operation").unwrap(),
+            "ENTITY_TYPE_DATABASE_OPERATION"
+        );
+    }
+
+    #[test]
+    fn normalize_entity_type_accepts_full_proto_name_any_case() {
+        assert_eq!(
+            normalize_entity_type("ENTITY_TYPE_JVM").unwrap(),
+            "ENTITY_TYPE_JVM"
+        );
+        assert_eq!(
+            normalize_entity_type("entity_type_jvm").unwrap(),
+            "ENTITY_TYPE_JVM"
+        );
+    }
+
+    #[test]
+    fn normalize_entity_type_trims_whitespace() {
+        assert_eq!(
+            normalize_entity_type("  service  ").unwrap(),
+            "ENTITY_TYPE_SERVICE"
+        );
+    }
+
+    #[test]
+    fn normalize_entity_type_rejects_empty() {
+        let err = normalize_entity_type("  ").unwrap_err();
+        assert!(err.to_string().contains("must not be empty"));
+    }
+
+    #[test]
+    fn normalize_entity_type_rejects_unknown_type() {
+        let err = normalize_entity_type("pod").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown entity type 'pod'"), "got: {msg}");
+        assert!(msg.contains("k8s-pod"), "got: {msg}");
+    }
+
+    /// `UNSPECIFIED` is a protobuf zero-value, not a real entity type - never
+    /// something a query should be able to ask for.
+    #[test]
+    fn normalize_entity_type_rejects_unspecified() {
+        assert!(normalize_entity_type("unspecified").is_err());
+        assert!(normalize_entity_type("ENTITY_TYPE_UNSPECIFIED").is_err());
+    }
+
+    #[test]
+    fn encode_entity_id_escapes_reserved_characters() {
+        assert_eq!(encode_entity_id("checkout/api"), "checkout%2Fapi");
+        assert_eq!(encode_entity_id("plain-name_1.2~3"), "plain-name_1.2~3");
+    }
+
+    // ── Response deserialization ─────────────────────────────────────────────
+
+    #[test]
+    fn deserialize_list_entity_types_response() {
+        let json = json!({
+            "entityTypes": [
+                {
+                    "type": "ENTITY_TYPE_SERVICE",
+                    "id": "service",
+                    "displayName": "Service",
+                    "description": "APM services"
+                }
+            ]
+        });
+        let resp: ListEntityTypesResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.entity_types.len(), 1);
+        assert_eq!(
+            resp.entity_types[0].entity_type.as_deref(),
+            Some("ENTITY_TYPE_SERVICE")
+        );
+        assert_eq!(resp.entity_types[0].id.as_deref(), Some("service"));
+    }
+
+    #[test]
+    fn deserialize_empty_list_entity_types_response() {
+        let resp: ListEntityTypesResponse = serde_json::from_value(json!({})).unwrap();
+        assert!(resp.entity_types.is_empty());
+    }
+
+    #[test]
+    fn deserialize_entity_type_metadata() {
+        let json = json!({
+            "entityId": "service",
+            "displayName": "Service",
+            "description": "APM services",
+            "columns": [{ "id": "latency_p99", "displayName": "P99 Latency", "unit": "UNIT_MILLISECONDS" }],
+            "defaultColumns": ["latency_p99"],
+            "groupableLabels": ["environment"],
+            "groupByLimit": 3,
+            "defaultGroupBy": [],
+            "filterableLabels": ["environment"],
+            "requiredFilters": []
+        });
+        let resp: EntityTypeMetadata = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.entity_id.as_deref(), Some("service"));
+        assert_eq!(resp.columns.len(), 1);
+        assert_eq!(resp.columns[0].id.as_deref(), Some("latency_p99"));
+        assert_eq!(resp.group_by_limit, Some(3));
+    }
+
+    #[test]
+    fn deserialize_empty_entity_type_metadata() {
+        let resp: EntityTypeMetadata = serde_json::from_value(json!({})).unwrap();
+        assert!(resp.columns.is_empty());
+        assert!(resp.group_by_limit.is_none());
+    }
+
+    #[test]
+    fn deserialize_list_entities_response() {
+        let json = json!({
+            "entities": [
+                {
+                    "name": "checkout",
+                    "system": "kubernetes",
+                    "lastSeen": "2026-07-01T00:00:00Z",
+                    "deployments": ["checkout-v1"],
+                    "environments": [{ "name": "prod", "lastSeen": "2026-07-01T00:00:00Z" }]
+                }
+            ]
+        });
+        let resp: ListEntitiesResponse = serde_json::from_value(json).unwrap();
+        assert_eq!(resp.entities.len(), 1);
+        assert_eq!(resp.entities[0].name.as_deref(), Some("checkout"));
+        assert_eq!(resp.entities[0].environments.len(), 1);
+        assert_eq!(
+            resp.entities[0].environments[0].name.as_deref(),
+            Some("prod")
+        );
+    }
+
+    #[test]
+    fn deserialize_empty_list_entities_response() {
+        let resp: ListEntitiesResponse = serde_json::from_value(json!({})).unwrap();
+        assert!(resp.entities.is_empty());
+    }
+
+    #[test]
+    fn deserialize_entities_data_result_table() {
+        let json = json!({
+            "table": {
+                "rows": [
+                    {
+                        "identity": { "name": "checkout" },
+                        "values": { "latency_p99": { "value": { "metric": 42.5 } } }
+                    }
+                ],
+                "columns": [{ "id": "latency_p99" }]
+            }
+        });
+        let resp: EntitiesDataResult = serde_json::from_value(json).unwrap();
+        let table = resp.table.expect("table should be present");
+        assert_eq!(table.rows.len(), 1);
+        assert_eq!(table.rows[0].identity.get("name").unwrap(), "checkout");
+        assert!(resp.timeseries.is_none());
+    }
+
+    #[test]
+    fn deserialize_entities_data_result_timeseries() {
+        let json = json!({
+            "timeseries": {
+                "series": [{ "columnId": "latency_p99", "datapoints": [] }],
+                "columns": [{ "id": "latency_p99" }],
+                "totalSeriesCount": 1
+            }
+        });
+        let resp: EntitiesDataResult = serde_json::from_value(json).unwrap();
+        let timeseries = resp.timeseries.expect("timeseries should be present");
+        assert_eq!(timeseries.series.len(), 1);
+        assert_eq!(timeseries.total_series_count, 1);
+        assert!(resp.table.is_none());
+    }
+
+    #[test]
+    fn deserialize_empty_entities_data_result() {
+        let resp: EntitiesDataResult = serde_json::from_value(json!({})).unwrap();
+        assert!(resp.table.is_none());
+        assert!(resp.timeseries.is_none());
+    }
+
+    // ── build_data_body ───────────────────────────────────────────────────────
+
+    #[test]
+    fn build_data_body_includes_required_fields_only_by_default() {
+        let filters = vec![];
+        let columns = vec!["latency_p99".to_string()];
+        let group_by = vec![];
+        let params = DataParams {
+            start: 1000,
+            end: 2000,
+            columns: &columns,
+            group_by: &group_by,
+            filters: &filters,
+            data_aggregation_type: "DATA_AGGREGATION_TYPE_TABLE",
+            limit: None,
+            sort_column: None,
+            sort_order: None,
+        };
+        let body = build_data_body(&params);
+        assert_eq!(body["timeRange"]["start"], 1000);
+        assert_eq!(body["timeRange"]["end"], 2000);
+        assert_eq!(body["dataAggregationType"], "DATA_AGGREGATION_TYPE_TABLE");
+        assert_eq!(body["columns"], json!([{ "columnId": "latency_p99" }]));
+        assert!(body.get("limit").is_none());
+        assert!(body.get("sortColumn").is_none());
+        assert!(body.get("sortOrder").is_none());
+        assert!(
+            body.get("entityType").is_none(),
+            "entityType travels in the URL path, not the body"
+        );
+    }
+
+    #[test]
+    fn build_data_body_includes_table_controls_when_set() {
+        let filters = vec![ApmFilterInput {
+            label_name: "environment".to_string(),
+            label_values: vec!["prod".to_string(), "staging".to_string()],
+        }];
+        let columns = vec!["latency_p99".to_string()];
+        let group_by = vec!["environment".to_string()];
+        let params = DataParams {
+            start: 1000,
+            end: 2000,
+            columns: &columns,
+            group_by: &group_by,
+            filters: &filters,
+            data_aggregation_type: "DATA_AGGREGATION_TYPE_TABLE",
+            limit: Some(10),
+            sort_column: Some("latency_p99"),
+            sort_order: Some("SORT_ORDER_DESCENDING"),
+        };
+        let body = build_data_body(&params);
+        assert_eq!(body["limit"], 10);
+        assert_eq!(body["sortColumn"], "latency_p99");
+        assert_eq!(body["sortOrder"], "SORT_ORDER_DESCENDING");
+        assert_eq!(body["groupBy"], json!(["environment"]));
+        assert_eq!(
+            body["filters"],
+            json!([{ "labelName": "environment", "labelValues": ["prod", "staging"] }])
+        );
+    }
+}

--- a/src/commands/service_catalog/mod.rs
+++ b/src/commands/service_catalog/mod.rs
@@ -557,15 +557,23 @@ fn format_entities_data_response(result: EntitiesDataResult) -> Result<Value> {
 /// same convention as `resource_to_json`); timeseries responses merge series.
 /// Columns are taken from the first successful profile - callers request the
 /// same `--column` set per profile, so they are expected to match.
+///
+/// Formatting (not just the HTTP call) can fail per profile - a malformed
+/// `ColumnResult` in just one profile's payload must not discard another
+/// profile's perfectly good rows, so formatting failures are routed through
+/// the same `report_errors_and_collect_successes` semantics as the HTTP
+/// fan-out: total failure bails, partial failure prints the bad profile and
+/// renders the survivors.
 fn render_entities_data_results(
     results: Vec<(String, EntitiesDataResult)>,
     include_profile: bool,
     output: OutputFormat,
 ) -> Result<()> {
-    let mut formatted: Vec<(String, Value)> = Vec::new();
-    for (profile, result) in results {
-        formatted.push((profile, format_entities_data_response(result)?));
-    }
+    let per_profile_formatted: Vec<(String, Result<Value>)> = results
+        .into_iter()
+        .map(|(profile, result)| (profile, format_entities_data_response(result)))
+        .collect();
+    let formatted = report_errors_and_collect_successes(per_profile_formatted)?;
 
     let is_timeseries = formatted
         .first()

--- a/src/commands/service_catalog/mod.rs
+++ b/src/commands/service_catalog/mod.rs
@@ -1,0 +1,1070 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, bail, Result};
+use colored::Colorize;
+use serde_json::{json, Value};
+use toon_format::encode_default as toon_encode;
+
+pub mod api;
+
+use api::{
+    normalize_entity_type, ApmFilterInput, ColumnMetadata, DataParams, EntitiesDataResult,
+    EntityItem, EntityTypeInfo, EntityTypeMetadata, ServiceCatalogApi, TableRow,
+};
+
+use crate::config::OutputFormat;
+use crate::execution::{fan_out, report_errors_and_collect_successes, ExecutionTarget};
+use crate::render;
+
+// ── Subcommand runners ────────────────────────────────────────────────────────
+
+/// `cx service-catalog entity-types` - the entity types this account has data for.
+pub async fn run_entity_types(
+    targets: &[Arc<ExecutionTarget>],
+    output: OutputFormat,
+) -> Result<()> {
+    eprintln!("{}", "Fetching entity types...".dimmed());
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |target| async move {
+        let api = ServiceCatalogApi::new(&target.client);
+        Ok(api.list_entity_types().await?)
+    })
+    .await;
+
+    let mut merged: Vec<(String, EntityTypeInfo)> = Vec::new();
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
+        for item in resp.entity_types {
+            merged.push((profile.clone(), item));
+        }
+    }
+
+    match output {
+        OutputFormat::Json | OutputFormat::Agents => {
+            let rows: Vec<Value> = merged
+                .iter()
+                .map(|(profile, item)| entity_type_info_to_json(item, include_profile, profile))
+                .collect();
+            render_machine_rows(output, &rows)?;
+        }
+        OutputFormat::Text => {
+            if merged.is_empty() {
+                render::print_no_results("No entity types found.");
+                return Ok(());
+            }
+            let rows: Vec<Vec<String>> = merged
+                .iter()
+                .map(|(profile, item)| {
+                    vec![
+                        profile.clone(),
+                        display_or_dash(item.entity_type.as_deref()),
+                        display_or_dash(item.id.as_deref()),
+                        display_or_dash(item.display_name.as_deref()),
+                    ]
+                })
+                .collect();
+            render::render_table(
+                &["Entity Type", "ID", "Display Name"],
+                rows,
+                include_profile,
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// `cx service-catalog schema <entity-type>` - columns/labels schema for one entity type.
+pub async fn run_schema(
+    targets: &[Arc<ExecutionTarget>],
+    entity_type: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let normalized = normalize_entity_type(entity_type)?;
+
+    eprintln!(
+        "{}",
+        format!("Fetching schema for entity type '{entity_type}'...").dimmed()
+    );
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |target| {
+        let normalized = normalized.clone();
+        async move {
+            let api = ServiceCatalogApi::new(&target.client);
+            Ok(api.entity_type_schema(&normalized).await?)
+        }
+    })
+    .await;
+
+    let mut results: Vec<Value> = Vec::new();
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
+        let mut val = entity_type_metadata_to_json(&resp);
+        if include_profile {
+            render::tag_get_result(&mut val, &profile);
+        }
+        results.push(val);
+    }
+
+    match output {
+        OutputFormat::Json => render::render_json_auto(&results)?,
+        OutputFormat::Agents => render::render_agents(&results)?,
+        OutputFormat::Text => {
+            render::render_get_text(
+                &results,
+                include_profile,
+                "No schema found.",
+                Some(&|val| {
+                    println!(
+                        "{}: {}",
+                        "Display Name".bold(),
+                        val.get("display_name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("-")
+                    );
+                    println!(
+                        "{}: {}",
+                        "Description".bold(),
+                        val.get("description")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("-")
+                    );
+                    println!(
+                        "{}: {}",
+                        "Group By Limit".bold(),
+                        val.get("group_by_limit")
+                            .and_then(|v| v.as_i64())
+                            .map(|n| n.to_string())
+                            .unwrap_or_else(|| "-".to_string())
+                    );
+                }),
+            )?;
+        }
+    }
+
+    Ok(())
+}
+
+/// `cx service-catalog entities <entity-type>` - known entities of one entity type.
+pub async fn run_entities(
+    targets: &[Arc<ExecutionTarget>],
+    entity_type: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let normalized = normalize_entity_type(entity_type)?;
+
+    eprintln!(
+        "{}",
+        format!("Fetching entities of type '{entity_type}'...").dimmed()
+    );
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |target| {
+        let normalized = normalized.clone();
+        async move {
+            let api = ServiceCatalogApi::new(&target.client);
+            Ok(api.list_entities(&normalized).await?)
+        }
+    })
+    .await;
+
+    let mut merged: Vec<(String, EntityItem)> = Vec::new();
+    for (profile, resp) in report_errors_and_collect_successes(per_profile)? {
+        for item in resp.entities {
+            merged.push((profile.clone(), item));
+        }
+    }
+
+    match output {
+        OutputFormat::Json | OutputFormat::Agents => {
+            let rows: Vec<Value> = merged
+                .iter()
+                .map(|(profile, item)| entity_item_to_json(item, include_profile, profile))
+                .collect();
+            render_machine_rows(output, &rows)?;
+        }
+        OutputFormat::Text => {
+            if merged.is_empty() {
+                render::print_no_results("No entities found.");
+                return Ok(());
+            }
+            let rows: Vec<Vec<String>> = merged
+                .iter()
+                .map(|(profile, item)| {
+                    vec![
+                        profile.clone(),
+                        display_or_dash(item.name.as_deref()),
+                        display_or_dash(item.system.as_deref()),
+                        display_or_dash(item.last_seen.as_deref()),
+                    ]
+                })
+                .collect();
+            render::render_table(&["Name", "System", "Last Seen"], rows, include_profile);
+        }
+    }
+
+    Ok(())
+}
+
+/// `cx service-catalog data <entity-type>` - column data across every entity of one type.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_data(
+    targets: &[Arc<ExecutionTarget>],
+    entity_type: &str,
+    start: &str,
+    end: &str,
+    columns: &[String],
+    group_by: &[String],
+    filters: &[String],
+    aggregation: &str,
+    limit: Option<i32>,
+    sort_column: Option<&str>,
+    sort_order: Option<&str>,
+    output: OutputFormat,
+) -> Result<()> {
+    let normalized_entity_type = normalize_entity_type(entity_type)?;
+    let (start_epoch, end_epoch) = parse_time_range(start, end)?;
+    let validated_columns = validate_columns(columns)?;
+    let validated_group_by = validate_group_by(group_by)?;
+    let validated_filters = parse_filters(filters)?;
+    let aggregation_enum = parse_aggregation(aggregation)?;
+    validate_table_controls_scope(aggregation_enum, limit, sort_column, sort_order)?;
+    let sort_order_enum = sort_order.map(parse_sort_order).transpose()?;
+
+    eprintln!(
+        "{}",
+        format!("Fetching entities data for '{entity_type}'...").dimmed()
+    );
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |target| {
+        let normalized_entity_type = normalized_entity_type.clone();
+        let validated_columns = validated_columns.clone();
+        let validated_group_by = validated_group_by.clone();
+        let validated_filters = clone_filters(&validated_filters);
+        async move {
+            let api = ServiceCatalogApi::new(&target.client);
+            let params = DataParams {
+                start: start_epoch,
+                end: end_epoch,
+                columns: &validated_columns,
+                group_by: &validated_group_by,
+                filters: &validated_filters,
+                data_aggregation_type: aggregation_enum,
+                limit,
+                sort_column,
+                sort_order: sort_order_enum,
+            };
+            Ok(api.entities_data(&normalized_entity_type, &params).await?)
+        }
+    })
+    .await;
+
+    let results = report_errors_and_collect_successes(per_profile)?;
+    render_entities_data_results(results, include_profile, output)
+}
+
+/// `cx service-catalog entity-data <entity-type> <entity-id>` - column data for one entity.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_entity_data(
+    targets: &[Arc<ExecutionTarget>],
+    entity_type: &str,
+    entity_id: &str,
+    start: &str,
+    end: &str,
+    columns: &[String],
+    group_by: &[String],
+    filters: &[String],
+    aggregation: &str,
+    output: OutputFormat,
+) -> Result<()> {
+    let normalized_entity_type = normalize_entity_type(entity_type)?;
+    let entity_id = require_non_empty(entity_id, "entity id")?.to_string();
+    let (start_epoch, end_epoch) = parse_time_range(start, end)?;
+    let validated_columns = validate_columns(columns)?;
+    let validated_group_by = validate_group_by(group_by)?;
+    let validated_filters = parse_filters(filters)?;
+    let aggregation_enum = parse_aggregation(aggregation)?;
+
+    eprintln!(
+        "{}",
+        format!("Fetching entity data for '{entity_id}' ({entity_type})...").dimmed()
+    );
+
+    let include_profile = targets.len() > 1;
+
+    let per_profile = fan_out(targets, |target| {
+        let normalized_entity_type = normalized_entity_type.clone();
+        let entity_id = entity_id.clone();
+        let validated_columns = validated_columns.clone();
+        let validated_group_by = validated_group_by.clone();
+        let validated_filters = clone_filters(&validated_filters);
+        async move {
+            let api = ServiceCatalogApi::new(&target.client);
+            let params = DataParams {
+                start: start_epoch,
+                end: end_epoch,
+                columns: &validated_columns,
+                group_by: &validated_group_by,
+                filters: &validated_filters,
+                data_aggregation_type: aggregation_enum,
+                limit: None,
+                sort_column: None,
+                sort_order: None,
+            };
+            Ok(api
+                .entity_data(&normalized_entity_type, &entity_id, &params)
+                .await?)
+        }
+    })
+    .await;
+
+    let results = report_errors_and_collect_successes(per_profile)?;
+    render_entities_data_results(results, include_profile, output)
+}
+
+// ── Entity type / aggregation / sort-order enum mapping ─────────────────────────
+
+const DATA_AGGREGATION_TABLE: &str = "DATA_AGGREGATION_TYPE_TABLE";
+const DATA_AGGREGATION_TIMESERIES: &str = "DATA_AGGREGATION_TYPE_TIMESERIES";
+const SORT_ORDER_ASC: &str = "SORT_ORDER_ASCENDING";
+const SORT_ORDER_DESC: &str = "SORT_ORDER_DESCENDING";
+
+fn parse_aggregation(aggregation: &str) -> Result<&'static str> {
+    match aggregation.trim().to_lowercase().as_str() {
+        "table" => Ok(DATA_AGGREGATION_TABLE),
+        "timeseries" => Ok(DATA_AGGREGATION_TIMESERIES),
+        other => bail!("unknown --aggregation '{other}'; allowed: table, timeseries"),
+    }
+}
+
+fn parse_sort_order(sort_order: &str) -> Result<&'static str> {
+    match sort_order.trim().to_lowercase().as_str() {
+        "asc" => Ok(SORT_ORDER_ASC),
+        "desc" => Ok(SORT_ORDER_DESC),
+        other => bail!("unknown --sort-order '{other}'; allowed: asc, desc"),
+    }
+}
+
+/// `--limit`/`--sort-column`/`--sort-order` are TABLE-only: the backend silently
+/// ignores them for TIMESERIES (CX-52920), so the CLI rejects the combination
+/// up front rather than sending a request whose flags are quietly dropped.
+fn validate_table_controls_scope(
+    aggregation: &str,
+    limit: Option<i32>,
+    sort_column: Option<&str>,
+    sort_order: Option<&str>,
+) -> Result<()> {
+    if aggregation == DATA_AGGREGATION_TIMESERIES
+        && (limit.is_some() || sort_column.is_some() || sort_order.is_some())
+    {
+        bail!(
+            "--limit, --sort-column, and --sort-order only apply to --aggregation table; \
+             the backend ignores them for timeseries, so they must be omitted rather than \
+             silently dropped"
+        );
+    }
+    Ok(())
+}
+
+// ── Validation helpers ────────────────────────────────────────────────────────
+
+fn require_non_empty<'v>(value: &'v str, field_name: &str) -> Result<&'v str> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        bail!("{field_name} must not be empty");
+    }
+    Ok(trimmed)
+}
+
+fn parse_time_range(start: &str, end: &str) -> Result<(i64, i64)> {
+    let start_epoch = crate::time::parse_timestamp_epoch_seconds(start)?;
+    let end_epoch = crate::time::parse_timestamp_epoch_seconds(end)?;
+    if end_epoch <= start_epoch {
+        bail!("--end ({end}) must be strictly after --start ({start})");
+    }
+    Ok((start_epoch, end_epoch))
+}
+
+/// Discover valid column ids with `cx service-catalog schema <entity-type>` first -
+/// the API rejects unknown ones anyway, so this only catches the empty case client-side.
+fn validate_columns(columns: &[String]) -> Result<Vec<String>> {
+    if columns.is_empty() {
+        bail!(
+            "--column is required and must be non-empty; run \
+             `cx service-catalog schema <entity-type>` first to discover valid column ids"
+        );
+    }
+    let trimmed: Vec<String> = columns.iter().map(|c| c.trim().to_string()).collect();
+    if trimmed.iter().any(|c| c.is_empty()) {
+        bail!("--column values must not be empty");
+    }
+    Ok(trimmed)
+}
+
+fn validate_group_by(group_by: &[String]) -> Result<Vec<String>> {
+    let trimmed: Vec<String> = group_by.iter().map(|g| g.trim().to_string()).collect();
+    if trimmed.iter().any(|g| g.is_empty()) {
+        bail!("--group-by values must not be empty");
+    }
+    Ok(trimmed)
+}
+
+/// Parses repeatable `--filter label=value1,value2` flags into `ApmFilter` inputs.
+///
+/// Each `label` may be given at most once; combine multiple values for the same
+/// label with commas rather than repeating `--filter` - repeating a label cannot
+/// mean "either value" once combined with other filters (they all AND together).
+fn parse_filters(filters: &[String]) -> Result<Vec<ApmFilterInput>> {
+    let mut parsed: Vec<ApmFilterInput> = Vec::new();
+
+    for raw in filters {
+        let Some((label_name, values)) = raw.split_once('=') else {
+            bail!("invalid --filter '{raw}': expected label=value1,value2,...");
+        };
+        let label_name = label_name.trim();
+        if label_name.is_empty() {
+            bail!("invalid --filter '{raw}': label name must not be empty");
+        }
+        let label_values: Vec<String> = values
+            .split(',')
+            .map(str::trim)
+            .filter(|v| !v.is_empty())
+            .map(String::from)
+            .collect();
+        if label_values.is_empty() {
+            bail!("invalid --filter '{raw}': must have at least one non-empty value");
+        }
+        if parsed.iter().any(|f| f.label_name == label_name) {
+            bail!(
+                "--filter label '{label_name}' given more than once; combine values with \
+                 commas instead (--filter {label_name}=a,b) - filters AND together, so \
+                 repeating a label cannot mean \"either value\""
+            );
+        }
+        parsed.push(ApmFilterInput {
+            label_name: label_name.to_string(),
+            label_values,
+        });
+    }
+
+    Ok(parsed)
+}
+
+fn clone_filters(filters: &[ApmFilterInput]) -> Vec<ApmFilterInput> {
+    filters
+        .iter()
+        .map(|f| ApmFilterInput {
+            label_name: f.label_name.clone(),
+            label_values: f.label_values.clone(),
+        })
+        .collect()
+}
+
+// ── EntitiesDataResult flattening ────────────────────────────────────────────────
+//
+// `ColumnValue` is a protobuf `oneof` with a dozen possible shapes, so JSON keeps
+// whichever single field was set. These mirror the shared Python implementation in
+// cx-olly's `libs/common/src/common/tools/service_catalog_tools.py`, which the MCP
+// server and Olly both use for the same v2 API - malformed/empty responses are
+// treated as errors rather than silently producing an empty or partial result.
+
+/// A `ColumnValue` object: exactly one value field, plus an optional `warning`.
+fn flatten_column_value(column_value: &Value) -> Result<Value> {
+    let obj = column_value
+        .as_object()
+        .ok_or_else(|| anyhow!("malformed service-catalog column value: expected an object"))?;
+    let value_keys: Vec<&String> = obj.keys().filter(|k| k.as_str() != "warning").collect();
+    if value_keys.len() != 1 {
+        bail!(
+            "malformed service-catalog column value: expected exactly one value field, got {:?}",
+            value_keys
+        );
+    }
+    let inner = obj[value_keys[0].as_str()].clone();
+    match obj.get("warning") {
+        Some(warning) if !warning.is_null() => Ok(json!({ "value": inner, "warning": warning })),
+        _ => Ok(inner),
+    }
+}
+
+/// A `ColumnResult`: either `{"value": ColumnValue}` or `{"error": ColumnError}`.
+fn flatten_column_result(column_result: &Value) -> Result<Value> {
+    let obj = column_result
+        .as_object()
+        .ok_or_else(|| anyhow!("malformed service-catalog column result: expected an object"))?;
+    let has_value = obj.contains_key("value");
+    let has_error = obj.contains_key("error");
+    if has_value == has_error {
+        bail!(
+            "malformed service-catalog column result: expected exactly one of 'value' or 'error'"
+        );
+    }
+    if has_value {
+        return flatten_column_value(&obj["value"]);
+    }
+    let error = &obj["error"];
+    let message = error
+        .get("message")
+        .and_then(|v| v.as_str())
+        .or_else(|| error.get("code").and_then(|v| v.as_str()))
+        .unwrap_or("unknown error");
+    Ok(json!({ "error": message }))
+}
+
+fn flatten_table_row(row: &TableRow) -> Result<Value> {
+    let mut flat = serde_json::Map::new();
+    for (key, value) in &row.identity {
+        flat.insert(key.clone(), json!(value));
+    }
+    for (column_id, column_result) in &row.values {
+        flat.insert(column_id.clone(), flatten_column_result(column_result)?);
+    }
+    Ok(Value::Object(flat))
+}
+
+/// Flattens one profile's `EntitiesDataResult` into `{rows, columns}` (table) or
+/// `{series, columns, total_series_count}` (timeseries). An empty/unrecognized
+/// response (neither `table` nor `timeseries` set) is an error, not a silent `[]`.
+fn format_entities_data_response(result: EntitiesDataResult) -> Result<Value> {
+    if let Some(table) = result.table {
+        let rows: Result<Vec<Value>> = table.rows.iter().map(flatten_table_row).collect();
+        return Ok(json!({
+            "rows": rows?,
+            "columns": table.columns.iter().map(column_metadata_to_json).collect::<Vec<_>>(),
+        }));
+    }
+    if let Some(timeseries) = result.timeseries {
+        return Ok(json!({
+            "series": timeseries.series,
+            "columns": timeseries.columns.iter().map(column_metadata_to_json).collect::<Vec<_>>(),
+            "total_series_count": timeseries.total_series_count,
+        }));
+    }
+    bail!(
+        "service-catalog returned an empty or unrecognized response \
+         (neither table nor timeseries data)"
+    );
+}
+
+/// Merges and renders `data`/`entity-data` results across profiles.
+///
+/// Table responses merge rows (tagging each with `profile` when multi-profile,
+/// same convention as `resource_to_json`); timeseries responses merge series.
+/// Columns are taken from the first successful profile - callers request the
+/// same `--column` set per profile, so they are expected to match.
+fn render_entities_data_results(
+    results: Vec<(String, EntitiesDataResult)>,
+    include_profile: bool,
+    output: OutputFormat,
+) -> Result<()> {
+    let mut formatted: Vec<(String, Value)> = Vec::new();
+    for (profile, result) in results {
+        formatted.push((profile, format_entities_data_response(result)?));
+    }
+
+    let is_timeseries = formatted
+        .first()
+        .map(|(_, v)| v.get("series").is_some())
+        .unwrap_or(false);
+
+    let columns = formatted
+        .first()
+        .and_then(|(_, v)| v.get("columns"))
+        .cloned()
+        .unwrap_or_else(|| json!([]));
+
+    if is_timeseries {
+        let mut series: Vec<Value> = Vec::new();
+        let mut total_series_count: i64 = 0;
+        for (profile, val) in &formatted {
+            for item in val
+                .get("series")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default()
+            {
+                series.push(tag_profile(item, include_profile, profile));
+            }
+            total_series_count += val
+                .get("total_series_count")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0);
+        }
+        let envelope = json!({
+            "series": series,
+            "columns": columns,
+            "total_series_count": total_series_count,
+        });
+        return render_data_envelope(output, &envelope, include_profile);
+    }
+
+    let mut rows: Vec<Value> = Vec::new();
+    for (profile, val) in &formatted {
+        for item in val
+            .get("rows")
+            .and_then(|v| v.as_array())
+            .cloned()
+            .unwrap_or_default()
+        {
+            rows.push(tag_profile(item, include_profile, profile));
+        }
+    }
+    let envelope = json!({ "rows": rows, "columns": columns });
+    render_data_envelope(output, &envelope, include_profile)
+}
+
+fn render_data_envelope(
+    output: OutputFormat,
+    envelope: &Value,
+    include_profile: bool,
+) -> Result<()> {
+    match output {
+        OutputFormat::Json => render::render_json_auto(std::slice::from_ref(envelope)),
+        OutputFormat::Agents => {
+            let encoded =
+                toon_encode(envelope).map_err(|e| anyhow!("TOON encoding failed: {e}"))?;
+            println!("{encoded}");
+            Ok(())
+        }
+        OutputFormat::Text => {
+            if let Some(series) = envelope.get("series").and_then(|v| v.as_array()) {
+                if series.is_empty() {
+                    render::print_no_results("No timeseries data found.");
+                    return Ok(());
+                }
+                // Timeseries datapoints are nested and variable-shaped - printed as
+                // JSON per series rather than forced into a flat table, same as the
+                // dataprime pipeline's aggregate-query fallback.
+                for item in series {
+                    println!("{}", serde_json::to_string_pretty(item)?);
+                }
+                return Ok(());
+            }
+
+            let rows = envelope
+                .get("rows")
+                .and_then(|v| v.as_array())
+                .cloned()
+                .unwrap_or_default();
+            if rows.is_empty() {
+                render::print_no_results("No data found.");
+                return Ok(());
+            }
+            render_table_rows(&rows, include_profile);
+            Ok(())
+        }
+    }
+}
+
+/// Renders flattened table rows with dynamically-discovered headers: the union
+/// of every row's keys (identity fields plus requested columns), `profile`
+/// pulled out to the front when multi-profile. Column sets can vary slightly
+/// row-to-row (e.g. a column present for one entity but not another), so the
+/// header is a union rather than just the first row's keys.
+fn render_table_rows(rows: &[Value], include_profile: bool) {
+    let mut headers: Vec<String> = Vec::new();
+    for row in rows {
+        if let Some(obj) = row.as_object() {
+            for key in obj.keys() {
+                if key != "profile" && !headers.contains(key) {
+                    headers.push(key.clone());
+                }
+            }
+        }
+    }
+
+    let table_rows: Vec<Vec<String>> = rows
+        .iter()
+        .map(|row| {
+            let profile = row
+                .get("profile")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let mut record = vec![profile];
+            for key in &headers {
+                record.push(display_json_or_dash(row.get(key)));
+            }
+            record
+        })
+        .collect();
+
+    let header_refs: Vec<&str> = headers.iter().map(String::as_str).collect();
+    render::render_table(&header_refs, table_rows, include_profile);
+}
+
+// ── JSON row builders ────────────────────────────────────────────────────────────
+
+fn render_machine_rows(output: OutputFormat, rows: &[Value]) -> Result<()> {
+    match output {
+        OutputFormat::Json => render::render_json(rows),
+        OutputFormat::Agents => render::render_agents(rows),
+        OutputFormat::Text => {
+            unreachable!("callers render text themselves; only Json/Agents reach here")
+        }
+    }
+}
+
+fn tag_profile(mut v: Value, include_profile: bool, profile: &str) -> Value {
+    if include_profile {
+        if let Value::Object(ref mut m) = v {
+            m.insert("profile".to_string(), Value::String(profile.to_string()));
+        }
+    }
+    v
+}
+
+fn entity_type_info_to_json(item: &EntityTypeInfo, include_profile: bool, profile: &str) -> Value {
+    let v = json!({
+        "entity_type": item.entity_type,
+        "id": item.id,
+        "display_name": item.display_name,
+        "description": item.description,
+    });
+    tag_profile(v, include_profile, profile)
+}
+
+fn column_metadata_to_json(c: &ColumnMetadata) -> Value {
+    json!({
+        "id": c.id,
+        "display_name": c.display_name,
+        "unit": c.unit,
+    })
+}
+
+fn entity_type_metadata_to_json(m: &EntityTypeMetadata) -> Value {
+    json!({
+        "entity_id": m.entity_id,
+        "display_name": m.display_name,
+        "description": m.description,
+        "columns": m.columns.iter().map(column_metadata_to_json).collect::<Vec<_>>(),
+        "default_columns": m.default_columns,
+        "groupable_labels": m.groupable_labels,
+        "group_by_limit": m.group_by_limit,
+        "default_group_by": m.default_group_by,
+        "filterable_labels": m.filterable_labels,
+        "required_filters": m.required_filters,
+    })
+}
+
+fn entity_item_to_json(item: &EntityItem, include_profile: bool, profile: &str) -> Value {
+    let v = json!({
+        "name": item.name,
+        "system": item.system,
+        "last_seen": item.last_seen,
+        "deployments": item.deployments,
+        "environments": item.environments.iter().map(|e| json!({
+            "name": e.name,
+            "last_seen": e.last_seen,
+        })).collect::<Vec<_>>(),
+    });
+    tag_profile(v, include_profile, profile)
+}
+
+fn display_or_dash(value: Option<&str>) -> String {
+    value.filter(|s| !s.is_empty()).unwrap_or("-").to_string()
+}
+
+fn display_json_or_dash(value: Option<&Value>) -> String {
+    match value {
+        None | Some(Value::Null) => "-".to_string(),
+        Some(Value::String(s)) if s.is_empty() => "-".to_string(),
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+
+    // ── parse_aggregation / parse_sort_order ─────────────────────────────────
+
+    #[test]
+    fn parse_aggregation_accepts_known_values_case_insensitively() {
+        assert_eq!(parse_aggregation("table").unwrap(), DATA_AGGREGATION_TABLE);
+        assert_eq!(
+            parse_aggregation("TIMESERIES").unwrap(),
+            DATA_AGGREGATION_TIMESERIES
+        );
+    }
+
+    #[test]
+    fn parse_aggregation_rejects_unknown_value() {
+        let err = parse_aggregation("chart").unwrap_err();
+        assert!(err.to_string().contains("unknown --aggregation 'chart'"));
+    }
+
+    #[test]
+    fn parse_sort_order_accepts_asc_and_desc() {
+        assert_eq!(parse_sort_order("asc").unwrap(), SORT_ORDER_ASC);
+        assert_eq!(parse_sort_order("DESC").unwrap(), SORT_ORDER_DESC);
+    }
+
+    #[test]
+    fn parse_sort_order_rejects_unknown_value() {
+        assert!(parse_sort_order("up").is_err());
+    }
+
+    // ── validate_table_controls_scope ────────────────────────────────────────
+
+    #[test]
+    fn table_controls_allowed_for_table_aggregation() {
+        assert!(validate_table_controls_scope(
+            DATA_AGGREGATION_TABLE,
+            Some(10),
+            Some("latency"),
+            Some(SORT_ORDER_ASC)
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn table_controls_rejected_for_timeseries_aggregation() {
+        let err = validate_table_controls_scope(DATA_AGGREGATION_TIMESERIES, Some(10), None, None)
+            .unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("only apply to --aggregation table"));
+    }
+
+    #[test]
+    fn timeseries_without_table_controls_is_fine() {
+        assert!(
+            validate_table_controls_scope(DATA_AGGREGATION_TIMESERIES, None, None, None).is_ok()
+        );
+    }
+
+    // ── validate_columns / validate_group_by ─────────────────────────────────
+
+    #[test]
+    fn validate_columns_rejects_empty_list() {
+        let err = validate_columns(&[]).unwrap_err();
+        assert!(err.to_string().contains("--column is required"));
+    }
+
+    #[test]
+    fn validate_columns_trims_and_rejects_blank_entries() {
+        assert_eq!(
+            validate_columns(&[" latency_p99 ".to_string()]).unwrap(),
+            vec!["latency_p99".to_string()]
+        );
+        assert!(validate_columns(&["  ".to_string()]).is_err());
+    }
+
+    #[test]
+    fn validate_group_by_allows_empty() {
+        assert!(validate_group_by(&[]).unwrap().is_empty());
+    }
+
+    // ── parse_filters ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn parse_filters_splits_comma_separated_values() {
+        let filters = parse_filters(&["environment=prod,staging".to_string()]).unwrap();
+        assert_eq!(filters.len(), 1);
+        assert_eq!(filters[0].label_name, "environment");
+        assert_eq!(filters[0].label_values, vec!["prod", "staging"]);
+    }
+
+    #[test]
+    fn parse_filters_rejects_missing_equals() {
+        let err = parse_filters(&["environment".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("expected label=value1,value2"));
+    }
+
+    #[test]
+    fn parse_filters_rejects_empty_values() {
+        let err = parse_filters(&["environment=".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("at least one non-empty value"));
+    }
+
+    #[test]
+    fn parse_filters_rejects_repeated_label() {
+        let err = parse_filters(&["a=1".to_string(), "a=2".to_string()]).unwrap_err();
+        assert!(err.to_string().contains("given more than once"));
+    }
+
+    #[test]
+    fn parse_filters_allows_distinct_labels() {
+        let filters =
+            parse_filters(&["environment=prod".to_string(), "team=core".to_string()]).unwrap();
+        assert_eq!(filters.len(), 2);
+    }
+
+    // ── flatten_column_value / flatten_column_result ─────────────────────────
+
+    #[test]
+    fn flatten_column_value_returns_the_single_set_field() {
+        let value = flatten_column_value(&json!({ "metric": 42.5 })).unwrap();
+        assert_eq!(value, json!(42.5));
+    }
+
+    #[test]
+    fn flatten_column_value_wraps_with_warning_when_present() {
+        let value = flatten_column_value(
+            &json!({ "metric": 1.0, "warning": { "code": "CODE_RATE_LIMITED" } }),
+        )
+        .unwrap();
+        assert_eq!(value["value"], json!(1.0));
+        assert_eq!(value["warning"]["code"], json!("CODE_RATE_LIMITED"));
+    }
+
+    #[test]
+    fn flatten_column_value_rejects_zero_value_fields() {
+        let err = flatten_column_value(&json!({ "warning": null })).unwrap_err();
+        assert!(err.to_string().contains("expected exactly one value field"));
+    }
+
+    #[test]
+    fn flatten_column_value_rejects_multiple_value_fields() {
+        let err = flatten_column_value(&json!({ "metric": 1.0, "health": {} })).unwrap_err();
+        assert!(err.to_string().contains("expected exactly one value field"));
+    }
+
+    #[test]
+    fn flatten_column_result_unwraps_value() {
+        let value = flatten_column_result(&json!({ "value": { "metric": 7.0 } })).unwrap();
+        assert_eq!(value, json!(7.0));
+    }
+
+    #[test]
+    fn flatten_column_result_maps_error_message() {
+        let value = flatten_column_result(&json!({
+            "error": { "code": "CODE_QUERY_TIMEOUT", "message": "took too long" }
+        }))
+        .unwrap();
+        assert_eq!(value["error"], json!("took too long"));
+    }
+
+    #[test]
+    fn flatten_column_result_falls_back_to_error_code() {
+        let value =
+            flatten_column_result(&json!({ "error": { "code": "CODE_RATE_LIMITED" } })).unwrap();
+        assert_eq!(value["error"], json!("CODE_RATE_LIMITED"));
+    }
+
+    #[test]
+    fn flatten_column_result_rejects_neither_value_nor_error() {
+        let err = flatten_column_result(&json!({})).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("expected exactly one of 'value' or 'error'"));
+    }
+
+    #[test]
+    fn flatten_column_result_rejects_both_value_and_error() {
+        let err = flatten_column_result(&json!({ "value": {}, "error": {} })).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("expected exactly one of 'value' or 'error'"));
+    }
+
+    #[test]
+    fn flatten_table_row_merges_identity_and_values() {
+        let mut identity = BTreeMap::new();
+        identity.insert("name".to_string(), "checkout".to_string());
+        let mut values = BTreeMap::new();
+        values.insert(
+            "latency_p99".to_string(),
+            json!({ "value": { "metric": 42.0 } }),
+        );
+        let row = TableRow { identity, values };
+
+        let flat = flatten_table_row(&row).unwrap();
+        assert_eq!(flat["name"], json!("checkout"));
+        assert_eq!(flat["latency_p99"], json!(42.0));
+    }
+
+    #[test]
+    fn flatten_table_row_propagates_malformed_column_errors() {
+        let mut values = BTreeMap::new();
+        values.insert("latency_p99".to_string(), json!({}));
+        let row = TableRow {
+            identity: BTreeMap::new(),
+            values,
+        };
+        assert!(flatten_table_row(&row).is_err());
+    }
+
+    // ── format_entities_data_response ────────────────────────────────────────
+
+    #[test]
+    fn format_entities_data_response_flattens_table() {
+        let result: EntitiesDataResult = serde_json::from_value(json!({
+            "table": {
+                "rows": [
+                    {
+                        "identity": { "name": "checkout" },
+                        "values": { "latency_p99": { "value": { "metric": 42.0 } } }
+                    }
+                ],
+                "columns": [{ "id": "latency_p99", "displayName": "P99 Latency" }]
+            }
+        }))
+        .unwrap();
+
+        let formatted = format_entities_data_response(result).unwrap();
+        assert_eq!(formatted["rows"][0]["name"], json!("checkout"));
+        assert_eq!(formatted["rows"][0]["latency_p99"], json!(42.0));
+        assert_eq!(formatted["columns"][0]["id"], json!("latency_p99"));
+    }
+
+    #[test]
+    fn format_entities_data_response_passes_through_timeseries() {
+        let result: EntitiesDataResult = serde_json::from_value(json!({
+            "timeseries": {
+                "series": [{ "columnId": "latency_p99" }],
+                "columns": [{ "id": "latency_p99" }],
+                "totalSeriesCount": 1
+            }
+        }))
+        .unwrap();
+
+        let formatted = format_entities_data_response(result).unwrap();
+        assert_eq!(formatted["series"][0]["columnId"], json!("latency_p99"));
+        assert_eq!(formatted["total_series_count"], json!(1));
+    }
+
+    #[test]
+    fn format_entities_data_response_rejects_empty_result() {
+        let result: EntitiesDataResult = serde_json::from_value(json!({})).unwrap();
+        let err = format_entities_data_response(result).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("neither table nor timeseries data"));
+    }
+
+    // ── display helpers ──────────────────────────────────────────────────────
+
+    #[test]
+    fn display_or_dash_falls_back_on_none_and_empty() {
+        assert_eq!(display_or_dash(Some("value")), "value");
+        assert_eq!(display_or_dash(Some("")), "-");
+        assert_eq!(display_or_dash(None), "-");
+    }
+
+    #[test]
+    fn display_json_or_dash_unwraps_strings_and_stringifies_others() {
+        assert_eq!(display_json_or_dash(Some(&json!("checkout"))), "checkout");
+        assert_eq!(display_json_or_dash(Some(&json!(42.5))), "42.5");
+        assert_eq!(display_json_or_dash(Some(&Value::Null)), "-");
+        assert_eq!(display_json_or_dash(None), "-");
+    }
+
+    #[test]
+    fn tag_profile_inserts_key_only_when_multi_profile() {
+        let tagged = tag_profile(json!({"a": 1}), true, "prod");
+        assert_eq!(tagged["profile"], "prod");
+        let untagged = tag_profile(json!({"a": 1}), false, "prod");
+        assert!(untagged.get("profile").is_none());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,7 @@ pub enum SearchByValueDataset {
   \x1b[1mviews\x1b[0m              Manage saved views and view folders
   \x1b[1mslos\x1b[0m               Manage SLO definitions
   \x1b[1minfra\x1b[0m              Query infrastructure resources and their data
+  \x1b[1mservice-catalog\x1b[0m    Query service-catalog entities and their RED/health/saturation data
 
 \x1b[1m\x1b[4mAI:\x1b[0m
   \x1b[1mai-center\x1b[0m (risky)  Manage AI Center applications, evaluations, policies, and pricing
@@ -536,6 +537,20 @@ Examples:
     Infra {
         #[command(subcommand)]
         cmd: InfraCmd,
+    },
+
+    /// Query service-catalog v2 entities: RED metrics, health, resource
+    /// saturation (k8s-pod/jvm), and dependency columns.
+    #[command(after_help = "\
+Examples:
+  cx service-catalog entity-types
+  cx service-catalog schema service
+  cx service-catalog entities service
+  cx service-catalog data service --start now-1h --end now --column latency_p99
+  cx service-catalog entity-data service checkout --start now-1h --end now --column latency_p99")]
+    ServiceCatalog {
+        #[command(subcommand)]
+        cmd: ServiceCatalogCmd,
     },
 
     /// Search log/span fields by description or by value content.
@@ -2631,6 +2646,119 @@ Examples:
     },
 }
 
+#[derive(Subcommand)]
+enum ServiceCatalogCmd {
+    /// List the entity types this account has service-catalog data for.
+    EntityTypes,
+    /// Show the columns/labels schema for one entity type.
+    #[command(after_help = "\
+Examples:
+  cx service-catalog schema service
+  cx service-catalog schema k8s-pod")]
+    Schema {
+        /// Entity type: service, database, operation, database-operation, jvm,
+        /// jvm-gc, k8s-pod, or transaction (also accepts the full
+        /// ENTITY_TYPE_* proto name).
+        entity_type: String,
+    },
+    /// List the known entities (e.g. service names) of one entity type.
+    #[command(after_help = "\
+Examples:
+  cx service-catalog entities service")]
+    Entities {
+        /// Entity type (see `schema` for accepted values).
+        entity_type: String,
+    },
+    /// Get column data (RED metrics, health, resource saturation, dependencies)
+    /// across every entity of one type.
+    #[command(after_help = "\
+Examples:
+  cx service-catalog data service --start now-1h --end now --column latency_p99 --column error_rate
+  cx service-catalog data k8s-pod --start now-1h --end now --column cpu_usage --column oom_killed
+  cx service-catalog data service --start now-1h --end now --column latency_p99 \\
+    --filter environment=prod --aggregation table --sort-column latency_p99 --sort-order desc --limit 10
+  cx service-catalog data service --start now-1h --end now --column latency_p99 --aggregation timeseries")]
+    Data {
+        /// Entity type (see `schema` for accepted values).
+        entity_type: String,
+
+        /// Start of the time range: `now`, `now-1h`, `now - 3d`, or ISO-8601.
+        #[arg(long)]
+        start: String,
+
+        /// End of the time range: `now`, `now-1h`, `now - 3d`, or ISO-8601.
+        #[arg(long)]
+        end: String,
+
+        /// Column id to fetch. Repeatable; at least one required. Discover
+        /// valid ids with `cx service-catalog schema <entity-type>`.
+        #[arg(long = "column", required = true)]
+        columns: Vec<String>,
+
+        /// Label to group rows by, on top of the entity identity. Repeatable.
+        #[arg(long = "group-by")]
+        group_by: Vec<String>,
+
+        /// Filter as label=value1,value2; repeatable across different labels,
+        /// at most once per label. Multiple labels combine with AND.
+        #[arg(long = "filter")]
+        filters: Vec<String>,
+
+        /// Response shape: `table` (default) or `timeseries`.
+        #[arg(long, default_value = "table")]
+        aggregation: String,
+
+        /// Max rows to return. `table` aggregation only.
+        #[arg(long)]
+        limit: Option<i32>,
+
+        /// Column id to sort by. `table` aggregation only.
+        #[arg(long)]
+        sort_column: Option<String>,
+
+        /// Sort direction: `asc` or `desc`. `table` aggregation only.
+        #[arg(long)]
+        sort_order: Option<String>,
+    },
+    /// Get column data for exactly one named entity (drilldown).
+    #[command(after_help = "\
+Examples:
+  cx service-catalog entity-data service checkout --start now-1h --end now --column latency_p99")]
+    EntityData {
+        /// Entity type (see `schema` for accepted values).
+        entity_type: String,
+
+        /// Entity id, exactly as returned by `cx service-catalog entities`.
+        entity_id: String,
+
+        /// Start of the time range: `now`, `now-1h`, `now - 3d`, or ISO-8601.
+        #[arg(long)]
+        start: String,
+
+        /// End of the time range: `now`, `now-1h`, `now - 3d`, or ISO-8601.
+        #[arg(long)]
+        end: String,
+
+        /// Column id to fetch. Repeatable; at least one required. Discover
+        /// valid ids with `cx service-catalog schema <entity-type>`.
+        #[arg(long = "column", required = true)]
+        columns: Vec<String>,
+
+        /// Label to group rows by, on top of the entity identity. Repeatable.
+        #[arg(long = "group-by")]
+        group_by: Vec<String>,
+
+        /// Filter as label=value1,value2; repeatable across different labels,
+        /// at most once per label. Multiple labels combine with AND.
+        #[arg(long = "filter")]
+        filters: Vec<String>,
+
+        /// Response shape: `table` (default) or `timeseries`.
+        #[arg(long, default_value = "table")]
+        aggregation: String,
+    },
+}
+
 #[tokio::main]
 async fn main() -> Result<()> {
     // Handle shell completions before any stdout output.
@@ -4225,6 +4353,71 @@ async fn main() -> Result<()> {
                         commands::infra::run_raw_data(&targets, &resource_id, output).await?;
                     }
                 },
+            },
+
+            Commands::ServiceCatalog { cmd } => match cmd {
+                ServiceCatalogCmd::EntityTypes => {
+                    commands::service_catalog::run_entity_types(&targets, output).await?;
+                }
+                ServiceCatalogCmd::Schema { entity_type } => {
+                    commands::service_catalog::run_schema(&targets, &entity_type, output).await?;
+                }
+                ServiceCatalogCmd::Entities { entity_type } => {
+                    commands::service_catalog::run_entities(&targets, &entity_type, output)
+                        .await?;
+                }
+                ServiceCatalogCmd::Data {
+                    entity_type,
+                    start,
+                    end,
+                    columns,
+                    group_by,
+                    filters,
+                    aggregation,
+                    limit,
+                    sort_column,
+                    sort_order,
+                } => {
+                    commands::service_catalog::run_data(
+                        &targets,
+                        &entity_type,
+                        &start,
+                        &end,
+                        &columns,
+                        &group_by,
+                        &filters,
+                        &aggregation,
+                        limit,
+                        sort_column.as_deref(),
+                        sort_order.as_deref(),
+                        output,
+                    )
+                    .await?;
+                }
+                ServiceCatalogCmd::EntityData {
+                    entity_type,
+                    entity_id,
+                    start,
+                    end,
+                    columns,
+                    group_by,
+                    filters,
+                    aggregation,
+                } => {
+                    commands::service_catalog::run_entity_data(
+                        &targets,
+                        &entity_type,
+                        &entity_id,
+                        &start,
+                        &end,
+                        &columns,
+                        &group_by,
+                        &filters,
+                        &aggregation,
+                        output,
+                    )
+                    .await?;
+                }
             },
 
             Commands::SearchFields {

--- a/src/time.rs
+++ b/src/time.rs
@@ -13,6 +13,17 @@ use chrono::{DateTime, Utc};
 /// Duration tokens are powered by [`humantime`] and support `s`, `m`, `h`,
 /// `d`, `w` and compound forms like `1h30m`.
 pub fn parse_timestamp(input: &str) -> Result<String> {
+    Ok(format_api_timestamp(parse_datetime(input)?))
+}
+
+/// Parse the same time expressions as [`parse_timestamp`], returning a Unix
+/// epoch in seconds. For APIs (like service-catalog v2) that take an
+/// `int64` seconds timestamp rather than an RFC3339 string.
+pub fn parse_timestamp_epoch_seconds(input: &str) -> Result<i64> {
+    Ok(parse_datetime(input)?.timestamp())
+}
+
+fn parse_datetime(input: &str) -> Result<DateTime<Utc>> {
     let trimmed = input.trim();
 
     let dt: DateTime<Utc> = if trimmed.eq_ignore_ascii_case("now") {
@@ -48,7 +59,7 @@ pub fn parse_timestamp(input: &str) -> Result<String> {
         })?
     };
 
-    Ok(format_api_timestamp(dt))
+    Ok(dt)
 }
 
 /// Format a UTC instant as the API's exact timestamp string.
@@ -96,5 +107,28 @@ mod tests {
     fn invalid_expression_errors() {
         assert!(parse_timestamp("yesterday").is_err());
         assert!(parse_timestamp("now+1h").is_err());
+    }
+
+    // ── parse_timestamp_epoch_seconds ────────────────────────────────────────
+
+    #[test]
+    fn epoch_seconds_iso8601_is_exact() {
+        assert_eq!(
+            parse_timestamp_epoch_seconds("2024-01-01T00:00:00Z").unwrap(),
+            1_704_067_200
+        );
+    }
+
+    #[test]
+    fn epoch_seconds_relative_is_in_the_past() {
+        let now = Utc::now().timestamp();
+        let one_hour_ago = parse_timestamp_epoch_seconds("now-1h").unwrap();
+        assert!(one_hour_ago < now);
+        assert!(now - one_hour_ago >= 3600 - 2, "should be ~1h in the past");
+    }
+
+    #[test]
+    fn epoch_seconds_invalid_expression_errors() {
+        assert!(parse_timestamp_epoch_seconds("yesterday").is_err());
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -76,6 +76,8 @@ mod routers;
 mod scopes;
 #[path = "e2e/search_fields/mod.rs"]
 mod search_fields;
+#[path = "e2e/service_catalog.rs"]
+mod service_catalog;
 #[path = "e2e/slos.rs"]
 mod slos;
 #[path = "e2e/spans/mod.rs"]

--- a/tests/e2e/service_catalog.rs
+++ b/tests/e2e/service_catalog.rs
@@ -1,0 +1,172 @@
+use std::sync::OnceLock;
+
+use crate::harness;
+
+#[test]
+#[ignore]
+fn service_catalog_entity_types() {
+    if harness::require_creds("service_catalog_entity_types").is_none() {
+        return;
+    }
+    let v = harness::run_ok_json(&["service-catalog", "entity-types", "-o", "json"]);
+    harness::assert_array_of_objects_with_keys(&v, &["entity_type", "id", "display_name"]);
+}
+
+#[test]
+#[ignore]
+fn service_catalog_schema() {
+    if harness::require_creds("service_catalog_schema").is_none() {
+        return;
+    }
+    let Some(entity_type) = discover_entity_type() else {
+        eprintln!("[e2e] skipping service_catalog_schema: no entity types on test team");
+        return;
+    };
+    let v = harness::run_ok_json(&["service-catalog", "schema", &entity_type, "-o", "json"]);
+    harness::assert_object_with_keys(&v, &["columns", "groupable_labels", "filterable_labels"]);
+    harness::assert_array_of_objects_with_keys(&v["columns"], &["id", "display_name"]);
+}
+
+#[test]
+#[ignore]
+fn service_catalog_entities() {
+    if harness::require_creds("service_catalog_entities").is_none() {
+        return;
+    }
+    let Some(entity_type) = discover_entity_type() else {
+        eprintln!("[e2e] skipping service_catalog_entities: no entity types on test team");
+        return;
+    };
+    let v = harness::run_ok_json(&["service-catalog", "entities", &entity_type, "-o", "json"]);
+    harness::assert_array_of_objects_with_keys(&v, &["name", "system", "last_seen"]);
+}
+
+#[test]
+#[ignore]
+fn service_catalog_data() {
+    if harness::require_creds("service_catalog_data").is_none() {
+        return;
+    }
+    let Some((entity_type, column)) = discover_entity_type_and_column() else {
+        eprintln!("[e2e] skipping service_catalog_data: no entity types/columns on test team");
+        return;
+    };
+    let v = harness::run_ok_json(&[
+        "service-catalog",
+        "data",
+        &entity_type,
+        "--start",
+        harness::SHORT_WINDOW_START,
+        "--end",
+        "now",
+        "--column",
+        &column,
+        "-o",
+        "json",
+    ]);
+    harness::assert_object_with_keys(&v, &["rows", "columns"]);
+    harness::assert_array(&v["rows"]);
+}
+
+#[test]
+#[ignore]
+fn service_catalog_entity_data() {
+    if harness::require_creds("service_catalog_entity_data").is_none() {
+        return;
+    }
+    let Some((entity_type, column)) = discover_entity_type_and_column() else {
+        eprintln!(
+            "[e2e] skipping service_catalog_entity_data: no entity types/columns on test team"
+        );
+        return;
+    };
+    let Some(entity_id) = discover_entity_id(&entity_type) else {
+        eprintln!(
+            "[e2e] skipping service_catalog_entity_data: no entities of type '{entity_type}' on test team"
+        );
+        return;
+    };
+    let v = harness::run_ok_json(&[
+        "service-catalog",
+        "entity-data",
+        &entity_type,
+        &entity_id,
+        "--start",
+        harness::SHORT_WINDOW_START,
+        "--end",
+        "now",
+        "--column",
+        &column,
+        "-o",
+        "json",
+    ]);
+    harness::assert_object_with_keys(&v, &["rows", "columns"]);
+}
+
+/// Discover an entity type from `service-catalog entity-types`. Cached so
+/// multiple tests don't each pay for the call.
+fn discover_entity_type() -> Option<String> {
+    static CACHE: OnceLock<Option<String>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            harness::require_creds("service_catalog_discover_entity_type")?;
+            let stdout = harness::run_ok(&["service-catalog", "entity-types", "-o", "json"]);
+            let v = harness::parse_json(&stdout)?;
+            v.as_array()?
+                .iter()
+                .find_map(|item| item.get("entity_type")?.as_str().map(String::from))
+        })
+        .clone()
+}
+
+/// Discover an `(entity_type, column_id)` pair via `entity-types` + `schema`,
+/// skipping entity types whose schema declares `required_filters` (e.g.
+/// `transaction` requires `service_name`) since supplying those would need
+/// another round of discovery this test isn't set up to do. Cached across
+/// the `data` and `entity-data` tests.
+fn discover_entity_type_and_column() -> Option<(String, String)> {
+    static CACHE: OnceLock<Option<(String, String)>> = OnceLock::new();
+    CACHE
+        .get_or_init(|| {
+            harness::require_creds("service_catalog_discover_entity_type_and_column")?;
+            let stdout = harness::run_ok(&["service-catalog", "entity-types", "-o", "json"]);
+            let entity_types = harness::parse_json(&stdout)?;
+            entity_types.as_array()?.iter().find_map(|item| {
+                let entity_type = item.get("entity_type")?.as_str()?.to_string();
+                let stdout =
+                    harness::run_ok(&["service-catalog", "schema", &entity_type, "-o", "json"]);
+                let schema = harness::parse_json(&stdout)?;
+                let has_required_filters = schema
+                    .get("required_filters")
+                    .and_then(|v| v.as_array())
+                    .is_some_and(|arr| !arr.is_empty());
+                if has_required_filters {
+                    return None;
+                }
+                let column = schema
+                    .get("columns")?
+                    .as_array()?
+                    .first()?
+                    .get("id")?
+                    .as_str()?
+                    .to_string();
+                Some((entity_type, column))
+            })
+        })
+        .clone()
+}
+
+/// Discover a known entity name for `entity_type` via `service-catalog
+/// entities`. Not cached on its own - only called once, by
+/// `service_catalog_entity_data`.
+fn discover_entity_id(entity_type: &str) -> Option<String> {
+    let stdout = harness::run_ok(&["service-catalog", "entities", entity_type, "-o", "json"]);
+    let v = harness::parse_json(&stdout)?;
+    v.as_array()?
+        .iter()
+        .find_map(|item| item.get("name")?.as_str().map(String::from))
+}
+
+// `service-catalog` has no mutating subcommands, so there is nothing
+// deliberately uncovered here - all five read-only subcommands
+// (entity-types, schema, entities, data, entity-data) are exercised above.

--- a/tests/schema/main.rs
+++ b/tests/schema/main.rs
@@ -21,7 +21,7 @@ fn schema_outputs_valid_json_with_expected_commands() {
     let commands = schema["commands"]
         .as_array()
         .expect("commands should be an array");
-    assert_eq!(commands.len(), 30, "expected 30 top-level commands");
+    assert_eq!(commands.len(), 31, "expected 31 top-level commands");
 
     let names: Vec<&str> = commands
         .iter()
@@ -45,6 +45,10 @@ fn schema_outputs_valid_json_with_expected_commands() {
     assert!(names.contains(&"olly"), "missing olly");
     assert!(names.contains(&"ai-center"), "missing ai-center");
     assert!(names.contains(&"infra"), "missing infra");
+    assert!(
+        names.contains(&"service-catalog"),
+        "missing service-catalog"
+    );
 
     // Verify old commands are gone
     assert!(

--- a/tests/service_catalog/main.rs
+++ b/tests/service_catalog/main.rs
@@ -417,9 +417,73 @@ async fn data_errors_on_malformed_column_result() {
     )
     .await
     .expect_err("a malformed column result must surface as an error, not silent data loss");
-    assert!(err
-        .to_string()
-        .contains("expected exactly one of 'value' or 'error'"));
+    let chain = format!("{err:#}");
+    assert!(chain.contains("expected exactly one of 'value' or 'error'"));
+}
+
+/// A malformed payload from one profile must not discard another profile's
+/// good rows - formatting failures follow the same partial-failure semantics
+/// as HTTP failures (report to stderr, render the survivors).
+#[tokio::test]
+async fn data_preserves_good_profile_when_another_profile_is_malformed() {
+    let server_ok = MockServer::start().await;
+    let server_malformed = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE/data")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "table": {
+                "rows": [
+                    {
+                        "identity": { "name": "checkout" },
+                        "values": { "latency_p99": { "value": { "metric": 42.5 } } }
+                    }
+                ],
+                "columns": [{ "id": "latency_p99" }]
+            }
+        })))
+        .expect(1)
+        .mount(&server_ok)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE/data")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "table": {
+                "rows": [
+                    {
+                        "identity": { "name": "checkout" },
+                        "values": { "latency_p99": {} }
+                    }
+                ],
+                "columns": []
+            }
+        })))
+        .expect(1)
+        .mount(&server_malformed)
+        .await;
+
+    let targets = vec![
+        common::test_target("profile-ok", &server_ok.uri()),
+        common::test_target("profile-malformed", &server_malformed.uri()),
+    ];
+
+    run_data(
+        &targets,
+        "service",
+        "now-1h",
+        "now",
+        &["latency_p99".to_string()],
+        &[],
+        &[],
+        "table",
+        None,
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("one profile's malformed payload must not discard another profile's good rows");
 }
 
 #[tokio::test]

--- a/tests/service_catalog/main.rs
+++ b/tests/service_catalog/main.rs
@@ -1,0 +1,544 @@
+#[path = "../common/mod.rs"]
+mod common;
+
+use serde_json::json;
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use coralogix_cli::commands::service_catalog::{
+    run_data, run_entities, run_entity_data, run_entity_types, run_schema,
+};
+use coralogix_cli::config::OutputFormat;
+
+const BASE: &str = "/v2/entities";
+
+fn entity_types_body() -> serde_json::Value {
+    json!({
+        "entityTypes": [
+            {
+                "type": "ENTITY_TYPE_SERVICE",
+                "id": "service",
+                "displayName": "Service",
+                "description": "APM services"
+            }
+        ]
+    })
+}
+
+#[tokio::test]
+async fn entity_types_returns_mappings_from_mock() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .respond_with(ResponseTemplate::new(200).set_body_json(entity_types_body()))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_entity_types(&targets, OutputFormat::Json)
+        .await
+        .expect("run_entity_types should succeed");
+}
+
+#[tokio::test]
+async fn entity_types_merges_multiple_profiles() {
+    let server_a = MockServer::start().await;
+    let server_b = MockServer::start().await;
+
+    for server in [&server_a, &server_b] {
+        Mock::given(method("GET"))
+            .and(path(BASE))
+            .respond_with(ResponseTemplate::new(200).set_body_json(entity_types_body()))
+            .expect(1)
+            .mount(server)
+            .await;
+    }
+
+    let targets = vec![
+        common::test_target("profile-a", &server_a.uri()),
+        common::test_target("profile-b", &server_b.uri()),
+    ];
+
+    run_entity_types(&targets, OutputFormat::Json)
+        .await
+        .expect("run_entity_types should merge both profiles");
+}
+
+#[tokio::test]
+async fn entity_types_tolerates_one_failing_profile() {
+    let server_ok = MockServer::start().await;
+    let server_err = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .respond_with(ResponseTemplate::new(200).set_body_json(entity_types_body()))
+        .expect(1)
+        .mount(&server_ok)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .respond_with(
+            ResponseTemplate::new(500).set_body_json(json!({ "message": "backend exploded" })),
+        )
+        .expect(1)
+        .mount(&server_err)
+        .await;
+
+    let targets = vec![
+        common::test_target("profile-ok", &server_ok.uri()),
+        common::test_target("profile-err", &server_err.uri()),
+    ];
+
+    run_entity_types(&targets, OutputFormat::Json)
+        .await
+        .expect("one failing profile should be non-fatal");
+}
+
+#[tokio::test]
+async fn entity_types_errors_when_all_profiles_fail() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({ "message": "boom" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let result = run_entity_types(&targets, OutputFormat::Json).await;
+    assert!(result.is_err(), "all profiles failing should be an error");
+}
+
+#[tokio::test]
+async fn all_output_formats_render_entity_types() {
+    for format in [OutputFormat::Text, OutputFormat::Json, OutputFormat::Agents] {
+        let server = MockServer::start().await;
+
+        Mock::given(method("GET"))
+            .and(path(BASE))
+            .respond_with(ResponseTemplate::new(200).set_body_json(entity_types_body()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let targets = vec![common::test_target("test-profile", &server.uri())];
+
+        run_entity_types(&targets, format)
+            .await
+            .unwrap_or_else(|e| panic!("run_entity_types should render {format:?}: {e:#}"));
+    }
+}
+
+#[tokio::test]
+async fn schema_hits_the_normalized_entity_type_path() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE/metadata")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "entityId": "service",
+            "displayName": "Service",
+            "columns": [{ "id": "latency_p99", "displayName": "P99 Latency" }],
+            "groupByLimit": 3
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_schema(&targets, "service", OutputFormat::Json)
+        .await
+        .expect("run_schema should hit the normalized path");
+}
+
+#[tokio::test]
+async fn schema_accepts_hyphenated_short_entity_type() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_K8S_POD/metadata")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "entityId": "k8s_pod" })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_schema(&targets, "k8s-pod", OutputFormat::Json)
+        .await
+        .expect("run_schema should normalize k8s-pod");
+}
+
+#[tokio::test]
+async fn schema_rejects_unknown_entity_type_before_any_request() {
+    let server = MockServer::start().await;
+    // No mocks mounted: an invalid entity type must fail client-side without HTTP.
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let err = run_schema(&targets, "pod", OutputFormat::Json)
+        .await
+        .expect_err("unknown entity type should error");
+    assert!(err.to_string().contains("unknown entity type 'pod'"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn entities_lists_known_entities() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "entities": [
+                {
+                    "name": "checkout",
+                    "system": "kubernetes",
+                    "lastSeen": "2026-07-01T00:00:00Z",
+                    "environments": [{ "name": "prod", "lastSeen": "2026-07-01T00:00:00Z" }]
+                }
+            ]
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_entities(&targets, "service", OutputFormat::Json)
+        .await
+        .expect("run_entities should succeed");
+}
+
+#[tokio::test]
+async fn entities_handles_empty_response() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "entities": [] })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_entities(&targets, "service", OutputFormat::Text)
+        .await
+        .expect("empty entities response should succeed in text mode");
+}
+
+#[tokio::test]
+async fn data_posts_the_expected_body_and_flattens_table_rows() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE/data")))
+        .and(body_json(json!({
+            "timeRange": { "start": 1000, "end": 2000 },
+            "dataAggregationType": "DATA_AGGREGATION_TYPE_TABLE",
+            "columns": [{ "columnId": "latency_p99" }],
+            "groupBy": [],
+            "filters": [{ "labelName": "environment", "labelValues": ["prod"] }],
+            "limit": 5,
+            "sortColumn": "latency_p99",
+            "sortOrder": "SORT_ORDER_DESCENDING"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "table": {
+                "rows": [
+                    {
+                        "identity": { "name": "checkout" },
+                        "values": { "latency_p99": { "value": { "metric": 42.5 } } }
+                    }
+                ],
+                "columns": [{ "id": "latency_p99" }]
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_data(
+        &targets,
+        "service",
+        "1970-01-01T00:16:40Z",
+        "1970-01-01T00:33:20Z",
+        &["latency_p99".to_string()],
+        &[],
+        &["environment=prod".to_string()],
+        "table",
+        Some(5),
+        Some("latency_p99"),
+        Some("desc"),
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_data should send the expected body and flatten the response");
+}
+
+#[tokio::test]
+async fn data_rejects_table_controls_with_timeseries_aggregation_before_any_request() {
+    let server = MockServer::start().await;
+    // No mocks mounted: the combination must fail client-side without HTTP.
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let err = run_data(
+        &targets,
+        "service",
+        "now-1h",
+        "now",
+        &["latency_p99".to_string()],
+        &[],
+        &[],
+        "timeseries",
+        Some(5),
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect_err("limit with timeseries aggregation should error");
+    assert!(err
+        .to_string()
+        .contains("only apply to --aggregation table"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn data_rejects_empty_columns_before_any_request() {
+    let server = MockServer::start().await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let err = run_data(
+        &targets,
+        "service",
+        "now-1h",
+        "now",
+        &[],
+        &[],
+        &[],
+        "table",
+        None,
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect_err("empty --column list should error");
+    assert!(err.to_string().contains("--column is required"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn data_handles_timeseries_aggregation() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE/data")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "timeseries": {
+                "series": [{ "columnId": "latency_p99", "datapoints": [] }],
+                "columns": [{ "id": "latency_p99" }],
+                "totalSeriesCount": 1
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_data(
+        &targets,
+        "service",
+        "now-1h",
+        "now",
+        &["latency_p99".to_string()],
+        &[],
+        &[],
+        "timeseries",
+        None,
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_data should handle timeseries responses");
+}
+
+#[tokio::test]
+async fn data_errors_on_malformed_column_result() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!("{BASE}/ENTITY_TYPE_SERVICE/data")))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "table": {
+                "rows": [
+                    {
+                        "identity": { "name": "checkout" },
+                        "values": { "latency_p99": {} }
+                    }
+                ],
+                "columns": []
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let err = run_data(
+        &targets,
+        "service",
+        "now-1h",
+        "now",
+        &["latency_p99".to_string()],
+        &[],
+        &[],
+        "table",
+        None,
+        None,
+        None,
+        OutputFormat::Json,
+    )
+    .await
+    .expect_err("a malformed column result must surface as an error, not silent data loss");
+    assert!(err
+        .to_string()
+        .contains("expected exactly one of 'value' or 'error'"));
+}
+
+#[tokio::test]
+async fn entity_data_posts_to_the_entity_scoped_path() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "{BASE}/ENTITY_TYPE_SERVICE/data/entity/checkout"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "table": {
+                "rows": [
+                    {
+                        "identity": { "name": "checkout" },
+                        "values": { "latency_p99": { "value": { "metric": 12.0 } } }
+                    }
+                ],
+                "columns": []
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_entity_data(
+        &targets,
+        "service",
+        "checkout",
+        "now-1h",
+        "now",
+        &["latency_p99".to_string()],
+        &[],
+        &[],
+        "table",
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_entity_data should succeed");
+}
+
+#[tokio::test]
+async fn entity_data_percent_encodes_entity_id() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path(format!(
+            "{BASE}/ENTITY_TYPE_SERVICE/data/entity/checkout%2Fapi"
+        )))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "table": { "rows": [], "columns": [] }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    run_entity_data(
+        &targets,
+        "service",
+        "checkout/api",
+        "now-1h",
+        "now",
+        &["latency_p99".to_string()],
+        &[],
+        &[],
+        "table",
+        OutputFormat::Json,
+    )
+    .await
+    .expect("run_entity_data should percent-encode the entity id");
+}
+
+#[tokio::test]
+async fn entity_data_rejects_empty_entity_id_before_any_request() {
+    let server = MockServer::start().await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let err = run_entity_data(
+        &targets,
+        "service",
+        "  ",
+        "now-1h",
+        "now",
+        &["latency_p99".to_string()],
+        &[],
+        &[],
+        "table",
+        OutputFormat::Json,
+    )
+    .await
+    .expect_err("blank entity id should error");
+    assert!(err.to_string().contains("entity id must not be empty"));
+    assert_eq!(server.received_requests().await.unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn api_error_body_surfaces_in_message() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path(BASE))
+        .respond_with(ResponseTemplate::new(400).set_body_json(json!({
+            "message": "invalid request"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let targets = vec![common::test_target("test-profile", &server.uri())];
+
+    let err = run_entity_types(&targets, OutputFormat::Json)
+        .await
+        .expect_err("400 from the only profile should error");
+    let chain = format!("{err:#}");
+    assert!(chain.contains("invalid request"));
+    assert!(chain.contains("profile 'test-profile' failed"));
+}


### PR DESCRIPTION
## Summary

Adds `cx service-catalog`, a REST-based command wrapping the v2 Service Catalog API so RED metrics, health, and resource saturation data are queryable from the CLI. This is the CLI leg of [CX-52318](https://coralogix.atlassian.net/browse/CX-52318) (Service Catalog support in MCP/Olly/CLI); the MCP/Olly leg is being tracked separately.

- `cx service-catalog entity-types` — entity types this account has data for
- `cx service-catalog schema <entity-type>` — columns/labels schema for one entity type
- `cx service-catalog entities <entity-type>` — known entities of a type (e.g. service names)
- `cx service-catalog data <entity-type>` — aggregated table/timeseries column data across every entity of a type
- `cx service-catalog entity-data <entity-type> <entity-id>` — column data for one named entity

Supports all entity types from the v2 API: `service`, `database`, `operation`, `database-operation`, `jvm`, `jvm-gc`, `k8s-pod`, `transaction` — including K8S_POD and JVM for resource saturation questions.

### Implementation notes

- Follows the existing REST archetype (`src/commands/infra`) — `cx-cli` talks HTTP only, never gRPC.
- `src/commands/service_catalog/api.rs`: entity-type normalization (short/hyphenated/full proto forms → `ENTITY_TYPE_*`), entity-id percent-encoding, request/response types.
- `src/commands/service_catalog/mod.rs`: argument validation (columns, group-by, filters, time range, aggregation/sort-order), and flattening of the `oneof`-based `EntitiesDataResult`/`ColumnValue`/`ColumnResult` shapes into plain JSON — mirrors the shared Python implementation in `cx-olly`'s `libs/common/src/common/tools/service_catalog_tools.py` so malformed/empty responses are errors rather than silent partial results.
- `--limit`/`--sort-column`/`--sort-order` are rejected client-side when `--aggregation timeseries` is set, since the backend currently ignores them for timeseries ([CX-52920](https://coralogix.atlassian.net/browse/CX-52920)).
- `src/time.rs`: added `parse_timestamp_epoch_seconds` since the v2 API's `TimeRange` is `Int64Value` (epoch seconds), not RFC3339.
- Multi-profile fan-out, `-o json`/`-o agents`/text rendering, and profile tagging all follow the existing conventions (`fan_out`, `report_errors_and_collect_successes`, `render::*`).

## Test plan

- [x] `cargo test --lib` — 532 passed, 0 failed (no regressions)
- [x] `cargo test --test service_catalog` — 19 new wiremock integration tests, all passing (multi-profile merge, partial-failure tolerance, all-profiles-failure, all three output formats, client-side validation short-circuits with zero HTTP calls, percent-encoding, malformed-response error surfacing)
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — zero warnings in new code (pre-existing unrelated warnings in `tests/e2e/*` untouched)
- [x] Manual smoke test: `cx service-catalog --help`, `cx service-catalog data --help`, and a client-side validation error (`cx service-catalog schema pod` → helpful error, no network call)
- [x] `scripts/verify-skills.sh` — 17/17 skills pass, including the new `cx-service-catalog` skill

Made with [Cursor](https://cursor.com)

[CX-52318]: https://coralogix.atlassian.net/browse/CX-52318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CX-52920]: https://coralogix.atlassian.net/browse/CX-52920?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ