### PR TITLE
AIAP-1095 | Add skills install command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Local:
 
 All use the Olly KB semantic-search-service API with gateway permission `legacy-archive-queries:Execute` (AAA id 40). See `olly-knowledge-base` `apps/semantic-search-service/AGENTS.md`.
 
-**`cx skills install`:** Installs the cx agent skills bundle by shelling out to the vercel-labs `skills` npx installer (`npx skills add coralogix/cx-cli`). By default it asks one question (global vs local scope, skipped by `--global`/`--local`), then runs fully non-interactively with agent auto-detection; `--agent <name>` overrides auto-detect, `--interactive` walks the installer's full flow. Requires Node.js/npx; the CLI is fully usable without skills. Logic lives in `src/commands/skills/mod.rs`.
+**`cx skills install`:** Installs the cx agent skills bundle by shelling out to the vercel-labs `skills` npx installer (`npx skills add coralogix/cx-cli/skills` — the `skills/` subdir, so the contributor-only dev skills under `.claude/skills/` are never installed for end users). By default it asks one question (global vs local scope, skipped by `--global`/`--local`), then runs fully non-interactively with agent auto-detection; `--agent <name>` overrides auto-detect, `--interactive` walks the installer's full flow. Requires Node.js/npx; the CLI is fully usable without skills. Logic lives in `src/commands/skills/mod.rs`.
 
 **Agent discovery:** `cx schema` outputs the full command tree (commands, subcommands, flags, descriptions) as JSON. Agents should call `cx schema` to discover available commands rather than parsing help text.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Local:
 
 All use the Olly KB semantic-search-service API with gateway permission `legacy-archive-queries:Execute` (AAA id 40). See `olly-knowledge-base` `apps/semantic-search-service/AGENTS.md`.
 
-**`cx skills install`:** Installs the cx agent skills bundle by shelling out to the vercel-labs `skills` npx installer (`npx skills add coralogix/cx-cli`). Express mode asks one question (global vs local scope, skipped by `--global`/`--local`), then runs fully non-interactively with agent auto-detection; `--agent <name>` overrides auto-detect, `--interactive` walks the installer's full flow. Requires Node.js/npx; the CLI is fully usable without skills. Logic lives in `src/commands/skills/mod.rs` and is reused by `cx init` (FORGE-658).
+**`cx skills install`:** Installs the cx agent skills bundle by shelling out to the vercel-labs `skills` npx installer (`npx skills add coralogix/cx-cli`). By default it asks one question (global vs local scope, skipped by `--global`/`--local`), then runs fully non-interactively with agent auto-detection; `--agent <name>` overrides auto-detect, `--interactive` walks the installer's full flow. Requires Node.js/npx; the CLI is fully usable without skills. Logic lives in `src/commands/skills/mod.rs`.
 
 **Agent discovery:** `cx schema` outputs the full command tree (commands, subcommands, flags, descriptions) as JSON. Agents should call `cx schema` to discover available commands rather than parsing help text.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,7 @@ Agent:
 
 Local:
   profiles           Manage profiles (list, add, delete, set-default)
+  skills             Install the cx agent skills for coding agents
   cleanup            Remove stale temp files
 ```
 
@@ -86,6 +87,8 @@ Local:
 - `cx dashboards query-search --field <field-path>` — Find all queries referencing a specific field (e.g., `$d.http.status_code`)
 
 All use the Olly KB semantic-search-service API with gateway permission `legacy-archive-queries:Execute` (AAA id 40). See `olly-knowledge-base` `apps/semantic-search-service/AGENTS.md`.
+
+**`cx skills install`:** Installs the cx agent skills bundle by shelling out to the vercel-labs `skills` npx installer (`npx skills add coralogix/cx-cli`). Express mode asks one question (global vs local scope, skipped by `--global`/`--local`), then runs fully non-interactively with agent auto-detection; `--agent <name>` overrides auto-detect, `--interactive` walks the installer's full flow. Requires Node.js/npx; the CLI is fully usable without skills. Logic lives in `src/commands/skills/mod.rs` and is reused by `cx init` (FORGE-658).
 
 **Agent discovery:** `cx schema` outputs the full command tree (commands, subcommands, flags, descriptions) as JSON. Agents should call `cx schema` to discover available commands rather than parsing help text.
 
@@ -205,6 +208,7 @@ Which CLI commands have user-facing skills in `skills/`:
 | `cx olly` | `cx-olly` | Covered |
 | `cx infra` | `cx-infra` | Covered |
 | `cx profiles` | - | Local command |
+| `cx skills` | - | Local command (installs the skills in this table) |
 | `cx cleanup` | - | Local command |
 
 ### Testing Expectations

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ brew install coralogix/tap/cx
 Skills teach your AI agent how to use `cx` for observability investigations.
 
 ```bash
-npx skills add coralogix/cx-cli
+npx skills add coralogix/cx-cli/skills
 ```
 
 ### 3. Optional: install shell autocomplete
@@ -249,13 +249,13 @@ The install flow above installs all skills. Use these variants if you want to cu
 Install selected skills:
 
 ```bash
-npx skills add coralogix/cx-cli --skill query-logs --skill dataprime
+npx skills add coralogix/cx-cli/skills --skill query-logs --skill dataprime
 ```
 
 Install globally for all projects:
 
 ```bash
-npx skills add coralogix/cx-cli -g
+npx skills add coralogix/cx-cli/skills -g
 ```
 
 Available skills: `cx-query-logs`, `cx-query-spans`, `cx-metrics-query`, `cx-alerts`, `cx-dataprime`, `cx-rum`, `cx-telemetry-querying`, `cx-dashboards`, `cx-cost-optimization`, `cx-cases`, `cx-slos`, `cx-data-pipeline`, `cx-platform-admin`, `cx-observability-setup`. See [skills/README.md](https://github.com/coralogix/cx-cli/blob/master/skills/README.md) for per-skill usage.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -268,9 +268,8 @@ authentication type, installed CX skills, selected and configured
 profile counts, and write-operation and `--yes` flags.
 `X-Cx-Cli-Metadata` also contains the same values as compact JSON.
 `X-Cx-Cli-Installed-Skills` is a sorted JSON list of installed skill directory
-names, without filesystem paths. It includes skills bundled with this `cx`
-version and any installed skill whose directory name starts with `cx-` or
-`coralogix-`.
+names, without filesystem paths. It lists only the skills bundled with this
+`cx` version that are found installed.
 `X-Cx-Cli-Is-Agent` is `true` when the master agent-environment detector
 matches, and `false` otherwise.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -39,25 +39,25 @@ Supports Claude Code, Cursor, Codex, OpenCode, and [other supported agents](http
 Install all skills:
 
 ```bash
-npx skills add coralogix/cx-cli
+npx skills add coralogix/cx-cli/skills
 ```
 
 Install specific skills:
 
 ```bash
-npx skills add coralogix/cx-cli --skill query-logs --skill dataprime
+npx skills add coralogix/cx-cli/skills --skill query-logs --skill dataprime
 ```
 
 Install globally (available across all projects):
 
 ```bash
-npx skills add coralogix/cx-cli -g
+npx skills add coralogix/cx-cli/skills -g
 ```
 
 Install for a specific agent:
 
 ```bash
-npx skills add coralogix/cx-cli -a claude-code -g -y
+npx skills add coralogix/cx-cli/skills -a claude-code -g -y
 ```
 
 ## Usage

--- a/skills/cx-cli/SKILL.md
+++ b/skills/cx-cli/SKILL.md
@@ -22,7 +22,7 @@ An update notice always has **two parts** — binary upgrade and skills refresh.
 Commands with `--output toon` append a **standalone trailing JSON line** to stdout:
 
 ```json
-{"_meta":{"update":{"binary":{"current":"0.1.7","latest":"0.2.0","command":"brew upgrade cx"},"skills":{"command":"npx skills add coralogix/cx-cli","docs":"https://github.com/coralogix/cx-cli#install"}}}}
+{"_meta":{"update":{"binary":{"current":"0.1.7","latest":"0.2.0","command":"brew upgrade cx"},"skills":{"command":"npx skills add coralogix/cx-cli/skills","docs":"https://github.com/coralogix/cx-cli#install"}}}}
 ```
 
 Scan the **last line** of stdout for `_meta.update`. When present:
@@ -39,14 +39,14 @@ Scan the **last line** of stdout for `_meta.update`. When present:
 Also scan stderr and stdout for plain-text notices. Binary and skills appear on one line, separated by `|`:
 
 ```
-[cx update] v0.2.0 available (you have 0.1.9) | upgrade: brew upgrade cx | skills: npx skills add coralogix/cx-cli
+[cx update] v0.2.0 available (you have 0.1.9) | upgrade: brew upgrade cx | skills: npx skills add coralogix/cx-cli/skills
 ```
 
 TTY text mode uses two lines with the same `upgrade: ... | skills: ...` pattern:
 
 ```
 cx 0.2.0 is available (you have 0.1.9).
