### PR TITLE
feat: custom endpoint support to profiles for private deployment onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Follow these steps to go from a fresh install to a working query.
     cx profiles add <name>
     ```
 
+    For BYOC / private environments, pass the API endpoint directly instead of picking a region: `cx profiles add <name> --endpoint https://api.myenv.example.com`. See [Custom / BYOC endpoints](docs/configuration.md#custom--byoc-endpoints).
+
 2. Query logs. The positional argument is a DataPrime query:
 
     ```bash
@@ -194,7 +196,7 @@ Commands are grouped by domain. Run `cx --help` for the full organized listing, 
 | Command | Purpose |
 |---|---|
 | `cx schema` | Output the full command tree as JSON for agent consumption |
-| `cx profiles` | Manage profiles: `list`, `add`, `delete`, `set-default` |
+| `cx profiles` | Manage profiles: `list`, `show`, `add`, `delete`, `set-default` |
 | `cx completions` | Shell tab-completion: `install`, `refresh`, `generate` |
 | `cx cleanup` | Remove `cx_results*` temp files older than 30 minutes |
 
@@ -204,7 +206,7 @@ Commands are grouped by domain. Run `cx --help` for the full organized listing, 
 ```
 -p, --profile <PROFILE>      Profile to use. Repeat to fan out across multiple profiles.
     --api-key <API_KEY>      Override the profile API key
-    --region <REGION>        Override the profile region
+    --region <REGION>        Override the profile region (name or full endpoint URL)
 -o, --output <FORMAT>        text | json | toon (default: text)
     --yes                    Skip confirmation prompts for destructive operations
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,7 +24,7 @@ cx profiles add <name>
 At the prompts:
 
 1. **Authentication method** — `OAuth (browser login)` (recommended) opens your browser and stores tokens securely. Select `API key (paste manually)` to use a static key instead.
