### PR TITLE
Fix flaky data_usage test on Windows CI

### DIFF
--- a/src/commands/data_usage/mod.rs
+++ b/src/commands/data_usage/mod.rs
@@ -456,16 +456,24 @@ pub async fn run_query(
 #[cfg(test)]
 mod tests {
     use super::{parse_query, read_query_from_file};
+    use std::sync::atomic::{AtomicU64, Ordering};
     use std::time::{SystemTime, UNIX_EPOCH};
 
+    /// A raw nanosecond timestamp alone can collide between tests running in
+    /// parallel on platforms with coarser clock resolution (observed on
+    /// Windows CI), letting one test's write clobber another's file before
+    /// it's read back. The atomic counter guarantees uniqueness within this
+    /// process regardless of clock granularity.
+    static UNIQUE_SUFFIX: AtomicU64 = AtomicU64::new(0);
+
     fn write_query(contents: &str) -> std::path::PathBuf {
-        let path = std::env::temp_dir().join(format!(
-            "cx-data-usage-query-unit-{}.json",
-            SystemTime::now()
-                .duration_since(UNIX_EPOCH)
-                .expect("clock is after Unix epoch")
-                .as_nanos()
-        ));
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock is after Unix epoch")
+            .as_nanos();
+        let counter = UNIQUE_SUFFIX.fetch_add(1, Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("cx-data-usage-query-unit-{nanos}-{counter}.json"));
         std::fs::write(&path, contents).unwrap();
         path
     }


### PR DESCRIPTION
## Summary

`write_query`'s temp filename used only a nanosecond timestamp, which collides between tests running in parallel on platforms with coarser clock resolution (observed on Windows CI): one test's write clobbered another's file before it was read back, so `read_query_from_file_rejects_non_object_json` read the other test's JSON object content instead of its own array.

Adds a process-local atomic counter to guarantee a unique filename regardless of clock granularity.

Split out of #183 per [review feedback](https://github.com/coralogix/cx-cli/pull/183#discussion_r3743430248) — unrelated to the Service Catalog feature, so it belongs in its own focused PR.

## Test plan

- `cargo test --lib data_usage` — 17 passed, 0 failed

Made with [Cursor](https://cursor.com)