### PR TITLE
BUGV2: wrong name field value displayed in standard text view for the infra resources list command

### DIFF
--- a/src/commands/infra/mod.rs
+++ b/src/commands/infra/mod.rs
@@ -154,7 +154,7 @@ pub async fn run_list(
                     vec![
                         profile.clone(),
                         display_or_dash(r.resource_id.as_deref()),
-                        display_or_dash(r.name.as_deref()),
+                        display_or_dash(display_name(r)),
                     ]
                 })
                 .collect();
@@ -536,6 +536,19 @@ fn display_or_dash(value: Option<&str>) -> String {
     value.filter(|s| !s.is_empty()).unwrap_or("-").to_string()
 }
 
+/// The name the API matches `--name-filter` against.
+///
+/// The `name` field is an internal identifier, while the `Name` column holds the display name
+/// that `nameFilter` actually searches. Falls back to `name` when the column is absent.
+fn display_name(item: &ResourceData) -> Option<&str> {
+    item.columns
+        .iter()
+        .find(|(key, _)| key.eq_ignore_ascii_case("name"))
+        .map(|(_, value)| value.as_str())
+        .filter(|s| !s.is_empty())
+        .or(item.name.as_deref())
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -841,6 +854,47 @@ mod tests {
         assert_eq!(display_or_dash(Some("value")), "value");
         assert_eq!(display_or_dash(Some("")), "-");
         assert_eq!(display_or_dash(None), "-");
+    }
+
+    fn resource(name: Option<&str>, columns: &[(&str, &str)]) -> ResourceData {
+        ResourceData {
+            resource_id: Some("4013226:host_id=i-077a1626590913a16".to_string()),
+            name: name.map(String::from),
+            columns: columns
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn display_name_prefers_the_name_column() {
+        let r = resource(
+            Some("i-077a1626590913a16"),
+            &[("Name", "ip-10-109-46-236.eu-west-1.compute.internal")],
+        );
+        assert_eq!(
+            display_name(&r),
+            Some("ip-10-109-46-236.eu-west-1.compute.internal")
+        );
+    }
+
+    #[test]
+    fn display_name_matches_the_column_key_case_insensitively() {
+        let r = resource(Some("i-abc123"), &[("name", "web-server-1")]);
+        assert_eq!(display_name(&r), Some("web-server-1"));
+    }
+
+    #[test]
+    fn display_name_falls_back_to_the_name_field() {
+        let missing = resource(Some("i-abc123"), &[("region", "eu-west-1")]);
+        assert_eq!(display_name(&missing), Some("i-abc123"));
+
+        let empty = resource(Some("i-abc123"), &[("Name", "")]);
+        assert_eq!(display_name(&empty), Some("i-abc123"));
+
+        let neither = resource(None, &[]);
+        assert_eq!(display_name(&neither), None);
     }
 
     fn counts(entries: &[(&str, i64, usize)]) -> Vec<ProfileCounts> {


### PR DESCRIPTION
[BUGV2-7055](https://coralogix.atlassian.net/browse/BUGV2-7055)

## Problem

`cx infra resources list` showed the resource's `name` field in the text table, but `--name-filter` matches against the `Name` column instead. The two differ, so users couldn't filter by a name they'd just seen in the list:

```
| Resource ID                         | Name                |
| 4013226:host_id=i-077a1626590913a16 | i-077a1626590913a16 |   <- name field
```

```json
"columns": { "Name": "ip-10-109-46-236.eu-west-1.compute.internal" }   // what --name-filter searches
```

## Fix

The text table's Name column now shows the `Name` column value, falling back to the `name` field when the column is absent or empty:

```
| Resource ID                         | Name                                        |
| 4013226:host_id=i-077a1626590913a16 | ip-10-109-46-236.eu-west-1.compute.internal |
```

JSON/agents output is unchanged — it still carries both `name` and `columns`.

## Tests

Three unit tests for the new `display_name()` helper: column preferred, case-insensitive key match, and fallback when the column is missing/empty.


[BUGV2-7055]: https://coralogix.atlassian.net/browse/BUGV2-7055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