### PR TITLE
Reject folder ids on dashboards get, check, and delete

### DIFF
--- a/skills/cx-dashboards/SKILL.md
+++ b/skills/cx-dashboards/SKILL.md
@@ -9,7 +9,7 @@ description: >
   deploy, update, replace, or modify a Coralogix dashboard, monitoring dashboard,
   or observability dashboard for a service, app, or pipeline.
 metadata:
-  version: "0.2.0"
+  version: "0.2.1"
 ---
 
 # Create Coralogix Dashboard
@@ -39,18 +39,22 @@ For choosing the right signal (metrics / logs / traces), use `cx-telemetry-query
 
 ## Dashboard Management
 
-Beyond creating dashboards, use these commands to manage existing ones:
+Beyond creating dashboards, use these commands to manage existing ones.
+
+**Ids are not interchangeable.** Dashboard ids are **21-character nanoids**. Folder ids are **UUIDs**. There is no “list dashboards in this folder” command.
 
 | Command | Purpose |
 |---|---|
-| `cx dashboards catalog -o json` | List all dashboards in the catalog |
-| `cx dashboards get <id> -o json` | Get a dashboard definition (useful as a template) |
-| `cx dashboards folders list -o json` | List dashboard folders |
+| `cx dashboards catalog -o json` | List all dashboards (each row has `id` plus `folder.id` / `folder.name`) |
+| `cx dashboards get <dashboard-id> -o json` | Get a dashboard definition. `<dashboard-id>` must be the catalog item `id` (21 chars) — never a folder UUID or folder name |
+| `cx dashboards folders list -o json` | List dashboard folders (UUID ids). Use these only with `--folder` / `--parent-id` |
 | `cx dashboards folders create --name "Name"` | Create a dashboard folder |
 | `cx dashboards folders create --name "Sub" --parent-id <id>` | Create a nested folder |
 | `cx dashboards replace --from-file dashboard.json` | Replace an existing dashboard with updated JSON |
 | `cx dashboards check --from-file dashboard.json` | Validate a dashboard definition without persisting (server-side strict check; exits non-zero on errors) |
-| `cx dashboards check <dashboard-id>` | Validate a stored dashboard by id |
+| `cx dashboards check <dashboard-id>` | Validate a stored dashboard by catalog `id` (21 chars) |
+
+**Inventory a folder:** `cx dashboards catalog -o json`, then filter on `folder.name` or `folder.id`. Do **not** run `cx dashboards get <folder-id>` or `cx dashboards get BMLL`. If the CLI or API says `dashboard_id is not 21 characters length`, you passed a folder id, a folder name, or a path segment like `catalog` — take the 21-character `id` from catalog instead.
 
 To update an existing dashboard:
 

--- a/skills/cx-dashboards/references/deploy.md
+++ b/skills/cx-dashboards/references/deploy.md
@@ -12,6 +12,8 @@ List folders and suggest the best match:
 cx dashboards folders list -o json
 ```
 
+Folder ids from this list are UUIDs. Pass them only as `--folder` / `--parent-id` on create. They are not dashboard ids — never `cx dashboards get <folder-id>`.
+
 Rank the existing folders by relevance (service name, team, product area) and present the top matches with `AskQuestion`:
 
 - "Folder X (id: `<id>`) - best match by name"

--- a/skills/cx-search-dashboard/SKILL.md
+++ b/skills/cx-search-dashboard/SKILL.md
@@ -2,7 +2,7 @@
 name: cx-search-dashboard
 description: This skill should be used when the user asks to "find a dashboard", "search dashboards", "does a dashboard exist for X", "find widgets that query Y", "which dashboards use this field", "find a dashboard about errors", "look up dashboards by description", "search for existing monitoring dashboards", "find widgets that reference a field", or wants to discover existing Coralogix dashboards or widgets using natural-language or field-based search.
 metadata:
-  version: "0.1.0"
+  version: "0.1.1"
 ---
 
 # Dashboard Search Skill