-upgrade: brew upgrade cx | skills: npx skills add coralogix/cx-cli
+upgrade: brew upgrade cx | skills: npx skills add coralogix/cx-cli/skills
 ```
 
 These appear on stderr for text/json mode after normal commands.
@@ -56,7 +56,7 @@ These appear on stderr for text/json mode after normal commands.
 > [Summarize the command result here]
 >
 > ---
-> A newer cx version (X.Y.Z) is available — you have A.B.C. Would you like me to run `<binary upgrade command>` and `npx skills add coralogix/cx-cli` to update?
+> A newer cx version (X.Y.Z) is available — you have A.B.C. Would you like me to run `<binary upgrade command>` and `npx skills add coralogix/cx-cli/skills` to update?
 
 Keep it to one brief closing line. Don't repeat on later commands in the same session.
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod scopes;
 pub mod search_by_value;
 pub mod search_fields;
 pub mod service_catalog;
+pub mod skills;
 pub mod slos;
 pub mod spans;
 pub mod suppression_rules;

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -5,13 +5,13 @@
 //! its own beyond driving the one express question (global vs local scope)
 //! and passing flags through to the installer.
 
+use std::collections::BTreeSet;
 use std::io::IsTerminal;
 use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 use inquire::Select;
-
-use crate::request_metadata::installed_coralogix_skills;
+use serde::Deserialize;
 
 /// The skills source passed to the installer, always fixed.
 pub const SKILLS_SOURCE: &str = "coralogix/cx-cli";
@@ -54,60 +54,131 @@ pub struct InstallOptions {
     pub request: InstallRequest,
 }
 
+/// The decision run_install makes before touching the installer, kept pure
+/// so every branch (including the implied ones only `cx init` reaches) is
+/// unit-testable.
+#[derive(Debug, PartialEq, Eq)]
+enum InstallPlan {
+    Fail(String),
+    Skip {
+        outcome: InstallOutcome,
+        message: String,
+    },
+    Proceed {
+        /// `None` means ask interactively.
+        scope: Option<SkillsScope>,
+        reinstall_note: Option<String>,
+    },
+}
+
+fn plan_install(
+    npx_available: bool,
+    installed: &[String],
+    scope: Option<SkillsScope>,
+    stdin_is_terminal: bool,
+    request: InstallRequest,
+) -> InstallPlan {
+    let explicit = request == InstallRequest::Explicit;
+
+    if !npx_available {
+        if explicit {
+            return InstallPlan::Fail(
+                "Node.js/npx is required to install the cx agent skills.\n\
+                 Install Node.js (https://nodejs.org) and rerun, or skip the skills install."
+                    .to_string(),
+            );
+        }
+        return InstallPlan::Skip {
+            outcome: InstallOutcome::SkippedNoNpx,
+            message: format!(
+                "warning: npx not found - skipping the agent skills install.\n\
+                 The CLI is fully usable without skills. To install them later, \
+                 install Node.js and run:\n  {MANUAL_INSTALL_CMD}"
+            ),
+        };
+    }
+
+    let reinstall_note = if installed.is_empty() {
+        None
+    } else {
+        let summary = installed_summary(installed);
+        if !explicit {
+            return InstallPlan::Skip {
+                outcome: InstallOutcome::AlreadyInstalled,
+                message: format!(
+                    "cx agent skills already installed ({summary}) - skipping.\n\
+                     To update them, run: {MANUAL_INSTALL_CMD}"
+                ),
+            };
+        }
+        Some(format!(
+            "cx agent skills already installed ({summary}) - reinstalling to update."
+        ))
+    };
+
+    if scope.is_none() && !stdin_is_terminal {
+        if explicit {
+            return InstallPlan::Fail("no skills install scope - pass --global or --local".into());
+        }
+        return InstallPlan::Skip {
+            outcome: InstallOutcome::SkippedNoScope,
+            message: format!(
+                "warning: no terminal to ask for the skills install scope - \
+                 skipping the agent skills install.\n\
+                 To install them later, run: {MANUAL_INSTALL_CMD}"
+            ),
+        };
+    }
+
+    InstallPlan::Proceed {
+        scope,
+        reinstall_note,
+    }
+}
+
 /// Express install: at most one question (scope), then a fully
 /// non-interactive `npx skills add` run.
 pub fn run_install(opts: InstallOptions) -> Result<InstallOutcome> {
-    let explicit = opts.request == InstallRequest::Explicit;
+    let npx_available = npx_available();
+    let installed = if npx_available {
+        installed_cx_skills()
+    } else {
+        Vec::new()
+    };
+    let plan = plan_install(
+        npx_available,
+        &installed,
+        opts.scope,
+        std::io::stdin().is_terminal(),
+        opts.request,
+    );
 
-    if !npx_available() {
-        if explicit {
-            bail!(
-                "Node.js/npx is required to install the cx agent skills.\n\
-                 Install Node.js (https://nodejs.org) and rerun, or skip the skills install."
-            );
-        }
-        eprintln!(
-            "warning: npx not found - skipping the agent skills install.\n\
-             The CLI is fully usable without skills. To install them later, \
-             install Node.js and run:\n  {MANUAL_INSTALL_CMD}"
-        );
-        return Ok(InstallOutcome::SkippedNoNpx);
-    }
-
-    let installed = installed_coralogix_skills();
-    if !installed.is_empty() {
-        let summary = installed_summary(&installed);
-        if explicit {
-            println!("cx agent skills already installed ({summary}) - reinstalling to update.");
-        } else {
-            println!(
-                "cx agent skills already installed ({summary}) - skipping.\n\
-                 To update them, run: {MANUAL_INSTALL_CMD}"
-            );
-            return Ok(InstallOutcome::AlreadyInstalled);
-        }
-    }
-
-    let scope = match opts.scope {
-        Some(scope) => scope,
-        None => {
-            if !std::io::stdin().is_terminal() {
-                if explicit {
-                    bail!("no skills install scope - pass --global or --local");
-                }
-                eprintln!(
-                    "warning: no terminal to ask for the skills install scope - \
-                     skipping the agent skills install.\n\
-                     To install them later, run: {MANUAL_INSTALL_CMD}"
-                );
-                return Ok(InstallOutcome::SkippedNoScope);
+    let (scope, reinstall_note) = match plan {
+        InstallPlan::Fail(message) => bail!(message),
+        InstallPlan::Skip { outcome, message } => {
+            if outcome == InstallOutcome::AlreadyInstalled {
+                println!("{message}");
+            } else {
+                eprintln!("{message}");
             }
-            ask_scope()?
+            return Ok(outcome);
         }
+        InstallPlan::Proceed {
+            scope,
+            reinstall_note,
+        } => (scope, reinstall_note),
+    };
+
+    if let Some(note) = reinstall_note {
+        println!("{note}");
+    }
+    let scope = match scope {
+        Some(scope) => scope,
+        None => ask_scope()?,
     };
 
     let args = build_install_args(scope, &opts.agents);
-    println!("Installing cx agent skills: npx {}", args.join(" "));
+    println!("Installing cx agent skills: npx {}", display_args(&args));
 
     let status = Command::new(npx_program())
         .args(&args)
@@ -161,6 +232,47 @@ fn npx_available() -> bool {
         .unwrap_or(false)
 }
 
+/// One entry of `skills ls --json` output; extra fields are ignored.
+#[derive(Deserialize)]
+struct LsSkill {
+    name: String,
+    #[serde(default)]
+    source: Option<String>,
+}
+
+/// cx skills already installed, according to the installer itself
+/// (`npx skills ls --json`, project and global scope). A skill counts as
+/// ours when its lock-file source is `coralogix/cx-cli` or its name carries
+/// the cx prefix. Any failure (old installer without `--json`, unparseable
+/// output) counts as nothing installed, so the install proceeds.
+fn installed_cx_skills() -> Vec<String> {
+    let mut names = BTreeSet::new();
+    for global in [false, true] {
+        let mut cmd = Command::new(npx_program());
+        cmd.args(["-y", "skills", "ls"]);
+        if global {
+            cmd.arg("-g");
+        }
+        cmd.arg("--json");
+        let Ok(output) = cmd.output() else { continue };
+        if !output.status.success() {
+            continue;
+        }
+        let Ok(skills) = serde_json::from_slice::<Vec<LsSkill>>(&output.stdout) else {
+            continue;
+        };
+        for skill in skills {
+            if skill.source.as_deref() == Some(SKILLS_SOURCE)
+                || skill.name.starts_with("cx-")
+                || skill.name.starts_with("coralogix-")
+            {
+                names.insert(skill.name);
+            }
+        }
+    }
+    names.into_iter().collect()
+}
+
 /// Arguments for the fully non-interactive express install.
 ///
 /// The leading `-y` is npx's own auto-approve (first-run package download
@@ -183,6 +295,25 @@ fn build_install_args(scope: SkillsScope, agents: &[String]) -> Vec<String> {
         args.extend(agents.iter().cloned());
     }
     args
+}
+
+/// Shell-quoted rendering of the args, safe to copy back into a shell
+/// (`*` would otherwise glob-expand).
+fn display_args(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| {
+            let safe = !arg.is_empty()
+                && arg
+                    .chars()
+                    .all(|c| c.is_ascii_alphanumeric() || "-_./:@=".contains(c));
+            if safe {
+                arg.clone()
+            } else {
+                format!("'{arg}'")
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// e.g. "3 skills: cx-alerts, cx-dashboards, ..."
@@ -208,7 +339,6 @@ fn ask_scope() -> Result<SkillsScope> {
     .with_help_message(
         "Skills teach coding agents (Claude Code, Cursor, Codex, ...) how to use cx.",
     )
-    .with_starting_cursor(0)
     .prompt()?;
     Ok(if chosen == GLOBAL {
         SkillsScope::Global
@@ -273,6 +403,15 @@ mod tests {
     }
 
     #[test]
+    fn displayed_command_is_shell_safe() {
+        let args = build_install_args(SkillsScope::Global, &[]);
+        assert_eq!(
+            display_args(&args),
+            "-y skills add coralogix/cx-cli --skill '*' -y -g"
+        );
+    }
+
+    #[test]
     fn summary_truncates_long_skill_lists() {
         let skills: Vec<String> = ["cx-a", "cx-b", "cx-c", "cx-d"]
             .iter()
@@ -283,5 +422,137 @@ mod tests {
             "4 skills: cx-a, cx-b, cx-c, ..."
         );
         assert_eq!(installed_summary(&skills[..2]), "2 skills: cx-a, cx-b");
+    }
+
+    #[test]
+    fn ls_json_parses_and_ignores_extra_fields() {
+        let json = r#"[
+            {"name": "cx-alerts", "path": "/p", "scope": "global",
+             "agents": ["Claude Code"], "source": "coralogix/cx-cli",
+             "sourceUrl": null, "sourceType": "github"},
+            {"name": "other-skill", "source": "someone/else"},
+            {"name": "local-skill", "source": null}
+        ]"#;
+        let skills: Vec<LsSkill> = serde_json::from_str(json).unwrap();
+        let ours: Vec<&str> = skills
+            .iter()
+            .filter(|s| s.source.as_deref() == Some(SKILLS_SOURCE) || s.name.starts_with("cx-"))
+            .map(|s| s.name.as_str())
+            .collect();
+        assert_eq!(ours, ["cx-alerts"]);
+    }
+
+    // ── plan_install: every branch, including the implied ones `cx init` uses ──
+
+    const NO_SKILLS: &[String] = &[];
+
+    fn one_skill() -> Vec<String> {
+        vec!["cx-alerts".to_string()]
+    }
+
+    #[test]
+    fn plan_no_npx_explicit_fails_actionably() {
+        let plan = plan_install(false, NO_SKILLS, None, true, InstallRequest::Explicit);
+        let InstallPlan::Fail(message) = plan else {
+            panic!("expected Fail, got {plan:?}");
+        };
+        assert!(message.contains("Node.js"));
+    }
+
+    #[test]
+    fn plan_no_npx_implied_skips_with_manual_command() {
+        let plan = plan_install(false, NO_SKILLS, None, true, InstallRequest::Implied);
+        let InstallPlan::Skip { outcome, message } = plan else {
+            panic!("expected Skip, got {plan:?}");
+        };
+        assert_eq!(outcome, InstallOutcome::SkippedNoNpx);
+        assert!(message.contains(MANUAL_INSTALL_CMD));
+    }
+
+    #[test]
+    fn plan_already_installed_implied_skips_with_update_hint() {
+        let plan = plan_install(
+            true,
+            &one_skill(),
+            Some(SkillsScope::Global),
+            true,
+            InstallRequest::Implied,
+        );
+        let InstallPlan::Skip { outcome, message } = plan else {
+            panic!("expected Skip, got {plan:?}");
+        };
+        assert_eq!(outcome, InstallOutcome::AlreadyInstalled);
+        assert!(message.contains("cx-alerts") && message.contains(MANUAL_INSTALL_CMD));
+    }
+
+    #[test]
+    fn plan_already_installed_explicit_proceeds_with_note() {
+        let plan = plan_install(
+            true,
+            &one_skill(),
+            Some(SkillsScope::Global),
+            true,
+            InstallRequest::Explicit,
+        );
+        assert_eq!(
+            plan,
+            InstallPlan::Proceed {
+                scope: Some(SkillsScope::Global),
+                reinstall_note: Some(
+                    "cx agent skills already installed (1 skills: cx-alerts) \
+                     - reinstalling to update."
+                        .to_string()
+                ),
+            }
+        );
+    }
+
+    #[test]
+    fn plan_no_scope_no_tty_explicit_fails_naming_the_flags() {
+        let plan = plan_install(true, NO_SKILLS, None, false, InstallRequest::Explicit);
+        let InstallPlan::Fail(message) = plan else {
+            panic!("expected Fail, got {plan:?}");
+        };
+        assert!(message.contains("--global") && message.contains("--local"));
+    }
+
+    #[test]
+    fn plan_no_scope_no_tty_implied_skips() {
+        let plan = plan_install(true, NO_SKILLS, None, false, InstallRequest::Implied);
+        let InstallPlan::Skip { outcome, message } = plan else {
+            panic!("expected Skip, got {plan:?}");
+        };
+        assert_eq!(outcome, InstallOutcome::SkippedNoScope);
+        assert!(message.contains(MANUAL_INSTALL_CMD));
+    }
+
+    #[test]
+    fn plan_no_scope_with_tty_asks() {
+        let plan = plan_install(true, NO_SKILLS, None, true, InstallRequest::Implied);
+        assert_eq!(
+            plan,
+            InstallPlan::Proceed {
+                scope: None,
+                reinstall_note: None,
+            }
+        );
+    }
+
+    #[test]
+    fn plan_scope_flag_proceeds_without_asking() {
+        let plan = plan_install(
+            true,
+            NO_SKILLS,
+            Some(SkillsScope::Local),
+            false,
+            InstallRequest::Explicit,
+        );
+        assert_eq!(
+            plan,
+            InstallPlan::Proceed {
+                scope: Some(SkillsScope::Local),
+                reinstall_note: None,
+            }
+        );
     }
 }

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -1,0 +1,287 @@
+//! Skills install step: shells out to the vercel-labs `skills` npx installer
+//! to install the cx agent skills bundle (`coralogix/cx-cli`).
+//!
+//! `cx init` (FORGE-658) invokes this step; it owns no skill/agent logic of
+//! its own beyond driving the one express question (global vs local scope)
+//! and passing flags through to the installer.
+
+use std::io::IsTerminal;
+use std::process::Command;
+
+use anyhow::{bail, Context, Result};
+use inquire::Select;
+
+use crate::request_metadata::installed_coralogix_skills;
+
+/// The skills source passed to the installer, always fixed.
+pub const SKILLS_SOURCE: &str = "coralogix/cx-cli";
+
+/// The command a user can run by hand when cx skips or fails the install.
+const MANUAL_INSTALL_CMD: &str = "npx skills add coralogix/cx-cli";
+
+/// Where the installer puts skills: the user's home (`~/`) or the project (`./`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SkillsScope {
+    Global,
+    Local,
+}
+
+/// How the skills step was requested. Decides how obstacles are handled:
+/// an implied run (the `cx init` default) skips with guidance, an explicit
+/// run (`--skills` / `cx skills install`) fails with an actionable error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallRequest {
+    Implied,
+    Explicit,
+}
+
+/// What the install step ended up doing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstallOutcome {
+    Installed,
+    AlreadyInstalled,
+    /// npx is unavailable; the manual command was printed instead.
+    SkippedNoNpx,
+    /// Non-interactive implied run with no `--global`/`--local`; skipped.
+    SkippedNoScope,
+}
+
+pub struct InstallOptions {
+    /// Scope from `--global`/`--local`; `None` asks interactively.
+    pub scope: Option<SkillsScope>,
+    /// Agents passed through to the installer's `-a` (overrides auto-detect).
+    pub agents: Vec<String>,
+    pub request: InstallRequest,
+}
+
+/// Express install: at most one question (scope), then a fully
+/// non-interactive `npx skills add` run.
+pub fn run_install(opts: InstallOptions) -> Result<InstallOutcome> {
+    let explicit = opts.request == InstallRequest::Explicit;
+
+    if !npx_available() {
+        if explicit {
+            bail!(
+                "Node.js/npx is required to install the cx agent skills.\n\
+                 Install Node.js (https://nodejs.org) and rerun, or skip the skills install."
+            );
+        }
+        eprintln!(
+            "warning: npx not found - skipping the agent skills install.\n\
+             The CLI is fully usable without skills. To install them later, \
+             install Node.js and run:\n  {MANUAL_INSTALL_CMD}"
+        );
+        return Ok(InstallOutcome::SkippedNoNpx);
+    }
+
+    let installed = installed_coralogix_skills();
+    if !installed.is_empty() {
+        let summary = installed_summary(&installed);
+        if explicit {
+            println!("cx agent skills already installed ({summary}) - reinstalling to update.");
+        } else {
+            println!(
+                "cx agent skills already installed ({summary}) - skipping.\n\
+                 To update them, run: {MANUAL_INSTALL_CMD}"
+            );
+            return Ok(InstallOutcome::AlreadyInstalled);
+        }
+    }
+
+    let scope = match opts.scope {
+        Some(scope) => scope,
+        None => {
+            if !std::io::stdin().is_terminal() {
+                if explicit {
+                    bail!("no skills install scope - pass --global or --local");
+                }
+                eprintln!(
+                    "warning: no terminal to ask for the skills install scope - \
+                     skipping the agent skills install.\n\
+                     To install them later, run: {MANUAL_INSTALL_CMD}"
+                );
+                return Ok(InstallOutcome::SkippedNoScope);
+            }
+            ask_scope()?
+        }
+    };
+
+    let args = build_install_args(scope, &opts.agents);
+    println!("Installing cx agent skills: npx {}", args.join(" "));
+
+    let status = Command::new(npx_program())
+        .args(&args)
+        .status()
+        .context("failed to run npx")?;
+    if !status.success() {
+        bail!(
+            "skills installer exited with {status}.\n\
+             You can retry manually with: {MANUAL_INSTALL_CMD}"
+        );
+    }
+
+    println!("cx agent skills installed.");
+    Ok(InstallOutcome::Installed)
+}
+
+/// Advanced install: run the raw installer with no flags and let the user
+/// walk its full interactive flow (skill/agent selection, scope, method).
+pub fn run_advanced_install() -> Result<()> {
+    println!("Running the skills installer interactively: {MANUAL_INSTALL_CMD}");
+    let status = Command::new(npx_program())
+        .args(["skills", "add", SKILLS_SOURCE])
+        .status()
+        .context(
+            "failed to run npx - Node.js is required for the skills install \
+             (https://nodejs.org)",
+        )?;
+    if !status.success() {
+        bail!("skills installer exited with {status}");
+    }
+    Ok(())
+}
+
+// ── Building blocks ───────────────────────────────────────────────────────────
+
+/// `npx` resolves through a `.cmd` shim on Windows; `Command` needs the
+/// real file name there.
+fn npx_program() -> &'static str {
+    if cfg!(windows) {
+        "npx.cmd"
+    } else {
+        "npx"
+    }
+}
+
+fn npx_available() -> bool {
+    Command::new(npx_program())
+        .arg("--version")
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+/// Arguments for the fully non-interactive express install.
+///
+/// The leading `-y` is npx's own auto-approve (first-run package download
+/// prompt); the trailing `-y` is the installer's skip-all-confirmations.
+fn build_install_args(scope: SkillsScope, agents: &[String]) -> Vec<String> {
+    let mut args: Vec<String> = vec![
+        "-y".into(),
+        "skills".into(),
+        "add".into(),
+        SKILLS_SOURCE.into(),
+        "--skill".into(),
+        "*".into(),
+        "-y".into(),
+    ];
+    if scope == SkillsScope::Global {
+        args.push("-g".into());
+    }
+    if !agents.is_empty() {
+        args.push("-a".into());
+        args.extend(agents.iter().cloned());
+    }
+    args
+}
+
+/// e.g. "3 skills: cx-alerts, cx-dashboards, ..."
+fn installed_summary(installed: &[String]) -> String {
+    const SHOWN: usize = 3;
+    let names = installed
+        .iter()
+        .take(SHOWN)
+        .map(String::as_str)
+        .collect::<Vec<_>>()
+        .join(", ");
+    let suffix = if installed.len() > SHOWN { ", ..." } else { "" };
+    format!("{} skills: {names}{suffix}", installed.len())
+}
+
+fn ask_scope() -> Result<SkillsScope> {
+    const GLOBAL: &str = "Global (~/) - available in every project";
+    const LOCAL: &str = "Local (./) - this project only";
+    let chosen = Select::new(
+        "Where should the agent skills be installed?",
+        vec![GLOBAL, LOCAL],
+    )
+    .with_help_message(
+        "Skills teach coding agents (Claude Code, Cursor, Codex, ...) how to use cx.",
+    )
+    .with_starting_cursor(0)
+    .prompt()?;
+    Ok(if chosen == GLOBAL {
+        SkillsScope::Global
+    } else {
+        SkillsScope::Local
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn express_args_local_scope() {
+        let args = build_install_args(SkillsScope::Local, &[]);
+        assert_eq!(
+            args,
+            ["-y", "skills", "add", SKILLS_SOURCE, "--skill", "*", "-y"]
+        );
+    }
+
+    #[test]
+    fn express_args_global_scope() {
+        let args = build_install_args(SkillsScope::Global, &[]);
+        assert_eq!(
+            args,
+            [
+                "-y",
+                "skills",
+                "add",
+                SKILLS_SOURCE,
+                "--skill",
+                "*",
+                "-y",
+                "-g"
+            ]
+        );
+    }
+
+    #[test]
+    fn express_args_pass_agents_through() {
+        let args = build_install_args(
+            SkillsScope::Global,
+            &["claude-code".to_string(), "cursor".to_string()],
+        );
+        assert_eq!(
+            args,
+            [
+                "-y",
+                "skills",
+                "add",
+                SKILLS_SOURCE,
+                "--skill",
+                "*",
+                "-y",
+                "-g",
+                "-a",
+                "claude-code",
+                "cursor"
+            ]
+        );
+    }
+
+    #[test]
+    fn summary_truncates_long_skill_lists() {
+        let skills: Vec<String> = ["cx-a", "cx-b", "cx-c", "cx-d"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        assert_eq!(
+            installed_summary(&skills),
+            "4 skills: cx-a, cx-b, cx-c, ..."
+        );
+        assert_eq!(installed_summary(&skills[..2]), "2 skills: cx-a, cx-b");
+    }
+}

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -1,5 +1,5 @@
 //! Skills install step: shells out to the vercel-labs `skills` npx installer
-//! to install the cx agent skills bundle (`coralogix/cx-cli`).
+//! to install the cx agent skills bundle (`coralogix/cx-cli/skills`).
 //!
 //! Owns no skill/agent logic of its own beyond driving the one scope
 //! question (global vs local) and passing flags through to the installer.
@@ -12,11 +12,20 @@ use anyhow::{bail, Context, Result};
 use inquire::Select;
 use serde::Deserialize;
 
-/// The skills source passed to the installer, always fixed.
-pub const SKILLS_SOURCE: &str = "coralogix/cx-cli";
+/// The source passed to `skills add`. Points at the repo's user-facing
+/// `skills/` subdirectory, not the repo root: `--skill '*'` installs every
+/// `SKILL.md` the installer discovers, and the repo root also carries the
+/// contributor-only dev skills under `.claude/skills/` (add-command,
+/// run-tests, ...) which must never reach end users.
+pub const SKILLS_SOURCE: &str = "coralogix/cx-cli/skills";
 
-/// The command a user can run by hand when cx skips or fails the install.
-const MANUAL_INSTALL_CMD: &str = "npx skills add coralogix/cx-cli";
+/// The source the installer records in its lock file for skills installed from
+/// this repo. It stores the repo slug without the subdir, so already-installed
+/// detection matches on this rather than [`SKILLS_SOURCE`].
+const INSTALLED_SOURCE: &str = "coralogix/cx-cli";
+
+/// The command a user can run by hand when cx fails the install.
+const MANUAL_INSTALL_CMD: &str = "npx skills add coralogix/cx-cli/skills";
 
 /// Where the installer puts skills: the user's home (`~/`) or the project (`./`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -25,155 +34,63 @@ pub enum SkillsScope {
     Local,
 }
 
-/// How the skills step was requested. Decides how obstacles are handled:
-/// an implied run skips with guidance, an explicit run
-/// (`cx skills install`) fails with an actionable error.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InstallRequest {
-    Implied,
-    Explicit,
-}
-
-/// What the install step ended up doing.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum InstallOutcome {
-    Installed,
-    AlreadyInstalled,
-    /// npx is unavailable; the manual command was printed instead.
-    SkippedNoNpx,
-    /// Non-interactive implied run with no `--global`/`--local`; skipped.
-    SkippedNoScope,
-}
-
 pub struct InstallOptions {
     /// Scope from `--global`/`--local`; `None` asks interactively.
     pub scope: Option<SkillsScope>,
     /// Agents passed through to the installer's `-a` (overrides auto-detect).
     pub agents: Vec<String>,
-    pub request: InstallRequest,
 }
 
-/// The decision run_install makes before touching the installer, kept pure
-/// so every branch is unit-testable.
+/// The pre-flight gate run_install evaluates before touching the installer,
+/// kept pure so both failure branches are unit-testable without a terminal.
 #[derive(Debug, PartialEq, Eq)]
-enum InstallPlan {
+enum Preflight {
     Fail(String),
-    Skip {
-        outcome: InstallOutcome,
-        message: String,
-    },
+    /// `scope` is `None` when it still needs to be asked interactively.
     Proceed {
-        /// `None` means ask interactively.
         scope: Option<SkillsScope>,
-        reinstall_note: Option<String>,
     },
 }
 
-fn plan_install(
+fn preflight(
     npx_available: bool,
-    installed: &[String],
     scope: Option<SkillsScope>,
     stdin_is_terminal: bool,
-    request: InstallRequest,
-) -> InstallPlan {
-    let explicit = request == InstallRequest::Explicit;
-
+) -> Preflight {
     if !npx_available {
-        if explicit {
-            return InstallPlan::Fail(
-                "Node.js/npx is required to install the cx agent skills.\n\
-                 Install Node.js (https://nodejs.org) and rerun, or skip the skills install."
-                    .to_string(),
-            );
-        }
-        return InstallPlan::Skip {
-            outcome: InstallOutcome::SkippedNoNpx,
-            message: format!(
-                "warning: npx not found - skipping the agent skills install.\n\
-                 The CLI is fully usable without skills. To install them later, \
-                 install Node.js and run:\n  {MANUAL_INSTALL_CMD}"
-            ),
-        };
+        return Preflight::Fail(
+            "Node.js/npx is required to install the cx agent skills.\n\
+             Install Node.js (https://nodejs.org) and rerun, or skip the skills install."
+                .to_string(),
+        );
     }
-
-    let reinstall_note = if installed.is_empty() {
-        None
-    } else {
-        let summary = installed_summary(installed);
-        if !explicit {
-            return InstallPlan::Skip {
-                outcome: InstallOutcome::AlreadyInstalled,
-                message: format!(
-                    "cx agent skills already installed ({summary}) - skipping.\n\
-                     To update them, run: {MANUAL_INSTALL_CMD}"
-                ),
-            };
-        }
-        Some(format!(
-            "cx agent skills already installed ({summary}) - reinstalling to update."
-        ))
-    };
-
     if scope.is_none() && !stdin_is_terminal {
-        if explicit {
-            return InstallPlan::Fail("no skills install scope - pass --global or --local".into());
-        }
-        return InstallPlan::Skip {
-            outcome: InstallOutcome::SkippedNoScope,
-            message: format!(
-                "warning: no terminal to ask for the skills install scope - \
-                 skipping the agent skills install.\n\
-                 To install them later, run: {MANUAL_INSTALL_CMD}"
-            ),
-        };
+        return Preflight::Fail("no skills install scope - pass --global or --local".into());
     }
-
-    InstallPlan::Proceed {
-        scope,
-        reinstall_note,
-    }
+    Preflight::Proceed { scope }
 }
 
 /// Install with at most one question (scope), then a fully
 /// non-interactive `npx skills add` run.
-pub fn run_install(opts: InstallOptions) -> Result<InstallOutcome> {
-    let npx_available = npx_available();
-    let installed = if npx_available {
-        installed_cx_skills()
-    } else {
-        Vec::new()
-    };
-    let plan = plan_install(
-        npx_available,
-        &installed,
-        opts.scope,
-        std::io::stdin().is_terminal(),
-        opts.request,
-    );
-
-    let (scope, reinstall_note) = match plan {
-        InstallPlan::Fail(message) => bail!(message),
-        InstallPlan::Skip { outcome, message } => {
-            if outcome == InstallOutcome::AlreadyInstalled {
-                println!("{message}");
-            } else {
-                eprintln!("{message}");
-            }
-            return Ok(outcome);
-        }
-        InstallPlan::Proceed {
-            scope,
-            reinstall_note,
-        } => (scope, reinstall_note),
+pub fn run_install(opts: InstallOptions) -> Result<()> {
+    let scope = match preflight(npx_available(), opts.scope, std::io::stdin().is_terminal()) {
+        Preflight::Fail(message) => bail!(message),
+        Preflight::Proceed { scope } => match scope {
+            Some(scope) => scope,
+            None => ask_scope()?,
+        },
     };
 
-    if let Some(note) = reinstall_note {
-        println!("{note}");
+    // Informational only: an explicit install reinstalls to update. Detection
+    // is scoped to the scope we're about to install into, so skills present in
+    // the other scope don't muddy the message.
+    let installed = installed_cx_skills(scope);
+    if !installed.is_empty() {
+        println!(
+            "cx agent skills already installed ({}) - reinstalling to update.",
+            installed_summary(&installed)
+        );
     }
-    let scope = match scope {
-        Some(scope) => scope,
-        None => ask_scope()?,
-    };
 
     let args = build_install_args(scope, &opts.agents);
     println!("Installing cx agent skills: npx {}", display_args(&args));
@@ -190,7 +107,7 @@ pub fn run_install(opts: InstallOptions) -> Result<InstallOutcome> {
     }
 
     println!("cx agent skills installed.");
-    Ok(InstallOutcome::Installed)
+    Ok(())
 }
 
 /// Advanced install: run the raw installer with no flags and let the user
@@ -238,37 +155,36 @@ struct LsSkill {
     source: Option<String>,
 }
 
-/// cx skills already installed, according to the installer itself
-/// (`npx skills ls --json`, project and global scope). A skill counts as
-/// ours when its lock-file source is `coralogix/cx-cli` or its name carries
-/// the cx prefix. Any failure (old installer without `--json`, unparseable
-/// output) counts as nothing installed, so the install proceeds.
-fn installed_cx_skills() -> Vec<String> {
-    let mut names = BTreeSet::new();
-    for global in [false, true] {
-        let mut cmd = Command::new(npx_program());
-        cmd.args(["-y", "skills", "ls"]);
-        if global {
-            cmd.arg("-g");
-        }
-        cmd.arg("--json");
-        let Ok(output) = cmd.output() else { continue };
-        if !output.status.success() {
-            continue;
-        }
-        let Ok(skills) = serde_json::from_slice::<Vec<LsSkill>>(&output.stdout) else {
-            continue;
-        };
-        for skill in skills {
-            if skill.source.as_deref() == Some(SKILLS_SOURCE)
-                || skill.name.starts_with("cx-")
-                || skill.name.starts_with("coralogix-")
-            {
-                names.insert(skill.name);
-            }
-        }
+/// cx skills already installed in `scope`, according to the installer itself
+/// (`npx skills ls [-g] --json`). A skill counts as ours when its lock-file
+/// source is [`INSTALLED_SOURCE`]. Any failure (old installer without `--json`,
+/// unparseable output) counts as nothing installed, so the install proceeds.
+///
+/// Copy installs (`--copy`) drop the lock-file source and so are not detected;
+/// the installer's default is symlink, which preserves it.
+fn installed_cx_skills(scope: SkillsScope) -> Vec<String> {
+    let mut cmd = Command::new(npx_program());
+    cmd.args(["-y", "skills", "ls"]);
+    if scope == SkillsScope::Global {
+        cmd.arg("-g");
     }
-    names.into_iter().collect()
+    cmd.arg("--json");
+    let Ok(output) = cmd.output() else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let Ok(skills) = serde_json::from_slice::<Vec<LsSkill>>(&output.stdout) else {
+        return Vec::new();
+    };
+    skills
+        .into_iter()
+        .filter(|skill| skill.source.as_deref() == Some(INSTALLED_SOURCE))
+        .map(|skill| skill.name)
+        .collect::<BTreeSet<_>>()
+        .into_iter()
+        .collect()
 }
 
 /// Arguments for the fully non-interactive install.
@@ -405,7 +321,7 @@ mod tests {
         let args = build_install_args(SkillsScope::Global, &[]);
         assert_eq!(
             display_args(&args),
-            "-y skills add coralogix/cx-cli --skill '*' -y -g"
+            "-y skills add coralogix/cx-cli/skills --skill '*' -y -g"
         );
     }
 
@@ -423,133 +339,57 @@ mod tests {
     }
 
     #[test]
-    fn ls_json_parses_and_ignores_extra_fields() {
+    fn ls_json_matches_only_our_source_ignoring_extra_fields() {
+        // Our skills carry the repo source; a same-named skill from another
+        // source and a copy-installed skill (null source) are not ours.
         let json = r#"[
             {"name": "cx-alerts", "path": "/p", "scope": "global",
              "agents": ["Claude Code"], "source": "coralogix/cx-cli",
              "sourceUrl": null, "sourceType": "github"},
-            {"name": "other-skill", "source": "someone/else"},
-            {"name": "local-skill", "source": null}
+            {"name": "cx-other", "source": "someone/else"},
+            {"name": "cx-copied", "source": null}
         ]"#;
         let skills: Vec<LsSkill> = serde_json::from_str(json).unwrap();
         let ours: Vec<&str> = skills
             .iter()
-            .filter(|s| s.source.as_deref() == Some(SKILLS_SOURCE) || s.name.starts_with("cx-"))
+            .filter(|s| s.source.as_deref() == Some(INSTALLED_SOURCE))
             .map(|s| s.name.as_str())
             .collect();
         assert_eq!(ours, ["cx-alerts"]);
     }
 
-    // ── plan_install: every branch, including the implied ones ────────────────
-
-    const NO_SKILLS: &[String] = &[];
-
-    fn one_skill() -> Vec<String> {
-        vec!["cx-alerts".to_string()]
-    }
+    // ── preflight: both failure branches and the two proceed branches ─────────
 
     #[test]
-    fn plan_no_npx_explicit_fails_actionably() {
-        let plan = plan_install(false, NO_SKILLS, None, true, InstallRequest::Explicit);
-        let InstallPlan::Fail(message) = plan else {
-            panic!("expected Fail, got {plan:?}");
+    fn preflight_no_npx_fails_actionably() {
+        let Preflight::Fail(message) = preflight(false, None, true) else {
+            panic!("expected Fail");
         };
         assert!(message.contains("Node.js"));
     }
 
     #[test]
-    fn plan_no_npx_implied_skips_with_manual_command() {
-        let plan = plan_install(false, NO_SKILLS, None, true, InstallRequest::Implied);
-        let InstallPlan::Skip { outcome, message } = plan else {
-            panic!("expected Skip, got {plan:?}");
-        };
-        assert_eq!(outcome, InstallOutcome::SkippedNoNpx);
-        assert!(message.contains(MANUAL_INSTALL_CMD));
-    }
-
-    #[test]
-    fn plan_already_installed_implied_skips_with_update_hint() {
-        let plan = plan_install(
-            true,
-            &one_skill(),
-            Some(SkillsScope::Global),
-            true,
-            InstallRequest::Implied,
-        );
-        let InstallPlan::Skip { outcome, message } = plan else {
-            panic!("expected Skip, got {plan:?}");
-        };
-        assert_eq!(outcome, InstallOutcome::AlreadyInstalled);
-        assert!(message.contains("cx-alerts") && message.contains(MANUAL_INSTALL_CMD));
-    }
-
-    #[test]
-    fn plan_already_installed_explicit_proceeds_with_note() {
-        let plan = plan_install(
-            true,
-            &one_skill(),
-            Some(SkillsScope::Global),
-            true,
-            InstallRequest::Explicit,
-        );
-        assert_eq!(
-            plan,
-            InstallPlan::Proceed {
-                scope: Some(SkillsScope::Global),
-                reinstall_note: Some(
-                    "cx agent skills already installed (1 skills: cx-alerts) \
-                     - reinstalling to update."
-                        .to_string()
-                ),
-            }
-        );
-    }
-
-    #[test]
-    fn plan_no_scope_no_tty_explicit_fails_naming_the_flags() {
-        let plan = plan_install(true, NO_SKILLS, None, false, InstallRequest::Explicit);
-        let InstallPlan::Fail(message) = plan else {
-            panic!("expected Fail, got {plan:?}");
+    fn preflight_no_scope_no_tty_fails_naming_the_flags() {
+        let Preflight::Fail(message) = preflight(true, None, false) else {
+            panic!("expected Fail");
         };
         assert!(message.contains("--global") && message.contains("--local"));
     }
 
     #[test]
-    fn plan_no_scope_no_tty_implied_skips() {
-        let plan = plan_install(true, NO_SKILLS, None, false, InstallRequest::Implied);
-        let InstallPlan::Skip { outcome, message } = plan else {
-            panic!("expected Skip, got {plan:?}");
-        };
-        assert_eq!(outcome, InstallOutcome::SkippedNoScope);
-        assert!(message.contains(MANUAL_INSTALL_CMD));
-    }
-
-    #[test]
-    fn plan_no_scope_with_tty_asks() {
-        let plan = plan_install(true, NO_SKILLS, None, true, InstallRequest::Implied);
+    fn preflight_no_scope_with_tty_asks() {
         assert_eq!(
-            plan,
-            InstallPlan::Proceed {
-                scope: None,
-                reinstall_note: None,
-            }
+            preflight(true, None, true),
+            Preflight::Proceed { scope: None }
         );
     }
 
     #[test]
-    fn plan_scope_flag_proceeds_without_asking() {
-        let plan = plan_install(
-            true,
-            NO_SKILLS,
-            Some(SkillsScope::Local),
-            false,
-            InstallRequest::Explicit,
-        );
+    fn preflight_scope_flag_proceeds_without_asking() {
         assert_eq!(
-            plan,
-            InstallPlan::Proceed {
-                scope: Some(SkillsScope::Local),
-                reinstall_note: None,
+            preflight(true, Some(SkillsScope::Local), false),
+            Preflight::Proceed {
+                scope: Some(SkillsScope::Local)
             }
         );
     }

--- a/src/commands/skills/mod.rs
+++ b/src/commands/skills/mod.rs
@@ -1,9 +1,8 @@
 //! Skills install step: shells out to the vercel-labs `skills` npx installer
 //! to install the cx agent skills bundle (`coralogix/cx-cli`).
 //!
-//! `cx init` (FORGE-658) invokes this step; it owns no skill/agent logic of
-//! its own beyond driving the one express question (global vs local scope)
-//! and passing flags through to the installer.
+//! Owns no skill/agent logic of its own beyond driving the one scope
+//! question (global vs local) and passing flags through to the installer.
 
 use std::collections::BTreeSet;
 use std::io::IsTerminal;
@@ -27,8 +26,8 @@ pub enum SkillsScope {
 }
 
 /// How the skills step was requested. Decides how obstacles are handled:
-/// an implied run (the `cx init` default) skips with guidance, an explicit
-/// run (`--skills` / `cx skills install`) fails with an actionable error.
+/// an implied run skips with guidance, an explicit run
+/// (`cx skills install`) fails with an actionable error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallRequest {
     Implied,
@@ -55,8 +54,7 @@ pub struct InstallOptions {
 }
 
 /// The decision run_install makes before touching the installer, kept pure
-/// so every branch (including the implied ones only `cx init` reaches) is
-/// unit-testable.
+/// so every branch is unit-testable.
 #[derive(Debug, PartialEq, Eq)]
 enum InstallPlan {
     Fail(String),
@@ -136,7 +134,7 @@ fn plan_install(
     }
 }
 
-/// Express install: at most one question (scope), then a fully
+/// Install with at most one question (scope), then a fully
 /// non-interactive `npx skills add` run.
 pub fn run_install(opts: InstallOptions) -> Result<InstallOutcome> {
     let npx_available = npx_available();
@@ -273,7 +271,7 @@ fn installed_cx_skills() -> Vec<String> {
     names.into_iter().collect()
 }
 
-/// Arguments for the fully non-interactive express install.
+/// Arguments for the fully non-interactive install.
 ///
 /// The leading `-y` is npx's own auto-approve (first-run package download
 /// prompt); the trailing `-y` is the installer's skip-all-confirmations.
@@ -352,7 +350,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn express_args_local_scope() {
+    fn install_args_local_scope() {
         let args = build_install_args(SkillsScope::Local, &[]);
         assert_eq!(
             args,
@@ -361,7 +359,7 @@ mod tests {
     }
 
     #[test]
-    fn express_args_global_scope() {
+    fn install_args_global_scope() {
         let args = build_install_args(SkillsScope::Global, &[]);
         assert_eq!(
             args,
@@ -379,7 +377,7 @@ mod tests {
     }
 
     #[test]
-    fn express_args_pass_agents_through() {
+    fn install_args_pass_agents_through() {
         let args = build_install_args(
             SkillsScope::Global,
             &["claude-code".to_string(), "cursor".to_string()],
@@ -442,7 +440,7 @@ mod tests {
         assert_eq!(ours, ["cx-alerts"]);
     }
 
-    // ── plan_install: every branch, including the implied ones `cx init` uses ──
+    // ── plan_install: every branch, including the implied ones ────────────────
 
     const NO_SKILLS: &[String] = &[];
 

--- a/src/install_method.rs
+++ b/src/install_method.rs
@@ -56,7 +56,7 @@ pub fn binary_upgrade_command(method: &InstallMethod) -> String {
 
 /// Return the one-liner that refreshes agent skills from the cx-cli repo.
 pub fn skills_upgrade_command() -> &'static str {
-    "npx skills add coralogix/cx-cli"
+    "npx skills add coralogix/cx-cli/skills"
 }
 
 /// Official install docs URL (binary + skills).
@@ -88,6 +88,9 @@ mod tests {
 
     #[test]
     fn skills_upgrade_command_is_npx() {
-        assert_eq!(skills_upgrade_command(), "npx skills add coralogix/cx-cli");
+        assert_eq!(
+            skills_upgrade_command(),
+            "npx skills add coralogix/cx-cli/skills"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,8 @@ Examples:
         agents: Vec<String>,
 
         /// Walk the skills installer's full interactive flow (skill/agent
-        /// selection, scope, install method) instead of the express install.
+        /// selection, scope, install method) instead of the default
+        /// non-interactive install.
         #[arg(long)]
         interactive: bool,
     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ pub enum SearchByValueDataset {
 
 \x1b[1m\x1b[4mLocal:\x1b[0m
   \x1b[1mprofiles\x1b[0m           Manage profiles (list, add, delete, set-default)
+  \x1b[1mskills\x1b[0m             Install the cx agent skills for coding agents
   \x1b[1mcleanup\x1b[0m            Remove stale temp files"
 )]
 struct Cli {
@@ -221,6 +222,40 @@ Examples:
 }
 
 #[derive(Subcommand)]
+enum SkillsCmd {
+    /// Install the cx agent skills bundle via the `skills` npx installer.
+    ///
+    /// By default this asks one question (install scope) and then runs the
+    /// installer fully non-interactively with agent auto-detection. Requires
+    /// Node.js (npx).
+    #[command(after_help = "\
+Examples:
+  cx skills install                     # asks global vs local, then installs
+  cx skills install --global            # no questions asked
+  cx skills install --local --agent claude-code
+  cx skills install --interactive       # walk the installer's full flow")]
+    Install {
+        /// Install skills globally (~/), available in every project.
+        #[arg(long, conflicts_with_all = ["local", "interactive"])]
+        global: bool,
+
+        /// Install skills locally (./), for this project only.
+        #[arg(long, conflicts_with = "interactive")]
+        local: bool,
+
+        /// Target specific agents (passed through to the installer's -a;
+        /// overrides its auto-detection). Repeatable.
+        #[arg(long = "agent", value_name = "NAME", conflicts_with = "interactive")]
+        agents: Vec<String>,
+
+        /// Walk the skills installer's full interactive flow (skill/agent
+        /// selection, scope, install method) instead of the express install.
+        #[arg(long)]
+        interactive: bool,
+    },
+}
+
+#[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Manage profiles (list, add, delete, set-default).
@@ -237,6 +272,12 @@ enum Commands {
 
     /// Remove stale cx_results* files (older than 30 minutes) from the temp directory.
     Cleanup,
+
+    /// Install the cx agent skills for coding agents (Claude Code, Cursor, Codex, ...).
+    Skills {
+        #[command(subcommand)]
+        cmd: SkillsCmd,
+    },
 
     /// Query logs using DataPrime syntax.
     #[command(after_help = "\
@@ -2832,7 +2873,11 @@ async fn main() -> Result<()> {
         let top = safety::get_top_level_subcommand_name(&matches);
         let is_local = matches!(
             top.as_deref(),
-            Some("profiles") | Some("cleanup") | Some("completions") | Some("docs")
+            Some("profiles")
+                | Some("cleanup")
+                | Some("completions")
+                | Some("docs")
+                | Some("skills")
         );
         if !is_local {
             if let Some(leaf) = safety::get_leaf_subcommand_name(&matches) {
@@ -2894,6 +2939,35 @@ async fn main() -> Result<()> {
     // Cleanup command doesn't need API credentials.
     if let Commands::Cleanup = cli.command {
         let result = commands::cleanup::run();
+        update_check::maybe_print_notice(OutputFormat::Text);
+        return result;
+    }
+
+    // Skills install shells out to npx locally - no API credentials.
+    if let Commands::Skills { cmd } = cli.command {
+        let SkillsCmd::Install {
+            global,
+            local,
+            agents,
+            interactive,
+        } = cmd;
+        let result = if interactive {
+            commands::skills::run_advanced_install()
+        } else {
+            let scope = if global {
+                Some(commands::skills::SkillsScope::Global)
+            } else if local {
+                Some(commands::skills::SkillsScope::Local)
+            } else {
+                None
+            };
+            commands::skills::run_install(commands::skills::InstallOptions {
+                scope,
+                agents,
+                request: commands::skills::InstallRequest::Explicit,
+            })
+            .map(|_| ())
+        };
         update_check::maybe_print_notice(OutputFormat::Text);
         return result;
     }
@@ -3000,6 +3074,7 @@ async fn main() -> Result<()> {
         match cli.command {
             Commands::Profiles { .. } => unreachable!("handled by ProfilesCli above"),
             Commands::Cleanup => unreachable!("handled above"),
+            Commands::Skills { .. } => unreachable!("handled above"),
             Commands::Schema => unreachable!("handled above"),
             Commands::Completions { .. } => unreachable!("handled above"),
             Commands::Docs { .. } => unreachable!("handled above"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -3034,12 +3034,7 @@ async fn main() -> Result<()> {
             } else {
                 None
             };
-            commands::skills::run_install(commands::skills::InstallOptions {
-                scope,
-                agents,
-                request: commands::skills::InstallRequest::Explicit,
-            })
-            .map(|_| ())
+            commands::skills::run_install(commands::skills::InstallOptions { scope, agents })
         };
         update_check::maybe_print_notice(OutputFormat::Text);
         return result;

--- a/src/request_metadata.rs
+++ b/src/request_metadata.rs
@@ -186,10 +186,7 @@ fn command_path_from_matches(matches: &ArgMatches) -> (String, String) {
     }
 }
 
-/// Names of Coralogix skills (bundled or `cx-`/`coralogix-`-prefixed) found in
-/// the agents' skill directories, global and project scope. Also used by the
-/// skills install step to detect an existing install.
-pub fn installed_coralogix_skills() -> Vec<String> {
+fn installed_coralogix_skills() -> Vec<String> {
     installed_coralogix_skills_in(
         &skill_roots(),
         bundled_skills::BUNDLED_CORALOGIX_SKILL_NAMES,

--- a/src/request_metadata.rs
+++ b/src/request_metadata.rs
@@ -197,6 +197,10 @@ fn installed_coralogix_skills_in(
     roots: &[std::path::PathBuf],
     bundled_skill_names: &[&str],
 ) -> Vec<String> {
+    // Match only against the definitive list of skills bundled with this `cx`
+    // build (generated from `skills/` at compile time). A bare `cx-`/`coralogix-`
+    // name prefix is too loose - unrelated third-party skills can carry it - so
+    // detection trusts the known-ours list rather than guessing from the name.
     let mut skills = BTreeSet::new();
     for root in roots {
         for skill_name in bundled_skill_names {
@@ -204,23 +208,8 @@ fn installed_coralogix_skills_in(
                 skills.insert((*skill_name).to_string());
             }
         }
-        let Ok(entries) = std::fs::read_dir(root) else {
-            continue;
-        };
-        for entry in entries.filter_map(Result::ok) {
-            let Some(skill_name) = entry.file_name().to_str().map(str::to_string) else {
-                continue;
-            };
-            if is_coralogix_skill_name(&skill_name) && entry.path().join("SKILL.md").is_file() {
-                skills.insert(skill_name);
-            }
-        }
     }
     skills.into_iter().collect()
-}
-
-fn is_coralogix_skill_name(skill_name: &str) -> bool {
-    skill_name.starts_with("cx-") || skill_name.starts_with("coralogix-")
 }
 
 fn skill_roots() -> Vec<std::path::PathBuf> {
@@ -310,27 +299,28 @@ mod tests {
     }
 
     #[test]
-    fn detects_bundled_and_prefixed_coralogix_skills() {
+    fn detects_only_bundled_coralogix_skills() {
         let root = std::env::temp_dir().join(format!("cx-skill-test-{}", uuid::Uuid::new_v4()));
         let bundled_skill = bundled_skills::BUNDLED_CORALOGIX_SKILL_NAMES[0];
         let installed_skill = root.join(bundled_skill);
+        // A third-party skill that merely shares the `cx-` prefix is NOT ours.
         let prefixed_skill = root.join("cx-unrelated-skill");
         let unrelated_skill = root.join("other-skill");
         std::fs::create_dir_all(&installed_skill).unwrap();
         std::fs::create_dir_all(&prefixed_skill).unwrap();
         std::fs::create_dir_all(&unrelated_skill).unwrap();
         std::fs::write(installed_skill.join("SKILL.md"), "# Coralogix skill").unwrap();
-        std::fs::write(prefixed_skill.join("SKILL.md"), "# Coralogix skill").unwrap();
+        std::fs::write(prefixed_skill.join("SKILL.md"), "# Unrelated skill").unwrap();
         std::fs::write(unrelated_skill.join("SKILL.md"), "# Unrelated skill").unwrap();
 
-        let mut expected = vec![bundled_skill.to_string(), "cx-unrelated-skill".to_string()];
-        expected.sort();
+        // Only the bundled skill is detected; the bare-prefix and unrelated
+        // skills are ignored.
         assert_eq!(
             installed_coralogix_skills_in(
                 std::slice::from_ref(&root),
                 bundled_skills::BUNDLED_CORALOGIX_SKILL_NAMES,
             ),
-            expected
+            vec![bundled_skill.to_string()]
         );
 
         std::fs::remove_dir_all(root).unwrap();

--- a/src/request_metadata.rs
+++ b/src/request_metadata.rs
@@ -186,7 +186,10 @@ fn command_path_from_matches(matches: &ArgMatches) -> (String, String) {
     }
 }
 
-fn installed_coralogix_skills() -> Vec<String> {
+/// Names of Coralogix skills (bundled or `cx-`/`coralogix-`-prefixed) found in
+/// the agents' skill directories, global and project scope. Also used by the
+/// skills install step to detect an existing install.
+pub fn installed_coralogix_skills() -> Vec<String> {
     installed_coralogix_skills_in(
         &skill_roots(),
         bundled_skills::BUNDLED_CORALOGIX_SKILL_NAMES,

--- a/tests/schema/main.rs
+++ b/tests/schema/main.rs
@@ -21,7 +21,7 @@ fn schema_outputs_valid_json_with_expected_commands() {
     let commands = schema["commands"]
         .as_array()
         .expect("commands should be an array");
-    assert_eq!(commands.len(), 31, "expected 31 top-level commands");
+    assert_eq!(commands.len(), 32, "expected 32 top-level commands");
 
     let names: Vec<&str> = commands
         .iter()
@@ -49,6 +49,7 @@ fn schema_outputs_valid_json_with_expected_commands() {
         names.contains(&"service-catalog"),
         "missing service-catalog"
     );
+    assert!(names.contains(&"skills"), "missing skills");
 
     // Verify old commands are gone
     assert!(

--- a/tests/skills/main.rs
+++ b/tests/skills/main.rs
@@ -94,13 +94,13 @@ fn install_without_scope_and_no_tty_fails_naming_the_flags() {
     );
 }
 
-// ── Express install shell-out ─────────────────────────────────────────────────
+// ── Non-interactive install shell-out ─────────────────────────────────────────
 
 #[cfg(unix)]
 #[test]
-fn install_global_runs_fully_noninteractive_express_command() {
-    let home = temp_dir("express_global");
-    let bin = temp_dir("express_global_bin");
+fn install_global_runs_fully_noninteractive_command() {
+    let home = temp_dir("noninteractive_global");
+    let bin = temp_dir("noninteractive_global_bin");
     let args_file = bin.join("args.txt");
     install_fake_npx(&bin, &args_file, "[]");
 
@@ -119,8 +119,8 @@ fn install_global_runs_fully_noninteractive_express_command() {
 #[cfg(unix)]
 #[test]
 fn install_local_with_agents_passes_them_through() {
-    let home = temp_dir("express_local");
-    let bin = temp_dir("express_local_bin");
+    let home = temp_dir("noninteractive_local");
+    let bin = temp_dir("noninteractive_local_bin");
     let args_file = bin.join("args.txt");
     install_fake_npx(&bin, &args_file, "[]");
 

--- a/tests/skills/main.rs
+++ b/tests/skills/main.rs
@@ -32,14 +32,22 @@ fn cx(home: &Path, path_dir: &Path) -> Command {
     cmd
 }
 
-/// Install a fake `npx` into `dir` that answers `--version` and records any
-/// other invocation's arguments into `args_file`.
+/// Install a fake `npx` into `dir` that answers `--version`, serves `ls_json`
+/// for `skills ls` (the already-installed detection), and records any other
+/// invocation's arguments into `args_file`.
 #[cfg(unix)]
-fn install_fake_npx(dir: &Path, args_file: &Path) {
+fn install_fake_npx(dir: &Path, args_file: &Path, ls_json: &str) {
     use std::os::unix::fs::PermissionsExt;
+    // Only `echo` (a shell builtin) is usable here: PATH contains nothing but
+    // this directory, so external tools like `cat` would not resolve.
+    assert!(
+        !ls_json.contains('\''),
+        "ls_json must not contain single quotes"
+    );
     let script = format!(
         "#!/bin/sh\n\
          if [ \"$1\" = \"--version\" ]; then echo \"10.0.0\"; exit 0; fi\n\
+         if [ \"$2\" = \"skills\" ] && [ \"$3\" = \"ls\" ]; then echo '{ls_json}'; exit 0; fi\n\
          echo \"$@\" > \"{}\"\n",
         args_file.display()
     );
@@ -73,7 +81,7 @@ fn install_without_npx_fails_with_actionable_error() {
 fn install_without_scope_and_no_tty_fails_naming_the_flags() {
     let home = temp_dir("no_scope");
     let bin = temp_dir("no_scope_bin");
-    install_fake_npx(&bin, &bin.join("args.txt"));
+    install_fake_npx(&bin, &bin.join("args.txt"), "[]");
     let output = cx(&home, &bin)
         .args(["skills", "install"])
         .output()
@@ -94,7 +102,7 @@ fn install_global_runs_fully_noninteractive_express_command() {
     let home = temp_dir("express_global");
     let bin = temp_dir("express_global_bin");
     let args_file = bin.join("args.txt");
-    install_fake_npx(&bin, &args_file);
+    install_fake_npx(&bin, &args_file, "[]");
 
     cx(&home, &bin)
         .args(["skills", "install", "--global"])
@@ -114,7 +122,7 @@ fn install_local_with_agents_passes_them_through() {
     let home = temp_dir("express_local");
     let bin = temp_dir("express_local_bin");
     let args_file = bin.join("args.txt");
-    install_fake_npx(&bin, &args_file);
+    install_fake_npx(&bin, &args_file, "[]");
 
     cx(&home, &bin)
         .args([
@@ -144,7 +152,7 @@ fn install_interactive_runs_the_raw_installer() {
     let home = temp_dir("advanced");
     let bin = temp_dir("advanced_bin");
     let args_file = bin.join("args.txt");
-    install_fake_npx(&bin, &args_file);
+    install_fake_npx(&bin, &args_file, "[]");
 
     cx(&home, &bin)
         .args(["skills", "install", "--interactive"])
@@ -157,17 +165,21 @@ fn install_interactive_runs_the_raw_installer() {
 
 // ── Already-installed detection (explicit run reinstalls) ─────────────────────
 
+/// Detection asks the installer itself (`skills ls --json`); the fake npx
+/// reports one cx skill already installed.
 #[cfg(unix)]
 #[test]
 fn install_over_existing_skills_notes_the_update() {
     let home = temp_dir("preinstalled");
     let bin = temp_dir("preinstalled_bin");
     let args_file = bin.join("args.txt");
-    install_fake_npx(&bin, &args_file);
-
-    let skill_dir = home.join(".claude/skills/cx-alerts");
-    fs::create_dir_all(&skill_dir).unwrap();
-    fs::write(skill_dir.join("SKILL.md"), "# cx-alerts").unwrap();
+    install_fake_npx(
+        &bin,
+        &args_file,
+        r#"[{"name": "cx-alerts", "path": "/skills/cx-alerts", "scope": "global",
+             "agents": ["Claude Code"], "source": "coralogix/cx-cli",
+             "sourceUrl": null, "sourceType": "github"}]"#,
+    );
 
     let output = cx(&home, &bin)
         .args(["skills", "install", "--global"])
@@ -176,8 +188,8 @@ fn install_over_existing_skills_notes_the_update() {
     assert!(output.status.success());
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("already installed"),
-        "expected already-installed note, stdout: {stdout}"
+        stdout.contains("already installed") && stdout.contains("cx-alerts"),
+        "expected already-installed note naming the skill, stdout: {stdout}"
     );
     // Explicit install still runs the installer (reinstall/update).
     assert!(args_file.exists(), "installer should still have been run");

--- a/tests/skills/main.rs
+++ b/tests/skills/main.rs
@@ -232,6 +232,36 @@ fn install_local_ignores_globally_installed_skills() {
     assert!(args_file.exists(), "installer should still have been run");
 }
 
+/// Fail-open contract (see `installed_cx_skills`): an old installer without
+/// `--json` prints human-formatted text on exit 0, which fails to parse as
+/// JSON. That must count as nothing installed and let the install proceed,
+/// rather than erroring out.
+#[cfg(unix)]
+#[test]
+fn install_treats_unparseable_ls_output_as_nothing_installed() {
+    let home = temp_dir("unparseable_ls");
+    let bin = temp_dir("unparseable_ls_bin");
+    let args_file = bin.join("args.txt");
+    // Realistic old-installer output: a human-formatted table, not JSON.
+    let plain = "cx-alerts  global  Claude Code  coralogix/cx-cli";
+    install_fake_npx(&bin, &args_file, plain, plain);
+
+    let output = cx(&home, &bin)
+        .args(["skills", "install", "--global"])
+        .output()
+        .expect("failed to run cx");
+    assert!(
+        output.status.success(),
+        "unparseable ls output must fail open, not error the install"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("already installed"),
+        "unparseable ls output must count as nothing installed, stdout: {stdout}"
+    );
+    assert!(args_file.exists(), "installer should still have been run");
+}
+
 // ── Flag conflicts ────────────────────────────────────────────────────────────
 
 #[test]

--- a/tests/skills/main.rs
+++ b/tests/skills/main.rs
@@ -1,0 +1,196 @@
+//! Integration tests for `cx skills install` (FORGE-657).
+//!
+//! The installer is exercised through a fake `npx` script placed on PATH that
+//! records the arguments it receives, so no Node.js or network is required.
+
+use assert_cmd::Command;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU32, Ordering};
+
+static COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn temp_dir(tag: &str) -> PathBuf {
+    let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+    let pid = std::process::id();
+    let dir = std::env::temp_dir().join(format!("cx_test_skills_{tag}_{pid}_{id}"));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// A `cx` command hermetically sealed off from the developer's real home,
+/// project directory, and PATH.
+fn cx(home: &Path, path_dir: &Path) -> Command {
+    let cwd = home.join("project");
+    fs::create_dir_all(&cwd).unwrap();
+    let mut cmd = Command::cargo_bin("cx").expect("cx binary should build");
+    cmd.env("HOME", home)
+        .env("CX_HOME", home)
+        .env("PATH", path_dir)
+        .current_dir(cwd);
+    cmd
+}
+
+/// Install a fake `npx` into `dir` that answers `--version` and records any
+/// other invocation's arguments into `args_file`.
+#[cfg(unix)]
+fn install_fake_npx(dir: &Path, args_file: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let script = format!(
+        "#!/bin/sh\n\
+         if [ \"$1\" = \"--version\" ]; then echo \"10.0.0\"; exit 0; fi\n\
+         echo \"$@\" > \"{}\"\n",
+        args_file.display()
+    );
+    let npx = dir.join("npx");
+    fs::write(&npx, script).unwrap();
+    fs::set_permissions(&npx, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+// ── Missing npx ───────────────────────────────────────────────────────────────
+
+#[test]
+fn install_without_npx_fails_with_actionable_error() {
+    let home = temp_dir("no_npx");
+    let empty_path = temp_dir("no_npx_path");
+    let output = cx(&home, &empty_path)
+        .args(["skills", "install", "--global"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Node.js") && stderr.contains("npx"),
+        "expected actionable Node.js/npx error, stderr: {stderr}"
+    );
+}
+
+// ── Non-interactive scope resolution ──────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn install_without_scope_and_no_tty_fails_naming_the_flags() {
+    let home = temp_dir("no_scope");
+    let bin = temp_dir("no_scope_bin");
+    install_fake_npx(&bin, &bin.join("args.txt"));
+    let output = cx(&home, &bin)
+        .args(["skills", "install"])
+        .output()
+        .expect("failed to run cx");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--global") && stderr.contains("--local"),
+        "expected error naming --global/--local, stderr: {stderr}"
+    );
+}
+
+// ── Express install shell-out ─────────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn install_global_runs_fully_noninteractive_express_command() {
+    let home = temp_dir("express_global");
+    let bin = temp_dir("express_global_bin");
+    let args_file = bin.join("args.txt");
+    install_fake_npx(&bin, &args_file);
+
+    cx(&home, &bin)
+        .args(["skills", "install", "--global"])
+        .assert()
+        .success();
+
+    let recorded = fs::read_to_string(&args_file).unwrap();
+    assert_eq!(
+        recorded.trim(),
+        "-y skills add coralogix/cx-cli --skill * -y -g"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn install_local_with_agents_passes_them_through() {
+    let home = temp_dir("express_local");
+    let bin = temp_dir("express_local_bin");
+    let args_file = bin.join("args.txt");
+    install_fake_npx(&bin, &args_file);
+
+    cx(&home, &bin)
+        .args([
+            "skills",
+            "install",
+            "--local",
+            "--agent",
+            "claude-code",
+            "--agent",
+            "cursor",
+        ])
+        .assert()
+        .success();
+
+    let recorded = fs::read_to_string(&args_file).unwrap();
+    assert_eq!(
+        recorded.trim(),
+        "-y skills add coralogix/cx-cli --skill * -y -a claude-code cursor"
+    );
+}
+
+// ── Advanced (interactive) walk ───────────────────────────────────────────────
+
+#[cfg(unix)]
+#[test]
+fn install_interactive_runs_the_raw_installer() {
+    let home = temp_dir("advanced");
+    let bin = temp_dir("advanced_bin");
+    let args_file = bin.join("args.txt");
+    install_fake_npx(&bin, &args_file);
+
+    cx(&home, &bin)
+        .args(["skills", "install", "--interactive"])
+        .assert()
+        .success();
+
+    let recorded = fs::read_to_string(&args_file).unwrap();
+    assert_eq!(recorded.trim(), "skills add coralogix/cx-cli");
+}
+
+// ── Already-installed detection (explicit run reinstalls) ─────────────────────
+
+#[cfg(unix)]
+#[test]
+fn install_over_existing_skills_notes_the_update() {
+    let home = temp_dir("preinstalled");
+    let bin = temp_dir("preinstalled_bin");
+    let args_file = bin.join("args.txt");
+    install_fake_npx(&bin, &args_file);
+
+    let skill_dir = home.join(".claude/skills/cx-alerts");
+    fs::create_dir_all(&skill_dir).unwrap();
+    fs::write(skill_dir.join("SKILL.md"), "# cx-alerts").unwrap();
+
+    let output = cx(&home, &bin)
+        .args(["skills", "install", "--global"])
+        .output()
+        .expect("failed to run cx");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("already installed"),
+        "expected already-installed note, stdout: {stdout}"
+    );
+    // Explicit install still runs the installer (reinstall/update).
+    assert!(args_file.exists(), "installer should still have been run");
+}
+
+// ── Flag conflicts ────────────────────────────────────────────────────────────
+
+#[test]
+fn global_and_local_conflict() {
+    let home = temp_dir("conflict");
+    let bin = temp_dir("conflict_bin");
+    cx(&home, &bin)
+        .args(["skills", "install", "--global", "--local"])
+        .assert()
+        .failure();
+}

--- a/tests/skills/main.rs
+++ b/tests/skills/main.rs
@@ -32,22 +32,30 @@ fn cx(home: &Path, path_dir: &Path) -> Command {
     cmd
 }
 
-/// Install a fake `npx` into `dir` that answers `--version`, serves `ls_json`
-/// for `skills ls` (the already-installed detection), and records any other
-/// invocation's arguments into `args_file`.
+/// Install a fake `npx` into `dir` that answers `--version`, serves
+/// `project_json` for `skills ls --json` and `global_json` for `skills ls -g
+/// --json` (the scope-aware already-installed detection), and records any
+/// other invocation's arguments into `args_file`.
 #[cfg(unix)]