-2. **Region** — your Coralogix region (e.g. `eu2`, `us1`). See [Regions](#regions) for the full list.
+2. **Region** — your Coralogix region (e.g. `eu2`, `us1`), or a custom endpoint URL for BYOC / private environments. See [Regions](#regions) and [Custom / BYOC endpoints](#custom--byoc-endpoints).
 3. **Label** — an optional tag to group or identify profiles (e.g. `production`).
 4. **Credential storage** — `file` (default) saves credentials in the profile TOML; `os-store` uses the OS keyring (macOS Keychain, Windows Credential Manager, or D-Bus Secret Service on Linux).
 
@@ -197,7 +197,32 @@ Legacy profiles without an `auth` field behave as `auth = "api_key"` automatical
 | `ap2` | `https://api.ap2.coralogix.com` |
 | `ap3` | `https://api.ap3.coralogix.com` |
 
-A fully qualified HTTPS URL can be used as a region value for non-standard environments.
+A fully qualified HTTPS URL can be used as a region value for non-standard environments — see below.
+
+## Custom / BYOC endpoints
+
+For BYOC, private-link, or other non-standard deployments whose API endpoint is not in the region list, `cx` accepts a full endpoint URL anywhere a region is accepted:
+
+- **Interactively** — select `Custom endpoint (specify URL)` (API-key auth) or `Custom (specify URL + client ID)` (OAuth) at the Region prompt and enter the URL.
+- **Scripted profile creation** — pass `--endpoint` to skip the region prompt:
+
+  ```sh
+  cx profiles add dev --endpoint https://api.myenv.example.com
+  ```
+
+- **Profile TOML** — set `region` to the URL directly:
+
+  ```toml
+  region = "https://api.myenv.example.com"
+  ```
+
+- **Runtime override / env-only mode** — `--region` and `CX_REGION` also accept a full URL, so headless environments need no profile file at all:
+
+  ```sh
+  CX_API_KEY=... CX_REGION=https://api.myenv.example.com cx logs "source logs | limit 1"
+  ```
+
+The URL must be an absolute `http(s)` URL; trailing slashes are stripped. Every subcommand uses it as the API base URL. Verify which endpoint a profile targets with `cx profiles show <name>`. If the web console is not discoverable via `/identity/whoami`, set `console_url` in the profile TOML to keep "View in Coralogix" links working — see [Console links](#console-links).
 
 ## Console links
 
@@ -232,7 +257,7 @@ Environment variables override profile file values:
 |---|---|
 | `CX_PROFILE` | `-p` flag / `default_profile` |
 | `CX_API_KEY` | `api_key` in profile (also overrides OAuth - sets the bearer token directly) |
-| `CX_REGION` | `region` in profile |
+| `CX_REGION` | `region` in profile (region name or a full endpoint URL) |
 | `CX_READ_ONLY` | `read_only` in global config (accepts `1`, `true`, `yes`, `on`) |
 | `CX_NO_CONSOLE_LINK` | `no_console_link` in global config (accepts `1`, `true`, `yes`, `on`) |
 | `CX_TELEMETRY` | Set to `false`, `no`, `off`, or `0` to disable CLI request metadata |
@@ -290,7 +315,7 @@ The env var accepts `1`, `true`, `yes`, or `on` (case-insensitive).
 
 ## Shell completion and profiles
 
-Profile names discovered in `~/.cx/profiles/*.toml` are offered as tab-completion candidates for the `-p`/`--profile` flag and for the `profiles add`, `profiles delete`, and `profiles set-default` subcommands.
+Profile names discovered in `~/.cx/profiles/*.toml` are offered as tab-completion candidates for the `-p`/`--profile` flag and for the `profiles show`, `profiles add`, `profiles delete`, and `profiles set-default` subcommands.
 
 When using static completions installed with `cx completions install`, profile names are captured at installation time. After adding or deleting a profile, `cx` will print a reminder to run `cx completions refresh`, which regenerates every file registered in `managed_completions`.
 

--- a/docs/multi-profile.md
+++ b/docs/multi-profile.md
@@ -42,7 +42,7 @@ Text output adds a `Profile` column to tables for REST commands (alerts, dashboa
 cx logs 'filter $m.severity == ERROR' -p prod -p staging --api-key sk-...
 ```
 
-Instead, store per-profile credentials ahead of time:
+Instead, store per-profile credentials ahead of time (use `--endpoint` for profiles targeting custom / BYOC endpoints):
 
 ```bash
 cx profiles add prod

--- a/example_config.toml
+++ b/example_config.toml
@@ -27,6 +27,9 @@ default_output_format = "text"
 # region = "eu1"
 # label = "production"
 #
+# For BYOC / private environments, region accepts a full endpoint URL:
+# region = "https://api.myenv.example.com"
+#
 # Optional: override the web console base URL used to build "View in
 # Coralogix" links printed after dashboard/alert/case mutations. By default
 # this is resolved automatically via GET /identity/whoami; only needed when

--- a/src/commands/profiles/mod.rs
+++ b/src/commands/profiles/mod.rs
@@ -12,9 +12,21 @@ use crate::oauth;
 
 const AUTH_METHODS: &[&str] = &["OAuth (browser login)", "API key (paste manually)"];
 
-const REGIONS: &[&str] = &["us1", "us2", "us3", "eu1", "eu2", "ap1", "ap2", "ap3"];
+/// Region list for API-key mode: canned regions plus a custom-endpoint option
+/// for BYOC / private environments.
+const REGIONS: &[&str] = &[
+    "us1",
+    "us2",
+    "us3",
+    "eu1",
+    "eu2",
+    "ap1",
+    "ap2",
+    "ap3",
+    "Custom endpoint (specify URL)",
+];
 
-/// Region list for OAuth mode: same as REGIONS plus a custom option.
+/// Region list for OAuth mode: same canned regions plus a custom option.
 const OAUTH_REGIONS: &[&str] = &[
     "us1",
     "us2",
@@ -61,6 +73,33 @@ fn hint_completions_refresh() {
              to update static completion scripts."
         );
     }
+}
+
+/// Validate a custom API endpoint: absolute http(s) URL with a host.
+/// Returns the URL with surrounding whitespace and trailing slashes removed.
+fn normalize_endpoint(raw: &str) -> Result<String> {
+    let trimmed = raw.trim().trim_end_matches('/');
+    let url = url::Url::parse(trimmed)
+        .map_err(|e| anyhow::anyhow!("Invalid endpoint URL '{trimmed}': {e}."))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        anyhow::bail!("Invalid endpoint URL '{trimmed}': scheme must be http or https.");
+    }
+    if url.host_str().is_none() {
+        anyhow::bail!("Invalid endpoint URL '{trimmed}': missing host.");
+    }
+    Ok(trimmed.to_string())
+}
+
+fn prompt_endpoint(prompt: &str) -> Result<String> {
+    let raw = Text::new(prompt)
+        .with_validator(|input: &str| match normalize_endpoint(input) {
+            Ok(_) => Ok(inquire::validator::Validation::Valid),
+            Err(e) => Ok(inquire::validator::Validation::Invalid(
+                e.to_string().into(),
+            )),
+        })
+        .prompt()?;
+    normalize_endpoint(&raw)
 }
 
 // ── List ──────────────────────────────────────────────────────────────────────
@@ -163,9 +202,56 @@ pub fn run_list() -> Result<()> {
     Ok(())
 }
 
+// ── Show ──────────────────────────────────────────────────────────────────────
+
+pub fn run_show(profile_name: Option<String>) -> Result<()> {
+    let global_config = load_config().unwrap_or_default();
+    let name = profile_name.unwrap_or_else(|| global_config.default_profile.clone());
+
+    let path = profile_file(&name)?;
+    if !path.exists() {
+        anyhow::bail!("Profile '{name}' not found.");
+    }
+    let profile = load_profile(&name)?;
+
+    let auth = match profile.auth {
+        AuthKind::OAuth => "oauth",
+        AuthKind::ApiKey => "api-key",
+    };
+    let storage = match profile.credential_storage {
+        CredentialStorage::File => "file",
+        CredentialStorage::OsStore => "os-store",
+    };
+    let output_fmt = profile
+        .default_output_format
+        .map(|f| f.as_str())
+        .unwrap_or("-");
+    let is_default = if name == global_config.default_profile {
+        "yes"
+    } else {
+        "no"
+    };
+
+    println!("Name:      {name}");
+    println!("Label:     {}", profile.label.as_deref().unwrap_or("-"));
+    println!("Region:    {}", profile.region);
+    println!("Endpoint:  {}", profile.region.api_endpoint());
+    println!("Auth:      {auth}");
+    println!("Storage:   {storage}");
+    println!("Output:    {output_fmt}");
+    println!("Default:   {is_default}");
+
+    Ok(())
+}
+
 // ── Add ───────────────────────────────────────────────────────────────────────
 
-pub async fn run_add(profile_name: Option<String>, set_default: bool) -> Result<()> {
+pub async fn run_add(
+    profile_name: Option<String>,
+    set_default: bool,
+    endpoint: Option<String>,
+) -> Result<()> {
+    let endpoint = endpoint.as_deref().map(normalize_endpoint).transpose()?;
     let is_first_profile = list_profile_names()?.is_empty();
 
     let name = match profile_name {
@@ -200,9 +286,9 @@ pub async fn run_add(profile_name: Option<String>, set_default: bool) -> Result<
     let use_oauth = auth_choice.starts_with("OAuth");
 
     let (mut profile, storage_desc) = if use_oauth {
-        configure_oauth(&name).await?
+        configure_oauth(&name, endpoint.as_deref()).await?
     } else {
-        configure_api_key(&name)?
+        configure_api_key(&name, endpoint.as_deref())?
     };
 
     // ── Common: default output format (per-profile) ────────────────────────────
@@ -346,17 +432,22 @@ pub fn run_set_default(profile_name: String) -> Result<()> {
 
 // ── OAuth configure path ──────────────────────────────────────────────────────
 
-async fn configure_oauth(name: &str) -> Result<(Profile, &'static str)> {
-    // Region / environment selection
-    let region_str = Select::new("Region:", OAUTH_REGIONS.to_vec())
-        .with_starting_cursor(3) // eu2
-        .prompt()?;
+async fn configure_oauth(name: &str, endpoint: Option<&str>) -> Result<(Profile, &'static str)> {
+    // Region / environment selection; a --endpoint flag skips the prompt.
+    let region_str = match endpoint {
+        Some(_) => "Custom",
+        None => Select::new("Region:", OAUTH_REGIONS.to_vec())
+            .with_starting_cursor(3) // eu1
+            .prompt()?,
+    };
 
     let is_custom = region_str.starts_with("Custom");
 
     let (region, base_url, client_id, oauth_client_id_for_profile) = if is_custom {
-        let raw_url = Text::new("Base URL (e.g. https://api.myenv.coralogix.com):").prompt()?;
-        let base_url = raw_url.trim_end_matches('/').to_string();
+        let base_url = match endpoint {
+            Some(url) => url.to_string(),
+            None => prompt_endpoint("Base URL (e.g. https://api.myenv.coralogix.com):")?,
+        };
         let client_id = Text::new("OAuth client ID:").prompt()?;
         let region = Region::Custom(base_url.clone());
         // Store the client ID in the profile for custom environments.
@@ -433,7 +524,7 @@ async fn configure_oauth(name: &str) -> Result<(Profile, &'static str)> {
 
 // ── API key configure path ────────────────────────────────────────────────────
 
-fn configure_api_key(name: &str) -> Result<(Profile, &'static str)> {
+fn configure_api_key(name: &str, endpoint: Option<&str>) -> Result<(Profile, &'static str)> {
     println!(
         "The API key must be a Team Key or a Personal Key.\n  \
          • Team Key:     Data Flow → API Keys → Team Keys\n  \
@@ -445,10 +536,21 @@ fn configure_api_key(name: &str) -> Result<(Profile, &'static str)> {
         .without_confirmation()
         .prompt()?;
 
-    let region_str = Select::new("Region:", REGIONS.to_vec())
-        .with_starting_cursor(2) // eu1
-        .prompt()?;
-    let region: Region = region_str.parse()?;
+    let region = match endpoint {
+        Some(url) => Region::Custom(url.to_string()),
+        None => {
+            let region_str = Select::new("Region:", REGIONS.to_vec())
+                .with_starting_cursor(3) // eu1
+                .prompt()?;
+            if region_str.starts_with("Custom") {
+                Region::Custom(prompt_endpoint(
+                    "API endpoint URL (e.g. https://api.myenv.example.com):",
+                )?)
+            } else {
+                region_str.parse()?
+            }
+        }
+    };
 
     let label = Text::new("Label (e.g. 'prod'):").prompt_skippable()?;
     let label = label.filter(|s| !s.is_empty());
@@ -521,6 +623,47 @@ mod tests {
                 "OUTPUT_FORMATS is missing canonical variant {:?}; picker cursor would \
                  not preselect it",
                 variant.as_str(),
+            );
+        }
+    }
+
+    /// Every canned picker entry must parse to a known `Region` variant.
+    /// `Region::FromStr` falls back to `Custom` for unrecognised strings, so a
+    /// typo in these lists would silently become a bogus endpoint.
+    #[test]
+    fn every_canned_region_parses_to_a_known_variant() {
+        for entry in REGIONS
+            .iter()
+            .chain(OAUTH_REGIONS.iter())
+            .filter(|r| !r.starts_with("Custom"))
+        {
+            let region: Region = entry.parse().expect("canned region should parse");
+            assert!(
+                !matches!(region, Region::Custom(_)),
+                "picker entry {entry:?} parsed to Region::Custom; \
+                 it would be used verbatim as an endpoint",
+            );
+        }
+    }
+
+    #[test]
+    fn normalize_endpoint_accepts_https_and_trims() {
+        assert_eq!(
+            normalize_endpoint(" https://api.myenv.example.com/ ").unwrap(),
+            "https://api.myenv.example.com"
+        );
+        assert_eq!(
+            normalize_endpoint("http://localhost:8080").unwrap(),
+            "http://localhost:8080"
+        );
+    }
+
+    #[test]
+    fn normalize_endpoint_rejects_invalid_urls() {
+        for bad in ["", "api.myenv.example.com", "ftp://api.myenv.example.com"] {
+            assert!(
+                normalize_endpoint(bad).is_err(),
+                "expected {bad:?} to be rejected"
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,7 @@ struct Cli {
     )]
     api_key: Option<String>,
 
-    /// Coralogix region (overrides a single profile; incompatible with multiple --profile).
+    /// Coralogix region or full endpoint URL (overrides a single profile; incompatible with multiple --profile).
     #[arg(
         long,
         global = true,
@@ -634,6 +634,12 @@ impl Commands {
 enum ProfilesCmd {
     /// List all configured profiles.
     List,
+    /// Show a profile's configuration, including the resolved API endpoint.
+    Show {
+        /// Profile name to show (defaults to the default profile).
+        #[arg(add = ArgValueCompleter::new(complete_profile_names))]
+        name: Option<String>,
+    },
     /// Add or reconfigure a profile interactively.
     Add {
         /// Profile name to configure (prompted if not provided).
@@ -642,6 +648,10 @@ enum ProfilesCmd {
         /// Set this profile as the default without prompting.
         #[arg(long)]
         set_default: bool,
+        /// Custom API endpoint URL for BYOC / private environments.
+        /// Skips the region prompt.
+        #[arg(long, value_name = "URL")]
+        endpoint: Option<String>,
     },
     /// Delete a profile and its stored credentials.
     Delete {
@@ -2798,9 +2808,12 @@ async fn main() -> Result<()> {
         let ProfilesTopLevel::Profiles { cmd } = profiles_cli.command;
         let result = match cmd {
             ProfilesCmd::List => commands::profiles::run_list(),
-            ProfilesCmd::Add { name, set_default } => {
-                commands::profiles::run_add(name, set_default).await
-            }
+            ProfilesCmd::Show { name } => commands::profiles::run_show(name),
+            ProfilesCmd::Add {
+                name,
+                set_default,
+                endpoint,
+            } => commands::profiles::run_add(name, set_default, endpoint).await,
             ProfilesCmd::Delete { name, force } => commands::profiles::run_delete(name, force),
             ProfilesCmd::SetDefault { name } => commands::profiles::run_set_default(name),
         };
@@ -2867,9 +2880,12 @@ async fn main() -> Result<()> {
     if let Commands::Profiles { cmd } = cli.command {
         let result = match cmd {
             ProfilesCmd::List => commands::profiles::run_list(),
-            ProfilesCmd::Add { name, set_default } => {
-                commands::profiles::run_add(name, set_default).await
-            }
+            ProfilesCmd::Show { name } => commands::profiles::run_show(name),
+            ProfilesCmd::Add {
+                name,
+                set_default,
+                endpoint,
+            } => commands::profiles::run_add(name, set_default, endpoint).await,
             ProfilesCmd::Delete { name, force } => commands::profiles::run_delete(name, force),
             ProfilesCmd::SetDefault { name } => commands::profiles::run_set_default(name),
         };

--- a/tests/profiles/main.rs
+++ b/tests/profiles/main.rs
@@ -21,14 +21,20 @@ fn cx(home: &std::path::Path) -> Command {
 }
 
 fn seed_profile(home: &std::path::Path, name: &str) {
+    seed_profile_with_region(home, name, "eu1");
+}
+
+fn seed_profile_with_region(home: &std::path::Path, name: &str, region: &str) {
     let profiles_dir = home.join(".cx").join("profiles");
     fs::create_dir_all(&profiles_dir).unwrap();
-    let profile_toml = r#"
+    let profile_toml = format!(
+        r#"
 auth = "api_key"
 credential_storage = "file"
 api_key = "fake-key-000"
-region = "eu1"
-"#;
+region = "{region}"
+"#
+    );
     fs::write(profiles_dir.join(format!("{name}.toml")), profile_toml).unwrap();
 }
 
@@ -81,6 +87,115 @@ fn set_default_flag_is_accepted_by_clap() {
     assert!(
         stdout.contains("--set-default"),
         "--set-default should appear in help, got: {stdout}"
+    );
+}
+
+// ── --endpoint flag ──────────────────────────────────────────────────────────
+
+#[test]
+fn add_endpoint_flag_is_accepted_by_clap() {
+    let tmp = temp_home();
+    let output = cx(&tmp)
+        .args(["profiles", "add", "--help"])
+        .output()
+        .expect("failed to run cx");
+    assert!(output.status.success(), "--help should exit 0");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("--endpoint"),
+        "--endpoint should appear in help, got: {stdout}"
+    );
+}
+
+#[test]
+fn add_invalid_endpoint_fails_before_prompting() {
+    let tmp = temp_home();
+    let output = cx(&tmp)
+        .args(["profiles", "add", "myenv", "--endpoint", "not-a-url"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Invalid endpoint URL"),
+        "should report invalid endpoint, stderr: {stderr}"
+    );
+}
+
+// ── profiles show ────────────────────────────────────────────────────────────
+
+#[test]
+fn show_prints_resolved_endpoint_for_canned_region() {
+    let tmp = temp_home();
+    seed_profile(&tmp, "prod");
+    seed_config(&tmp, "default_profile = \"prod\"\n");
+
+    let output = cx(&tmp)
+        .args(["profiles", "show", "prod"])
+        .output()
+        .expect("failed to run cx");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("https://api.eu1.coralogix.com"),
+        "should print the resolved endpoint, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("fake-key-000"),
+        "must never print credentials, got: {stdout}"
+    );
+}
+
+#[test]
+fn show_prints_custom_endpoint() {
+    let tmp = temp_home();
+    seed_profile_with_region(&tmp, "byoc", "https://api.myenv.example.com");
+    seed_config(&tmp, "default_profile = \"byoc\"\n");
+
+    let output = cx(&tmp)
+        .args(["profiles", "show", "byoc"])
+        .output()
+        .expect("failed to run cx");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("https://api.myenv.example.com"),
+        "should print the custom endpoint, got: {stdout}"
+    );
+}
+
+#[test]
+fn show_defaults_to_default_profile() {
+    let tmp = temp_home();
+    seed_profile(&tmp, "primary");
+    seed_config(&tmp, "default_profile = \"primary\"\n");
+
+    let output = cx(&tmp)
+        .args(["profiles", "show"])
+        .output()
+        .expect("failed to run cx");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("primary"),
+        "should show the default profile, got: {stdout}"
+    );
+}
+
+#[test]
+fn show_nonexistent_profile_fails() {
+    let tmp = temp_home();
+    seed_config(&tmp, "");
+
+    let output = cx(&tmp)
+        .args(["profiles", "show", "ghost"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "should report not found, stderr: {stderr}"
     );
 }
 


### PR DESCRIPTION
## Context
* On private deployments the API endpoint is not in the canned region list, so `cx profiles add` forces a region choice, writes the wrong endpoint into `~/.cx`, and the profile is unusable until hand-edited.
* This is the first thing a new user on such a deployment hits, making it an onboarding blocker. This PR makes custom endpoints a first-class part of the profile flow.

## Linked Issues
https://github.com/coralogix/cx-cli/issues/196 

## Design
The config layer already supports custom endpoints: `Region` has an untagged `Custom(String)` serde variant whose value flows verbatim through `ResolvedConfig.endpoint` into every API client, which is why hand-edited profiles (and the wiremock test suite, which injects mock-server URIs as `region`) already work. 

The gap was UX: 
1. No way to enter a URL through the CLI's API-key path, 
2. No validation
3. No way to see which backend a profile targets.

The change therefore adds no new config field and no resolution changes. A new `normalize_endpoint` helper (trim + absolute-http(s)-URL validation via the `url` crate) feeds `Region::Custom` from three entry points: the API-key region picker (new "Custom endpoint" option, mirroring the existing OAuth custom option), an inquire inline validator on the URL prompt, and a `--endpoint` flag on `profiles add`. A new `profiles show` subcommand prints the profile including the resolved endpoint (`region.api_endpoint()`), so canned-region profiles show their derived URL too.

## Key Decisions
- **Reuse `Region::Custom` rather than adding an `endpoint` field to `Profile`.** The format already round-trips URLs in `region` (existing BYOC users' hand-edited profiles depend on it), and a second field would create precedence ambiguity plus churn across ~13 exhaustive `Profile` struct literals.
- **No global `--endpoint` / `CX_ENDPOINT` runtime override** (confirmed with the requester). `--region <url>` / `CX_REGION=<url>` already provide exactly that behavior, including headless env-only mode; a parallel flag would duplicate the env-suppression and multi-profile guard logic for zero new capability. Instead the docs now promote URL-as-region to documented first-class behavior.
- **`--endpoint` on `profiles add` has no env var** — an env var that only affects `add` but not runtime would be a trap; scripted runtime already has `CX_REGION`.
- **Validation only at the new entry points.** `Region::FromStr`'s fall-through-to-`Custom` is untouched: it is load-bearing for env-only mode and for the integration test suite's endpoint injection.
- **`--endpoint` is validated before any prompt**, so an invalid URL fails fast headless — which also makes it integration-testable without a TTY.

## Changes
- `cx profiles add` (API-key path) region picker gains a "Custom endpoint (specify URL)" option; the URL is validated inline (absolute http(s) URL, host required) and normalized (whitespace/trailing-slash trimmed). The OAuth custom path now runs through the same validation instead of a bare trim.
- New `cx profiles add --endpoint <URL>`: skips the region prompt on both auth paths and stores the URL as the profile's region; other prompts remain interactive.
- New `cx profiles show [name]` subcommand (defaults to the default profile): prints Name, Label, Region, resolved Endpoint, Auth, Storage, Output, Default. Never prints credentials and never touches the OS keyring (no Keychain prompts).
- Fixed both region-picker starting-cursor bugs: the API-key picker preselected `us3` (comment claimed `eu1`), the OAuth picker's comment claimed `eu2` while preselecting `eu1`. Both now preselect `eu1` as the comments always intended — note this changes the API-key picker's default highlight from `us3` to `eu1`.
- Docs: new "Custom / BYOC endpoints" section in `docs/configuration.md`; `--region`/`CX_REGION` help and docs now state they accept a full endpoint URL; README, multi-profile doc, and `example_config.toml` updated.

## Testing
- `cargo fmt --check && cargo clippy --locked -- -D warnings && cargo test --locked` — full CI sequence, all green (52 test binaries, 0 failures).
- New unit tests: `normalize_endpoint` accept/reject cases; a picker-coverage test asserting every canned entry in `REGIONS`/`OAUTH_REGIONS` parses to a known `Region` variant (a typo would silently become a bogus endpoint via the `FromStr` fallback).
- New integration tests (`tests/profiles/main.rs`): `--endpoint` in `add --help`; invalid `--endpoint` fails headless before prompting; `show` prints the resolved endpoint for a canned region, prints a custom URL, defaults to the default profile, errors on unknown names, and never leaks the API key.
- Manual pty-driven runs (expect) of the real binary against a temp `CX_HOME`: `profiles add dev --endpoint https://api.myenv.example.com/` skips the region prompt and writes `region = "https://api.myenv.example.com"` (trailing slash normalized); the interactive "Custom endpoint" picker path writes the entered URL; the inline validator visibly rejects `not-a-url`; `profiles show`/`list` display the URL.

## Risks & Rollout
Backwards compatible: no config schema change, existing profiles (including hand-edited BYOC ones) load unchanged, and `Region::FromStr` behavior is untouched. The only behavioral deltas for existing users are the extra picker entry, the API-key picker's default highlight moving from `us3` to `eu1`, and the new subcommand/flag. Rollback is a straight revert.

## Out of Scope / Follow-ups
- No `console_url` prompting for BYOC environments where `/identity/whoami` can't resolve a console link — it remains a manual profile field (documented in the new BYOC section).
- `Region::FromStr` still silently turns typos like `eu5` into a bogus custom endpoint at runtime; tightening that is a separate discussion since the fallback is intentionally load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)