@@ -16,10 +16,12 @@ Use this skill to discover existing Coralogix dashboards and widgets using seman
 | `cx dashboards search "<description>"` | Find dashboards by natural-language description | `--limit` |
 | `cx dashboards query-search --description "<text>"` | Find widgets whose queries match a description | `--limit` |
 | `cx dashboards query-search --field "<field-path>"` | Find all widgets that reference a specific field | `--limit` |
-| `cx dashboards catalog -o json` | List all dashboards | - |
-| `cx dashboards get <id> -o json` | Get full dashboard definition | - |
+| `cx dashboards catalog -o json` | List all dashboards (use each item's 21-character `id`) | - |
+| `cx dashboards get <dashboard-id> -o json` | Get full definition. Use catalog `id` only — not `folder.id` and not a folder name | - |
 
 **Output format:** append `-o json` or `-o toon` for machine-readable output.
+
+Dashboard ids are 21-character nanoids. Folder ids are UUIDs. To see what is in a folder, filter `cx dashboards catalog -o json` by `folder.name` / `folder.id`. Do not `get` a folder id. If you see `dashboard_id is not 21 characters length`, you used the wrong id.
 
 ## When to Use Each Command
 

--- a/src/commands/dashboards/mod.rs
+++ b/src/commands/dashboards/mod.rs
@@ -25,6 +25,33 @@ use crate::safety::confirm_destructive;
 /// JSON key for the source profile when merging multi-profile dashboard REST rows.
 const JSON_KEY_PROFILE: &str = "profile";
 
+/// Coralogix dashboard ids are nanoids of this length. Folder ids are UUIDs
+/// (36 chars) and must not be passed to get / check / delete.
+pub const DASHBOARD_ID_LEN: usize = 21;
+
+/// Reject empty ids and anything that is not a 21-character dashboard nanoid.
+///
+/// Agents commonly pass a folder UUID, a folder name (`BMLL`), or the path
+/// segment `catalog` to `cx dashboards get`. The API then returns
+/// `dashboard_id is not 21 characters length`. Fail locally with a pointer
+/// to `cx dashboards catalog` instead of making that request.
+pub fn validate_dashboard_id(id: &str) -> Result<()> {
+    let id = id.trim();
+    if id.is_empty() {
+        bail!("dashboard id cannot be empty");
+    }
+    let len = id.chars().count();
+    if len != DASHBOARD_ID_LEN {
+        bail!(
+            "'{id}' is not a dashboard id (got {len} characters, need {DASHBOARD_ID_LEN}).\n\
+             Dashboard ids are 21-character nanoids from `cx dashboards catalog` (each item's `id`).\n\
+             Folder ids are UUIDs from `cx dashboards folders list` — use them only with `--folder` / `--parent-id`.\n\
+             To list dashboards in a folder, run `cx dashboards catalog -o json` and filter by `folder.name` or `folder.id`. Do not pass a folder id or folder name to get, check, or delete."
+        );
+    }
+    Ok(())
+}
+
 /// Look up a string value at a JSON pointer path (e.g. `/dashboard/id`).
 fn json_str_at(v: &Value, pointer: &str) -> Option<String> {
     v.pointer(pointer)
@@ -501,9 +528,7 @@ pub async fn run_get(
     dashboard_id: &str,
     output: OutputFormat,
 ) -> Result<()> {
-    if dashboard_id.trim().is_empty() {
-        bail!("dashboard id cannot be empty");
-    }
+    validate_dashboard_id(dashboard_id)?;
     eprintln!(
         "{}",
         format!("Fetching dashboard {dashboard_id}...").dimmed()
@@ -797,6 +822,7 @@ pub async fn run_replace(
 // ── Delete ────────────────────────────────────────────────────────────────────
 
 pub async fn run_delete(targets: &[Arc<ExecutionTarget>], id: &str) -> Result<()> {
+    validate_dashboard_id(id)?;
     eprintln!("{}", format!("Deleting dashboard {id}...").dimmed());
     let dashboard_id_owned = id.to_string();
     let per_profile = fan_out(targets, |target| {
@@ -1037,9 +1063,7 @@ pub async fn run_check(
             check_body_from_file(path)?
         }
         (None, Some(id)) => {
-            if id.trim().is_empty() {
-                bail!("dashboard id cannot be empty");
-            }
+            validate_dashboard_id(id)?;
             eprintln!("{}", format!("Checking dashboard {id}...").dimmed());
             check_body_from_id(id)
         }
@@ -1133,6 +1157,30 @@ pub async fn run_check(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_dashboard_id_accepts_21_char_nanoid() {
+        validate_dashboard_id("nPl9zg5A61iJ75CtN2FDB").expect("21-char id should pass");
+    }
+
+    #[test]
+    fn validate_dashboard_id_rejects_folder_name_and_uuid() {
+        for bad in [
+            "BMLL",
+            "catalog",
+            "6d4aac44-0f7e-46e6-9f51-2454af16fd0f",
+            "   ",
+        ] {
+            let err = validate_dashboard_id(bad).expect_err(bad);
+            let msg = err.to_string();
+            if bad.trim().is_empty() {
+                assert!(msg.contains("empty"), "{msg}");
+            } else {
+                assert!(msg.contains("not a dashboard id"), "{msg}");
+                assert!(msg.contains("cx dashboards catalog"), "{msg}");
+            }
+        }
+    }
 
     /// Regression guard for the `render_table` profile-column contract.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -1041,7 +1041,7 @@ Examples:
     Catalog,
     /// Get a single dashboard by ID.
     Get {
-        /// Dashboard ID.
+        /// Dashboard ID (21-character nanoid from `cx dashboards catalog`, not a folder UUID or name).
         dashboard_id: String,
     },
     /// Create a new dashboard from a JSON definition file [requires --yes].
@@ -1086,8 +1086,8 @@ Examples:
 Examples:
   cx dashboards check --from-file dash.json
   cx dashboards check --from-file -            # read from stdin
-  cx dashboards check 01234abcd                 # validate a stored dashboard by id
-  cx -p prod -p staging dashboards check 01234abcd   # multi-profile")]
+  cx dashboards check nPl9zg5A61iJ75CtN2FDB                 # validate a stored dashboard by id
+  cx -p prod -p staging dashboards check nPl9zg5A61iJ75CtN2FDB   # multi-profile")]
     Check {
         /// Path to a JSON file with the dashboard definition. Use '-' for stdin.
         /// Accepts either a bare dashboard document or a `{\"dashboard\": {...}}` wrapper.
@@ -1095,13 +1095,13 @@ Examples:
         #[arg(long, conflicts_with = "dashboard_id")]
         from_file: Option<String>,
 
-        /// Validate an existing dashboard by id. Mutually exclusive with --from-file.
+        /// Validate an existing dashboard by id (21-character nanoid from catalog). Mutually exclusive with --from-file.
         #[arg(conflicts_with = "from_file")]
         dashboard_id: Option<String>,
     },
     /// Delete a dashboard [requires --yes].
     Delete {
-        /// Dashboard ID.
+        /// Dashboard ID (21-character nanoid from `cx dashboards catalog`, not a folder UUID or name).
         dashboard_id: String,
     },
     /// Search dashboards semantically by description.
@@ -3430,6 +3430,7 @@ async fn main() -> Result<()> {
                     .await?;
                 }
                 DashboardsCmd::Delete { dashboard_id } => {
+                    commands::dashboards::validate_dashboard_id(&dashboard_id)?;
                     confirm_destructive(
                         &format!("Delete dashboard '{dashboard_id}'?"),
                         yes,

--- a/tests/console_urls/main.rs
+++ b/tests/console_urls/main.rs
@@ -3069,8 +3069,12 @@ async fn alerts_list_prints_console_link() {
 async fn dashboard_get_prints_console_link() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/5/dashboards/dashboards/v1/dash-abc123"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(json!({"id": "dash-abc123"})))
+        .and(path(
+            "/mgmt/openapi/5/dashboards/dashboards/v1/nPl9zg5A61iJ75CtN2FDB",
+        ))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(json!({"id": "nPl9zg5A61iJ75CtN2FDB"})),
+        )
         .mount(&server)
         .await;
 
@@ -3084,7 +3088,13 @@ async fn dashboard_get_prints_console_link() {
     write_config(&home, "mock");
 
     let output = cx(&home)
-        .args(["--profile", "mock", "dashboards", "get", "dash-abc123"])
+        .args([
+            "--profile",
+            "mock",
+            "dashboards",
+            "get",
+            "nPl9zg5A61iJ75CtN2FDB",
+        ])
         .output()
         .expect("failed to run cx");
 
@@ -3092,7 +3102,7 @@ async fn dashboard_get_prints_console_link() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains(
-            "View in Coralogix: https://c4c.app.eu2.coralogix.com/dashboards/dash-abc123"
+            "View in Coralogix: https://c4c.app.eu2.coralogix.com/dashboards/nPl9zg5A61iJ75CtN2FDB"
         ),
         "stderr did not contain the console link: {stderr}"
     );
@@ -3117,7 +3127,13 @@ async fn dashboard_check_by_id_prints_console_link() {
     write_config(&home, "mock");
 
     let output = cx(&home)
-        .args(["--profile", "mock", "dashboards", "check", "dash-abc123"])
+        .args([
+            "--profile",
+            "mock",
+            "dashboards",
+            "check",
+            "nPl9zg5A61iJ75CtN2FDB",
+        ])
         .output()
         .expect("failed to run cx");
 
@@ -3125,7 +3141,7 @@ async fn dashboard_check_by_id_prints_console_link() {
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         stderr.contains(
-            "View in Coralogix: https://c4c.app.eu2.coralogix.com/dashboards/dash-abc123"
+            "View in Coralogix: https://c4c.app.eu2.coralogix.com/dashboards/nPl9zg5A61iJ75CtN2FDB"
         ),
         "stderr did not contain the console link: {stderr}"
     );

--- a/tests/dashboard_commands.rs
+++ b/tests/dashboard_commands.rs
@@ -169,14 +169,17 @@ async fn dashboard_catalog_toon_output_succeeds() {
 async fn dashboard_get_returns_result() {
     let server = MockServer::start().await;
 
+    let dash_id = "nPl9zg5A61iJ75CtN2FDB";
     let body = json!({
-        "id": "dash-001",
+        "id": dash_id,
         "name": "API Overview",
         "layout": {"sections": []}
     });
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/5/dashboards/dashboards/v1/dash-001"))
+        .and(path(format!(
+            "/mgmt/openapi/5/dashboards/dashboards/v1/{dash_id}"
+        )))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .expect(1)
         .mount(&server)
@@ -185,7 +188,7 @@ async fn dashboard_get_returns_result() {
     let target = common::test_target("test-profile", &server.uri());
     let targets = vec![target];
 
-    dashboards::run_get(&targets, "dash-001", OutputFormat::Json)
+    dashboards::run_get(&targets, dash_id, OutputFormat::Json)
         .await
         .expect("get should succeed");
 }
@@ -194,8 +197,11 @@ async fn dashboard_get_returns_result() {
 async fn dashboard_get_404_returns_error() {
     let server = MockServer::start().await;
 
+    let missing_id = "zzzzzzzzzzzzzzzzzzzzz";
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/5/dashboards/dashboards/v1/nonexistent"))
+        .and(path(format!(
+            "/mgmt/openapi/5/dashboards/dashboards/v1/{missing_id}"
+        )))
         .respond_with(
             ResponseTemplate::new(404).set_body_json(json!({"message": "Dashboard not found"})),
         )
@@ -206,8 +212,22 @@ async fn dashboard_get_404_returns_error() {
     let target = common::test_target("test-profile", &server.uri());
     let targets = vec![target];
 
-    let result = dashboards::run_get(&targets, "nonexistent", OutputFormat::Json).await;
+    let result = dashboards::run_get(&targets, missing_id, OutputFormat::Json).await;
     assert!(result.is_err(), "404 should return Err for get");
+}
+
+#[tokio::test]
+async fn dashboard_get_folder_id_returns_error_without_http() {
+    let target = common::test_target("test-profile", "http://127.0.0.1:1");
+    let targets = vec![target];
+    let err = dashboards::run_get(
+        &targets,
+        "6d4aac44-0f7e-46e6-9f51-2454af16fd0f",
+        OutputFormat::Json,
+    )
+    .await
+    .expect_err("folder UUID must not be sent to get");
+    assert!(err.to_string().contains("not a dashboard id"), "{}", err);
 }
 
 #[tokio::test]
@@ -223,15 +243,20 @@ async fn dashboard_get_multi_profile_includes_profile_field() {
     let server_a = MockServer::start().await;
     let server_b = MockServer::start().await;
 
-    let body = json!({"id": "dash-001", "name": "Shared", "layout": {}});
+    let dash_id = "nPl9zg5A61iJ75CtN2FDB";
+    let body = json!({"id": dash_id, "name": "Shared", "layout": {}});
 
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/5/dashboards/dashboards/v1/dash-001"))
+        .and(path(format!(
+            "/mgmt/openapi/5/dashboards/dashboards/v1/{dash_id}"
+        )))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .mount(&server_a)
         .await;
     Mock::given(method("GET"))
-        .and(path("/mgmt/openapi/5/dashboards/dashboards/v1/dash-001"))
+        .and(path(format!(
+            "/mgmt/openapi/5/dashboards/dashboards/v1/{dash_id}"
+        )))
         .respond_with(ResponseTemplate::new(200).set_body_json(&body))
         .mount(&server_b)
         .await;
@@ -241,7 +266,7 @@ async fn dashboard_get_multi_profile_includes_profile_field() {
         common::test_target("profile-b", &server_b.uri()),
     ];
 
-    dashboards::run_get(&targets, "dash-001", OutputFormat::Json)
+    dashboards::run_get(&targets, dash_id, OutputFormat::Json)
         .await
         .expect("multi-profile get should succeed");
 }

--- a/tests/dashboards/main.rs
+++ b/tests/dashboards/main.rs
@@ -123,8 +123,11 @@ async fn run_catalog_json_output_succeeds() {
 async fn delete_dashboard_from_mock() {
     let server = MockServer::start().await;
 
+    let dash_id = "nPl9zg5A61iJ75CtN2FDB";
     Mock::given(method("DELETE"))
-        .and(path("/mgmt/openapi/5/dashboards/dashboards/v1/dash-abc"))
+        .and(path(format!(
+            "/mgmt/openapi/5/dashboards/dashboards/v1/{dash_id}"
+        )))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
         .expect(1)
         .mount(&server)
@@ -133,7 +136,7 @@ async fn delete_dashboard_from_mock() {
     let target = common::test_target("mock-profile", &server.uri());
     let targets = vec![target];
 
-    run_delete(&targets, "dash-abc")
+    run_delete(&targets, dash_id)
         .await
         .expect("run_delete should succeed");
 }
@@ -477,7 +480,9 @@ async fn run_check_by_id_sends_dashboard_id_in_body() {
 
     Mock::given(method("POST"))
         .and(path(CHECK_PATH))
-        .and(body_partial_json(json!({ "dashboardId": "dash-abc-123" })))
+        .and(body_partial_json(
+            json!({ "dashboardId": "nPl9zg5A61iJ75CtN2FDB" }),
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "issues": [] })))
         .expect(1)
         .mount(&server)
@@ -486,9 +491,14 @@ async fn run_check_by_id_sends_dashboard_id_in_body() {
     let target = common::test_target("mock-profile", &server.uri());
     let targets = vec![target];
 
-    run_check(&targets, None, Some("dash-abc-123"), OutputFormat::Text)
-        .await
-        .expect("run_check by id should succeed");
+    run_check(
+        &targets,
+        None,
+        Some("nPl9zg5A61iJ75CtN2FDB"),
+        OutputFormat::Text,
+    )
+    .await
+    .expect("run_check by id should succeed");
 }
 
 /// Verify that `run_check` renders issues as a JSON array in json output mode.

--- a/tests/e2e/dashboards/mod.rs
+++ b/tests/e2e/dashboards/mod.rs
@@ -51,9 +51,10 @@ fn dashboards_delete_nonexistent() {
     }
     // Attempting to delete a non-existent dashboard - the CLI should at least
     // parse the command and attempt the API call (we don't assert success since
-    // the resource won't exist).
+    // the resource won't exist). Id must be 21 characters so local validation
+    // does not reject it before the "Deleting..." status line.
     let output = harness::cx()
-        .args(["dashboards", "delete", "nonexistent-id-000", "--yes"])
+        .args(["dashboards", "delete", "zzzzzzzzzzzzzzzzzzzzz", "--yes"])
         .output()
         .expect("failed to execute cx");
     let stderr = String::from_utf8_lossy(&output.stderr);


### PR DESCRIPTION
## Context
Agents inventorying dashboards often pass a folder name (`BMLL`, `AWS`) or a folder UUID to `cx dashboards get`. That hits GetDashboard, which returns `400 Bad Request: dashboard_id is not 21 characters length`. Catalog list already works; the mistake is using the wrong identifier. This PR fails those calls locally with a pointer to catalog `id` vs folder UUID/`--folder`.

## Linked Issues
N/A — prompted by a PoC inventory failure (folder names/UUIDs passed to get), not a tracked ticket.

## Design
`validate_dashboard_id` lives in `src/commands/dashboards/mod.rs` and requires a non-empty 21-character id (unicode scalar count). `run_get`, `run_delete`, and `run_check` (by-id) call it before HTTP. Delete confirmation in `main.rs` runs after this check so a folder name never prompts. Help text on get/delete/check and the cx-dashboards / cx-search-dashboard skills document the same rule: catalog item `id` for get; folder UUIDs only for `--folder` / `--parent-id`; inventory a folder by filtering catalog JSON.

## Key Decisions
- Local 21-char check only — do not relax the server validator, and do not add `catalog --folder` in this PR (list-then-filter is enough for inventory).
- Length-only (not nanoid alphabet) so we match the API error agents already see and keep the check cheap.
- Validate before the delete `--yes` prompt so a bad id is never treated as a destructive write.

## Changes
- `cx dashboards get|delete|check <id>` reject ids that are not 21 characters, with an error that names catalog vs folders list vs filter-by-folder.
- Clap help and examples use 21-character dashboard ids.
- Skills (`cx-dashboards` 0.2.1, `cx-search-dashboard` 0.1.1, deploy reference) tell agents not to `get` a folder id or name.

## Testing
- `cargo fmt`
- `cargo clippy --locked -- -D warnings`
- `cargo test --locked --lib --test dashboard_commands --test dashboards --test console_urls`
  Unit tests cover accept nanoid / reject BMLL, `catalog`, UUID, blank. Integration tests cover get without HTTP for a folder UUID, plus existing get/delete/check paths with 21-char ids.

## Risks & Rollout
CLI-only, no API or schema change. Ids that are not 21 characters never reached a successful GetDashboard before; those calls now fail earlier with a clearer message. Rollback is revert. Skills version bumps apply on next `cx skills` install.

## Out of Scope / Follow-ups
No `cx dashboards catalog --folder` filter flag. No change to dashboards-api validation. Folder get/list commands are unchanged.

Made with [Cursor](https://cursor.com)