### PR TITLE
docs(cx-olly): run cx olly ask asynchronously by default

### DIFF
--- a/skills/cx-olly/SKILL.md
+++ b/skills/cx-olly/SKILL.md
@@ -32,7 +32,7 @@ Only run `cx olly ask` inline (foreground, blocking) for a short question you ex
 ### Start a new conversation
 
 ```bash
-cx olly ask "Why is the checkout service showing high latency?"
+cx olly ask "What alerts fired today?"
 ```
 
 This creates a new chat and returns a response along with a **Chat ID** that you can use for follow-up questions.

--- a/skills/cx-olly/SKILL.md
+++ b/skills/cx-olly/SKILL.md
@@ -21,12 +21,18 @@ Use this skill to interact with Coralogix's Observability Agent (Olly) via the `
 
 **Single-profile only:** `cx olly` commands do not support multi-profile fan-out. Use `-p <profile>` to specify a single profile.
 
+## Running Olly (async by default)
+
+**Run `cx olly ask` asynchronously by default:** launch it as a **background process and poll it for completion** rather than blocking on it. Olly investigations routinely take minutes, so this is the normal mode for `cx olly ask`.
+
+Only run `cx olly ask` inline (foreground, blocking) for a short question you expect Olly to answer quickly — a quick lookup or a one-line follow-up. When in doubt, run it in the background.
+
 ## Chat Commands
 
 ### Start a new conversation
 
 ```bash
-cx olly ask "What alerts fired today?"
+cx olly ask "Why is the checkout service showing high latency?"
 ```
 
 This creates a new chat and returns a response along with a **Chat ID** that you can use for follow-up questions.
@@ -37,7 +43,7 @@ This creates a new chat and returns a response along with a **Chat ID** that you
 cx olly ask "Tell me more about the error rates" --chat-id <chat-id>
 ```
 
-Use `--chat-id` to continue a conversation and maintain context from previous messages.
+Use `--chat-id` to continue a conversation and maintain context from previous messages. Background the follow-up too when it kicks off another investigation.
 
 ### Model selection
 
@@ -89,13 +95,13 @@ Output behavior:
 ### Investigate an issue
 
 ```bash
-# Start investigation
+# Start investigation — run in the background and poll for completion
 cx olly ask "Why is the checkout service showing high latency?"
 
-# Follow up with the chat ID from the response
+# Follow up with the chat ID from the response — also background and poll
 cx olly ask "What changed in the last hour?" --chat-id abc-123-def
 
-# Get any generated charts
+# Once the interaction has completed, get any generated charts
 cx olly artifacts list -o json | jq '.[0].id'
 cx olly artifacts get <artifact-id>
 ```
@@ -120,6 +126,7 @@ cx olly ask "Perform root cause analysis for the outage on 2024-01-15" \
 
 ## Key Principles
 
+- **Async by default** - run `cx olly ask` as a background process and poll it for completion; only run inline (blocking) for short questions you expect Olly to answer quickly
 - **Chat IDs enable context** - save the Chat ID from responses to continue conversations
 - **Use `-o json` for scripting** - pipe to `jq` for filtering and extraction
 - **Artifact IDs are in response text** - look for markdown links like `[Chart](https://...artifact_view/<id>)`


### PR DESCRIPTION
## Context
`cx olly ask` investigations routinely take minutes to complete, but agent skills previously showed only blocking, foreground invocations. This left agents waiting synchronously on long-running Olly investigations instead of treating the call as async work they can poll for completion. FORGE-675.

## Linked Issues
FORGE-675

## Design
This is a docs-only change to `skills/cx-olly/SKILL.md`, the user-facing skill that teaches agents how to drive `cx olly ask`/`cx olly artifacts`. Adds a new "Running Olly (async by default)" section right after the single-profile note, restates the guidance as a bullet under "Key Principles", and annotates the existing "Investigate an issue" example comments to say each `cx olly ask` call should be backgrounded and polled. No code, command, or API changes.

## Key Decisions
- Default guidance is "background + poll" rather than always-async, with an explicit carve-out for short/quick questions the agent expects to answer fast — avoids forcing unnecessary polling overhead for trivial one-line follow-ups.
- Kept the change confined to documentation/skill guidance rather than changing `cx olly` CLI behavior itself, since the underlying command already returns promptly when invoked as a background process by the calling agent; the skill just needed to say so.

## Changes
- `skills/cx-olly/SKILL.md`: adds explicit guidance that agents should run `cx olly ask` as a background process and poll for completion by default, reserving blocking/inline calls for short questions expected to return quickly. Applies the same guidance to `--chat-id` follow-ups and to fetching artifacts after an investigation completes.

## Testing
Docs-only change; no code paths affected. Verified the diff renders correctly and reads coherently in context via `git diff`.

## Risks & Rollout
N/A — low risk, isolated documentation change to a single skill file with no effect on CLI behavior or other skills.

## Out of Scope / Follow-ups
N/A — fully self-contained.