### PR TITLE
Publish crates.io via trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,9 @@ jobs:
     name: Publish to crates.io
     needs: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -168,7 +171,11 @@ jobs:
       - name: Install system dependencies
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
+      - name: Authenticate with crates.io
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth
+
       - name: Publish
         run: cargo publish
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}


### PR DESCRIPTION
## Context
The crates.io publish job currently authenticates with a long-lived `CARGO_REGISTRY_TOKEN` GitHub secret. That token can expire or leak, and it is the only thing blocking `cargo publish` on tagged releases. This change switches the release workflow to crates.io trusted publishing (OIDC), so CI mints a short-lived publish token instead of storing a permanent API key.

## Linked Issues
N/A — follow-up to rotating/replacing an expired crates.io API token; no Linear ticket.

## Design
On a tagged release, `publish-crate` still runs after the GitHub Release job. Before `cargo publish`, it calls `rust-lang/crates-io-auth-action`, which exchanges the GitHub Actions OIDC identity for a ~30-minute crates.io token. `cargo publish` continues to read `CARGO_REGISTRY_TOKEN`; the value now comes from the action output. crates.io already allowlists this repo + `release.yml` as a trusted publisher, so only that workflow can mint a token.

## Key Decisions
- Keep publishing in the existing `release.yml` job rather than a new workflow, because the trusted-publisher config is bound to this filename.
- Pin `crates-io-auth-action` to a commit SHA (v1.0.5), matching other actions in this file.
- Leave the top-level `id-token: write` permission in place (cosign still needs it) and also set job-level `id-token: write` + `contents: read` on `publish-crate` so the OIDC exchange is explicit.
- Do not enable “trusted publishing only” or delete the GitHub secret in this PR; those happen after one successful publish.

## Changes
- `publish-crate` authenticates via GitHub OIDC instead of `secrets.CARGO_REGISTRY_TOKEN`.
- GitHub Releases, binary artifacts, Homebrew, and the install script are unchanged.

## Testing
- Workflow YAML was reviewed against the crates.io trusted-publishing docs and the current `release.yml` job shape.
- No `cargo test` / clippy run: this PR only changes GitHub Actions YAML; publish cannot be exercised until the next `v*` tag (or a manual Release workflow dispatch).

## Risks & Rollout
- If the crates.io trusted-publisher fields do not match (`coralogix` / `cx-cli` / `release.yml`, empty environment), the **Publish to crates.io** job will fail. GitHub Release binaries still succeed because that job runs first.
- Rollback: revert this PR (or restore `CARGO_REGISTRY_TOKEN` on the job) before the next tag. Keep the GitHub secret until a trusted-publish run succeeds.

## Out of Scope / Follow-ups
- Delete the `CARGO_REGISTRY_TOKEN` repo secret after the next successful crates.io publish.
- Revoke the old crates.io API token on crates.io.
- Optionally add a GitHub Environment with required reviewers; that would also require updating the trusted-publisher Environment field.

Made with [Cursor](https://cursor.com)