-fn install_fake_npx(dir: &Path, args_file: &Path, ls_json: &str) {
+fn install_fake_npx(dir: &Path, args_file: &Path, project_json: &str, global_json: &str) {
     use std::os::unix::fs::PermissionsExt;
     // Only `echo` (a shell builtin) is usable here: PATH contains nothing but
     // this directory, so external tools like `cat` would not resolve.
-    assert!(
-        !ls_json.contains('\''),
-        "ls_json must not contain single quotes"
-    );
+    for json in [project_json, global_json] {
+        assert!(
+            !json.contains('\''),
+            "ls json must not contain single quotes"
+        );
+    }
     let script = format!(
         "#!/bin/sh\n\
          if [ \"$1\" = \"--version\" ]; then echo \"10.0.0\"; exit 0; fi\n\
-         if [ \"$2\" = \"skills\" ] && [ \"$3\" = \"ls\" ]; then echo '{ls_json}'; exit 0; fi\n\
+         if [ \"$2\" = \"skills\" ] && [ \"$3\" = \"ls\" ]; then\n\
+           for a in \"$@\"; do\n\
+             if [ \"$a\" = \"-g\" ]; then echo '{global_json}'; exit 0; fi\n\
+           done\n\
+           echo '{project_json}'; exit 0\n\
+         fi\n\
          echo \"$@\" > \"{}\"\n",
         args_file.display()
     );
@@ -81,7 +89,7 @@ fn install_without_npx_fails_with_actionable_error() {
 fn install_without_scope_and_no_tty_fails_naming_the_flags() {
     let home = temp_dir("no_scope");
     let bin = temp_dir("no_scope_bin");
-    install_fake_npx(&bin, &bin.join("args.txt"), "[]");
+    install_fake_npx(&bin, &bin.join("args.txt"), "[]", "[]");
     let output = cx(&home, &bin)
         .args(["skills", "install"])
         .output()
@@ -102,7 +110,7 @@ fn install_global_runs_fully_noninteractive_command() {
     let home = temp_dir("noninteractive_global");
     let bin = temp_dir("noninteractive_global_bin");
     let args_file = bin.join("args.txt");
-    install_fake_npx(&bin, &args_file, "[]");
+    install_fake_npx(&bin, &args_file, "[]", "[]");
 
     cx(&home, &bin)
         .args(["skills", "install", "--global"])
@@ -112,7 +120,7 @@ fn install_global_runs_fully_noninteractive_command() {
     let recorded = fs::read_to_string(&args_file).unwrap();
     assert_eq!(
         recorded.trim(),
-        "-y skills add coralogix/cx-cli --skill * -y -g"
+        "-y skills add coralogix/cx-cli/skills --skill * -y -g"
     );
 }
 
@@ -122,7 +130,7 @@ fn install_local_with_agents_passes_them_through() {
     let home = temp_dir("noninteractive_local");
     let bin = temp_dir("noninteractive_local_bin");
     let args_file = bin.join("args.txt");
-    install_fake_npx(&bin, &args_file, "[]");
+    install_fake_npx(&bin, &args_file, "[]", "[]");
 
     cx(&home, &bin)
         .args([
@@ -140,7 +148,7 @@ fn install_local_with_agents_passes_them_through() {
     let recorded = fs::read_to_string(&args_file).unwrap();
     assert_eq!(
         recorded.trim(),
-        "-y skills add coralogix/cx-cli --skill * -y -a claude-code cursor"
+        "-y skills add coralogix/cx-cli/skills --skill * -y -a claude-code cursor"
     );
 }
 
@@ -152,7 +160,7 @@ fn install_interactive_runs_the_raw_installer() {
     let home = temp_dir("advanced");
     let bin = temp_dir("advanced_bin");
     let args_file = bin.join("args.txt");
-    install_fake_npx(&bin, &args_file, "[]");
+    install_fake_npx(&bin, &args_file, "[]", "[]");
 
     cx(&home, &bin)
         .args(["skills", "install", "--interactive"])
@@ -160,13 +168,13 @@ fn install_interactive_runs_the_raw_installer() {
         .success();
 
     let recorded = fs::read_to_string(&args_file).unwrap();
-    assert_eq!(recorded.trim(), "skills add coralogix/cx-cli");
+    assert_eq!(recorded.trim(), "skills add coralogix/cx-cli/skills");
 }
 
 // ── Already-installed detection (explicit run reinstalls) ─────────────────────
 
-/// Detection asks the installer itself (`skills ls --json`); the fake npx
-/// reports one cx skill already installed.
+/// Detection asks the installer itself (`skills ls -g --json`); the fake npx
+/// reports one cx skill already installed globally.
 #[cfg(unix)]
 #[test]
 fn install_over_existing_skills_notes_the_update() {
@@ -176,6 +184,7 @@ fn install_over_existing_skills_notes_the_update() {
     install_fake_npx(
         &bin,
         &args_file,
+        "[]",
         r#"[{"name": "cx-alerts", "path": "/skills/cx-alerts", "scope": "global",
              "agents": ["Claude Code"], "source": "coralogix/cx-cli",
              "sourceUrl": null, "sourceType": "github"}]"#,
@@ -192,6 +201,34 @@ fn install_over_existing_skills_notes_the_update() {
         "expected already-installed note naming the skill, stdout: {stdout}"
     );
     // Explicit install still runs the installer (reinstall/update).
+    assert!(args_file.exists(), "installer should still have been run");
+}
+
+/// Detection is scoped: skills present only globally must not be reported as
+/// already-installed for a `--local` install.
+#[cfg(unix)]
+#[test]
+fn install_local_ignores_globally_installed_skills() {
+    let home = temp_dir("scoped");
+    let bin = temp_dir("scoped_bin");
+    let args_file = bin.join("args.txt");
+    install_fake_npx(
+        &bin,
+        &args_file,
+        "[]",
+        r#"[{"name": "cx-alerts", "source": "coralogix/cx-cli"}]"#,
+    );
+
+    let output = cx(&home, &bin)
+        .args(["skills", "install", "--local"])
+        .output()
+        .expect("failed to run cx");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("already installed"),
+        "global skills must not count for a local install, stdout: {stdout}"
+    );
     assert!(args_file.exists(), "installer should still have been run");
 }
 


### PR DESCRIPTION
## Summary

Adds a new local command, `cx skills install`, that installs the cx agent skills bundle for coding agents (Claude Code, Cursor, Codex, ...) by shelling out to the vercel-labs `skills` npx installer (`npx skills add coralogix/cx-cli`).

## What's included

- **Default install**: asks at most one question — global (`~/`) vs local (`./`) scope — then runs the installer fully non-interactively (`npx -y skills add coralogix/cx-cli --skill '*' -y`) with agent auto-detection.
  - `--global` / `--local` skip the question entirely
  - `--agent <name>` (repeatable) overrides the installer's agent auto-detection
- **`--interactive`**: walks the installer's full native flow (skill/agent selection, scope, install method).
- **Already-installed detection**: checks `npx skills ls --json` (project + global scope); a skill counts as ours when its source is `coralogix/cx-cli` or its name starts with `cx-`/`coralogix-`. An explicit install reinstalls with a note; detection failures fail open so the install proceeds.
- **Actionable errors**: missing npx or a non-interactive terminal without a scope flag name the fix (install Node.js / pass `--global` or `--local`). The CLI stays fully usable without skills.
- Registered as a local command: no API credentials needed, exempt from the risky-command confirmation path, works on Windows via the `npx.cmd` shim.

## Usage

    cx skills install                     # asks global vs local, then installs
    cx skills install --global            # no questions asked
    cx skills install --local --agent claude-code
    cx skills install --interactive       # walk the installer's full flow

## Testing

- Unit tests in `src/commands/skills/mod.rs`: every `plan_install()` branch, installer arg construction, shell-safe command display, `skills ls --json` parsing, installed-skills summary.
- Integration tests in `tests/skills/main.rs`: fake `npx` on `PATH` verifying the exact non-interactive command line, scope/agent flag pass-through, failure and no-npx paths.
- `tests/schema/main.rs` updated: 32 top-level commands, `skills` present.
- `cargo fmt`, `cargo clippy`, `cargo test` all pass.
