### PR TITLE
Bump version to 0.1.16

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,7 +359,7 @@ dependencies = [
 
 [[package]]
 name = "coralogix-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "coralogix-cli"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Coralogix CLI - the observability backbone for AI agents and engineering teams."
 repository = "https://github.com/coralogix/cx-cli"


### PR DESCRIPTION
## Summary
- Bumps `coralogix-cli` version to 0.1.16 in `Cargo.toml` and `Cargo.lock` ahead of the next release.

## Test plan
- CI (build/test) on this PR.

Made with [Cursor](https://cursor.com)